### PR TITLE
Wigi rtl fonts

### DIFF
--- a/lib/ui/fontmapping.flow
+++ b/lib/ui/fontmapping.flow
@@ -304,12 +304,6 @@ setDefaultFontMappingFn(mapping : [Pair<string, string>]) -> void {
 	setDefaultFontMappingFn2(mapper);
 }
 
-setDefaultFontMappingFn3(mapping : [Pair<string, string>]) -> void {
-	mapper = setDefaultFontMappingFnHelper(mapping);
-
-	defaultFontMappingFn := mapper;
-}
-
 cjkFontMappingFn(family : string, size : double) -> Pair<string, double> {
 	lang = getValue(currentLang);
 	fontParams = {


### PR DESCRIPTION
Enabled simple font mapping for Arabic. This allows to change text to be Bold, Italic, etc. That was the issue the customer complained.

The drop down with fonts still incorrect, it shows Roboto. Probably worth to disable it?