### PR TITLE
MDynamicList. Fixed wrong items heights bug while reordering.

### DIFF
--- a/lib/material/internal/material_list.flow
+++ b/lib/material/internal/material_list.flow
@@ -138,16 +138,34 @@ MDynamicList2T(manager : MaterialManager, parent : MFocusGroup, m : MDynamicList
 			else
 				fsubselect(loadQuota, FLift(\lq -> {
 					il = min(length(itms), lq);
-					fselect(
-						fmerge(generate(0, il, itemsHeights)),
-						FLift(\lh : [Maybe<double>] -> {
-							nextDistinct(hgt, dsum(map(lh, \v -> either(v, 0.))));
-							MDynamicListData(
-								MDynamicListLineHeights(lh, il),
-								itms,
-								sh
-							)
-						})
+					eitherMap(
+						state.reorder,
+						\rdr ->
+							fselect2(
+								fmerge(generate(0, il, itemsHeights)),
+								rdr.order,
+								FLift2(\lh : [Maybe<double>], ord : [int] -> {
+									nextDistinct(hgt, dsum(map(lh, \v -> either(v, 0.))));
+									lhgts =	generate(0, il, \i -> elementAt(lh, elementAt(ord, i, i), None()));
+
+									MDynamicListData(
+										MDynamicListLineHeights(lhgts, il),
+										itms,
+										sh
+									)
+								})
+							),
+						fselect(
+							fmerge(generate(0, il, itemsHeights)),
+							FLift(\lh : [Maybe<double>] -> {
+								nextDistinct(hgt, dsum(map(lh, \v -> either(v, 0.))));
+								MDynamicListData(
+									MDynamicListLineHeights(lh, il),
+									itms,
+									sh
+								)
+							})
+						)
 					)
 				}))
 		}));
@@ -175,11 +193,8 @@ MDynamicList2T(manager : MaterialManager, parent : MFocusGroup, m : MDynamicList
 						eitherMap(
 							state.reorder,
 							\rdr ->
-								fselect2(itemId, rdr.order, FLift2(\id, sl ->
-									if (id >= 0 &&  id < length(sl))
-										sl[id]
-									else
-										id
+								fselect2(itemId, rdr.order, FLift2(\id, ord ->
+									elementAt(ord, id, id)
 								)),
 							itemId
 						);


### PR DESCRIPTION
Before : 
![image](https://user-images.githubusercontent.com/27855185/52286420-d8176a80-2970-11e9-9199-7a24a604fda8.png)

After : 
![image](https://user-images.githubusercontent.com/27855185/52286575-1e6cc980-2971-11e9-81d1-116bfe6b1c42.png)

