### PR TITLE
Flowc. Eliminate duplicated error message.

### DIFF
--- a/tools/flowc/incremental/fc2fi.flow
+++ b/tools/flowc/incremental/fc2fi.flow
@@ -220,7 +220,7 @@ fctype2fi(e : FcTypeEnv, onError : (string, FcInfo2) -> void, t : FcType) -> FiT
 mfctype2fi(e : FcTypeEnv, onError : (string, FcInfo2) -> void, m : Maybe<FcType>) -> FiType {
 	switch (m) {
 		None(): {
-			onError("Did not have a type", FcInfo2(0, 0));
+			onError("Expression typing failed", FcInfo2(0, 0));
 			FiTypeFlow();
 		}
 		Some(t): fctype2fi(e, onError, t);

--- a/tools/flowc/typechecker/typechecker.flow
+++ b/tools/flowc/typechecker/typechecker.flow
@@ -38,9 +38,13 @@ typecheckFcModule(env0 : FcTypeEnv, module : FcModule) -> FcTypecheckResult {
 
 	// Any type errors in this module?
 	moduleErrors = ref false;
+	moduleErrorsSet = ref makeSet();
 	onModuleError = \e : FcError -> {
 		moduleErrors := true;
-		addFcTypeError(env0.program, e);
+		if (!containsSet(^moduleErrorsSet, e)) {
+			addFcTypeError(env0.program, e);
+			moduleErrorsSet := insertSet(^moduleErrorsSet, e);
+		}
 	}
 
 	// Use updated onModuleError callback in typing environment


### PR DESCRIPTION
This fix is for https://trello.com/c/j0EkRfDE/270-remove-multiple-repeating-messages

Error, reported here, means that we failed to type something due to previous typing error, whatever it was. Error repeated, because the same situation repeats upper in syntax tree.
Principally it is possible to report place in a tree, where _each_ error occurs, but this will be useless for developer. So I propose simply suppress further messages and report only one error.
Also, I changed error message to be more meaningful.