### PR TITLE
Experimental fix for review

### DIFF
--- a/lib/material/internal/material_scroll.flow
+++ b/lib/material/internal/material_scroll.flow
@@ -901,12 +901,19 @@ MScrollBars2T(
 					|> (\t -> TCropSize(makeBox(boxSize), t))
 					|> (\t -> TConstruct([
 							makeSubscribe(scale, \scl -> {
+								println("boxWH=");
+								println(fgetValue(boxWH));
+								println("=====");	
+								println("boxSize=" + d2s(fgetValue(boxSize)));
 								nextDistinct(barVisible, scl < 1.);
-								boxSz = fgetValue(boxSize);
+								//??????
+								//boxSz = fgetValue(boxSize);
+								boxSz = if (horizontal) fgetValue(boxWH).width else fgetValue(boxWH).height;
 								minBSize = min(24., boxSz / 2.);
 								bSize0 = boxSz * scl;
 								nextDistinct(barHeight, max(bSize0, minBSize));
 								nextDistinct(barGap, min(bSize0 - minBSize, 0.));
+								println("barHeight=" + d2s(getValue(barHeight)));
 							})
 					], t))
 				})


### PR DESCRIPTION
Some unclear for me boxSize Transform behaviour:
boxWH : Transform\<WidthHeight\>
boxSize = fheight(boxWH) , i.e. boxSize : Transform\<double\>
but in changed code when boxWH keeps some WidthHeight(x, y), boxSize not equal y.

Related to:
https://trello.com/c/zO9dRHRV/3960-menu-scroll-is-not-shown-in-curator-until-zoom-is-used-chorme 
When sidebar expanded more than one time - scrollbar is hidden, because boxSize "contains" 0.

If replace 
boxSz = fgetValue(boxSize);
to something like
boxSz = if (horizontal) fgetValue(boxWH).width else fgetValue(boxWH).height;
it seems all works ok

