### PR TITLE
add isUrlFlagSet

### DIFF
--- a/lib/url_parameter.flow
+++ b/lib/url_parameter.flow
@@ -1,5 +1,4 @@
 import string;
-import array;
 import binarytree;
 
 export {


### PR DESCRIPTION
the idea is to allow use url flags. 
i.e. instead of `flag1=true&flag2=true&flagN=true`
to use `flag1&flag2&flag3`

also introduced `isUrlParameterExists` which allows to check if empty parameter is supplied
for example, if we want to force some url parameter to be an empty line
currently (in master) this case is treated as `parameter is not set`

additinal optional funcs added: 
- `isAnyUrlFlagSet`
- `isAllUrlFlagsSet`