### PR TITLE
material.flow: added MInnerFocused style

### DIFF
--- a/lib/material/material.flow
+++ b/lib/material/material.flow
@@ -45,7 +45,7 @@ export {
 
 		MButtonState ::= MouseOnDownAroundState, MFocusEnabled, MForceFocusEnabled, MFocusOnPrevious, MShortcut, MShortcutKeyCodeComparison, MShortcutPreventDefault, MDefaultShortcutEnabled,
 			AccessRole, FAccessAttribute, MRippleStyle, MFocusOnDown, MHighlightOnFocus, MHighlightOnHover, MCursorShape, MClickEnabled, MHoverEnabled, MShortcutFilter,
-			MTooltipText, MFocused, MKeepFocusOnClickOut, IScriptBehaviour, IScriptId, IScriptRecordingEnabled, MFocusId,
+			MTooltipText, MFocused, MInnerFocused, MKeepFocusOnClickOut, IScriptBehaviour, IScriptId, IScriptRecordingEnabled, MFocusId,
 			MAddFocusGroup, MAccessOneWayConnection, MGetFocus, MElevation, MButtonTitle;
 
 				MouseOnDownAroundState ::= MOnClick, MOnMiddleClick, MOnRightClick, MMousePosition, MOnDoubleClick, MOnTripleClick, MOnClickAsync, MOnLongClick, MOnLongTouch, MOnTouch,
@@ -103,6 +103,9 @@ export {
 			// Shows is this component focused
 			// Also allows to set focus
 			MFocused(focused : DynamicBehaviour<bool>);
+			// Shows this component's innerFocused
+			// Also allows to set inner focus
+			MInnerFocused(innerFocused : DynamicBehaviour<bool>);
 			// Keep focus on clicks outside this component
 			MKeepFocusOnClickOut();
 			// Mouse coordinates inside component


### PR DESCRIPTION
I've created MInnerFocused style, added to MWigiStateStyle to set/get innerFocusedB into makeMWigiEditor() function in mw_editor.flow (as suggested by @stanislavpodolia )