### PR TITLE
Add global coordinates to mouse info structure

### DIFF
--- a/lib/form/form.flow
+++ b/lib/form/form.flow
@@ -266,7 +266,7 @@ Interactive : (listeners: [EventHandler], form : Form);
 
 	// Does not respect z-order
 	MouseWheel(fn : (() -> MouseInfo) -> void);
-	MouseInfo(x : double, y : double, dx : double, dy : double, inside : bool);
+	MouseInfo(x : double, y : double, dx : double, dy : double, globalX: double, globalY: double, inside : bool);
 
 	MouseDownInfo(x : double, y : double, dx : double, dy : double, inside : () -> bool);
 

--- a/lib/sys/interactive.flow
+++ b/lib/sys/interactive.flow
@@ -10,7 +10,7 @@ export {
 
 	handleRealEvents(l : EventHandler, clip : native, clipalive : ref bool, stage : native, zorder : [int], doHittest : bool, doRespectHandled : bool) -> () -> void;
 
-	emptyMouseInfo = MouseInfo(0.0, 0.0, 0.0, 0.0, false);
+	emptyMouseInfo = MouseInfo(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, false);
 }
 
 native getClipVisible : (native) -> bool = RenderSupport.getClipVisible;
@@ -20,7 +20,11 @@ native addMouseWheelEventListener : io (clip : native, cb : (delta : double) -> 
 handleRealEvents(l : EventHandler, clip : native, clipalive : ref bool, stage : native, zorder : [int], doHittest : bool, doRespectHandled : bool) -> () -> void {
 	getMouseInfo : () -> MouseInfo = \ -> {
 		if (^clipalive && getClipVisible(clip)) {
-			MouseInfo(getMouseX(clip), getMouseY(clip), 0.0, 0.0, doHittest && hittest(clip, getMouseX(stage), getMouseY(stage)));
+			MouseInfo(
+				getMouseX(clip), getMouseY(clip),
+				0.0, 0.0,
+				getMouseX(stage), getMouseY(stage),
+				doHittest && hittest(clip, getMouseX(stage), getMouseY(stage)));
 		} else {
 			emptyMouseInfo
 		}
@@ -74,7 +78,11 @@ handleRealEvents(l : EventHandler, clip : native, clipalive : ref bool, stage : 
 			addMouseWheelEventListener(clip, 
 				\deltay -> {
 					if (^clipalive && getClipVisible(clip))
-						fn(\ -> MouseInfo(getMouseX(clip), getMouseY(clip), 0.0, deltay, doHittest && hittest(clip, getMouseX(stage), getMouseY(stage))));
+						fn(\ -> MouseInfo(
+							getMouseX(clip), getMouseY(clip),
+							0.0, deltay,
+							getMouseX(stage), getMouseY(stage),
+							doHittest && hittest(clip, getMouseX(stage), getMouseY(stage))));
 				}
 			);
 		}
@@ -82,7 +90,11 @@ handleRealEvents(l : EventHandler, clip : native, clipalive : ref bool, stage : 
 			stage, zorder, GetMouseInfo(\ -> {
 				dx = getValue(fineGrainMouseWheelDx);
 				dy = getValue(fineGrainMouseWheelDy);
-				MouseInfo(getMouseX(clip), getMouseY(clip), dx, dy, doHittest && hittest(clip, getMouseX(stage), getMouseY(stage)))
+				MouseInfo(
+					getMouseX(clip), getMouseY(clip),
+					dx, dy,
+					getMouseX(stage), getMouseY(stage),
+					doHittest && hittest(clip, getMouseX(stage), getMouseY(stage)))
 			}), 
 			\handled : bool, gm : GetMouseInfo -> {
 				if (^clipalive && getClipVisible(clip)) fn(handled, gm.fn) else handled

--- a/lib/ui/slider.flow
+++ b/lib/ui/slider.flow
@@ -148,7 +148,7 @@ ISlider(outx : DynamicBehaviour<double>, outy : DynamicBehaviour<double>, maxX :
 		Interactive([
 			MouseDown(\mouseInfo -> {
 				if (!getValue(isDragging) && getValue(^isEnabled) 
-						&& isInActiveZone(MouseInfo(mouseInfo.x, mouseInfo.y, 0.0, 0.0, false))) {
+						&& isInActiveZone(MouseInfo(mouseInfo.x, mouseInfo.y, 0.0, 0.0, 0.0, 0.0, false))) {
 					if (mouseInfo.inside()) {
 						// This is inside the drag handler
 						next(isDragging, true);


### PR DESCRIPTION
This is needed to support hovering feature of words tagged by lexicon tag, it will be much easier to build popups near words, otherwise we need to calculate somehow coordinates of words, it's hard.