### PR TITLE
fix to show all items

### DIFF
--- a/lib/material/internal/material_grid.flow
+++ b/lib/material/internal/material_grid.flow
@@ -761,7 +761,7 @@ MDynamicGrid2T(manager : MaterialManager, parent : MFocusGroup, m : MDynamicGrid
 					// how much items on the screen
 					itemCount = min((ceil(wh.height / sz.height) + 1) * rowCount, il);
 					// max avaliable value of the first index
-					topItemMax = ((il - itemCount) / rowCount * rowCount) + if ((il - itemCount) % rowCount > 0) rowCount else 0;
+					topItemMax = (ceil(i2d(il - itemCount) / i2d(rowCount)) * rowCount) + if ((il - itemCount) % rowCount > 0) rowCount else 0;
 					// index of the first shown item
 					topItem = min(max(floor(p.y / sz.height) * rowCount, 0), topItemMax);
 


### PR DESCRIPTION
Bug: if we try to show to much elements - the last row in the MDynamicGrid is empty.
Before fix:
![image](https://user-images.githubusercontent.com/19839037/51676208-81bd3a00-2008-11e9-8f57-019a4def909b.png)

After fix:
![image](https://user-images.githubusercontent.com/19839037/51676215-871a8480-2008-11e9-9a41-938a581642bd.png)

Trello: https://trello.com/c/oxUejkEL/3551-icon-view-when-adding-media-as-curator-doesnt-load-all-files-from-db?menu=filter&filter=label:MVP%201.5