### PR TITLE
MDynamicDataTable: take into account row height for check box selection

### DIFF
--- a/lib/material/internal/material_datatable.flow
+++ b/lib/material/internal/material_datatable.flow
@@ -203,7 +203,7 @@ MDynamicDataTable2T(manager : MaterialManager, parent : MFocusGroup, m : MDynami
 			m2t
 		)
 		|> (\t -> TBorderA(-checkboxBorder / 2., 0., 0., 0., t))
-		|> (\t -> TCenterYIn(t, TFillXH(rowHeight)));
+		|> (\t -> TCenterYIn(t, TFixed(0., rowHeight)));
 
 	addCellBorder = \t, size ->
 		TBorderA(8., 0., 8., 1., TAvailable(t, TBorderA(-16., 0., 0., -1., size)));


### PR DESCRIPTION
For the card: https://trello.com/c/OsRgJo7a/4209-checkbox-isnt-centered-when-using-custom-row-height