### PR TITLE
wigify: fix form2material issue in complex case

### DIFF
--- a/lib/form/gui2.flow
+++ b/lib/form/gui2.flow
@@ -31,6 +31,13 @@ Select(b : Behaviour<?>, fn : (?) -> Form) -> Form {
 		Constructor(Mutable(form), \ -> {
 			// Now, the first time, we need to make sure the value did not change
 			// since we constructed.
+			// We use subscribe2 here to avoid calling the function two times initially
+			uns = subscribe2(b, \nv -> {
+				lastValue := nv;
+				impersonateCallstackFn(fn,0);
+				nextDistinct(form, fn(nv));
+			});
+
 			v = getValue(b);
 			if (v != ^lastValue) {
 				// Since we constructed the form, the value changed, so
@@ -39,12 +46,8 @@ Select(b : Behaviour<?>, fn : (?) -> Form) -> Form {
 				impersonateCallstackFn(fn,0);
 				nextDistinct(form, fn(v));
 			}
-			// We use subscribe2 here to avoid calling the function two times initially
-			subscribe2(b, \nv -> {
-				lastValue := nv;
-				impersonateCallstackFn(fn,0);
-				nextDistinct(form, fn(nv));
-			});
+
+			uns
 		});
 	}
 }
@@ -125,4 +128,3 @@ SelectGlobal(b : Behaviour<?>, transform : (?) -> ??, fn : (Behaviour<??>) -> Fo
 		}
 	)
 }
-


### PR DESCRIPTION
See https://trello.com/c/QUk82vJj/3948-text-not-fully-displayed-when-in-a-table

The test app:

```
import mwigi/mw_wigify;

main() {
	manager = makeMaterialManager([]);
	content = "WigiParagraph([WigiText(\"\", []), WigiRecursive([WigiRecursive([WigiStory(ref [WigiParagraph([WigiText(\"As part of our security architecture, it is important that we can make central updates to the core tools, such as Datawarp, and meta_app in general to implement better security protocols. When this is done, we often need to regenerate new code with the latest security practices (see Components to know more about regenerating code). This is why customization of generated code should be clearly separated, so it is possible to review all code easily.\", [])], [TightWidth()])], ref [], [])], WigiTableCell(DynamicBehaviour(ref WidthHeight(790.0, 96.0), DList(DEnd(), DEnd())), [WigiCellTightWidth()]), [WigiRecursiveFontStyle([FontSize(16.0), FontFamily(\"Roboto\"), Fill(0), FillOpacity(0.87)])])], WigiTable(1, 1, [WigiCellSpan(1, 1)], [WigiTableVisibleFormula(\"=true\"), WigiTableBorder(1.0, 0.0, 2141101726), WigiTableRigidCols(), WigiTableDisableForceShrinkOnMobile(), WigiTableColumnWidths([]), WigiTableTightWidth()]), [WigiName(\"table1\"), WigiRecursiveFontStyle([FontSize(16.0), FontFamily(\"Roboto\"), Fill(0), FillOpacity(0.87)])]), WigiText(\"\", [])], [])";

	makeForm = \ -> {
		doc = if (isWigiContent(content)) deserialize2(content, wigiFixup(), IllegalStruct());
		pages = Wigify(doc, tightMWStyle, [WigifyNoScroll()]);
		forms = map(pages, \p -> p.form);
		forms[0]();
	}

	makeButton = \text, action -> MTextButton(text, action, [MButtonRaised()], []);

	showDialog = \material -> {
		close = make(false);
		ShowMDialog(manager, close,
		[MDialogCustomFrame(0.0, 0.0, 0.0, 0.0, MBackground(6, TFillXY()))],
		MLines([
			material,
			TFixed(0., 24.),
			makeButton("CLOSE", \ -> nextDistinct(close, true))
			])
		)
	}

	box : Tropic = TFixed(600., 300.);

	mrender(manager, true, MLines([
		MCols([
			makeButton("TFORMAVAILABLE", \-> showDialog(
				TFormAvailable(makeForm(), box)
			)),
			TFixed(24., 0.),
			makeButton("FORM2MATERIAL", \-> showDialog(
				MAvailable(form2material(makeForm()), box)
			)),
			TFixed(24., 0.),
			makeButton("FORM2MATERIAL MSetMax*", \-> showDialog(
				MAvailable(MRemoveMinMetrics(form2material(makeForm())), box)
					|> MSetMaxWidth2(const(^tropicFillersMax))
					|> MSetMaxHeight2(const(^tropicFillersMax))
			)),
		]),
		TFixed(0., 24.),
		MText("TFormAvailable(makeForm(), box):", []),
		TFormAvailable(makeForm(), box),
		TFixed(0., 24.),
		MText("MAvailable(form2material(makeForm()), box):", []),
		MAvailable(form2material(makeForm()), box)
	])) |> ignore
}
```

**in master**:
![image](https://user-images.githubusercontent.com/14361571/53631886-994d9b00-3c24-11e9-9f19-ca0e5d167639.png)


**in branch**:
![image](https://user-images.githubusercontent.com/14361571/53631850-80dd8080-3c24-11e9-82f3-99016faf9f8e.png)
