### PR TITLE
 - attempt to fix crashing popups on Android

### DIFF
--- a/QtByteRunner/gl-gui/GLRenderer.cpp
+++ b/QtByteRunner/gl-gui/GLRenderer.cpp
@@ -337,7 +337,7 @@ void GLRenderer::beginDrawFont(float radius)
 
 void GLRenderer::beginFilter(GLDrawSurface *main, GLDrawSurface *mask)
 {
-    assert(!mask || main->isCompatible(mask));
+    //assert(!mask || main->isCompatible(mask));
 
     main->bindToTexture(GL_TEXTURE0);
     if (mask)


### PR DESCRIPTION
Attempting to fix crashing popups on Android - currently, as long as user types something in an autocomplete-enabled text box, Android app crashes on this line (assertion fails). Seems to work without it, but I am not sure.