### PR TITLE
Fusion. Fix fthrottle implementation

### DIFF
--- a/lib/fusion.flow
+++ b/lib/fusion.flow
@@ -1535,7 +1535,7 @@ fthrottleTimer(
 		maybeApply(
 			^pendingV,
 			\pv -> if (pv != getValue(newV)) {
-				nextDistinct(newV, pv);
+				next(newV, pv);
 				fthrottleTimer(pendingV, newV, samplingRate)
 			} else {
 				pendingV := None();


### PR DESCRIPTION
fthrottle does not obey it's description which reads `Throttle a behaviour to only fire a different value at most every X millisecond. It will fire instantly if it was more than X millisecond since we fired last.`