### PR TITLE
Implement getting array element by index in Maybe

### DIFF
--- a/lib/ds/array.flow
+++ b/lib/ds/array.flow
@@ -65,9 +65,6 @@ export {
 	// Gets last element of array or specified value, if it's empty
 	lastElement(a: [?], def: ?) -> ?;
 
-	// Gets an array element by index wrapped in Some, or None if out of bounds
-	elementAtM(a : [?], idx : int) -> Maybe<?>;
-
 	// Gets the element by index or default value, if specified index doesn't exist in array
 	elementAt(a : [?], idx : int, def : ?) -> ?;
 
@@ -638,16 +635,12 @@ lastElement(a: [?], def: ?) -> ? {
 	}
 }
 
-elementAtM(a : [?], idx : int) -> Maybe<?> {
-	if (existsIndex(a, idx)) {
-		Some(a[idx])
-	} else {
-		None()
-	}
-}
-
 elementAt(a : [?], idx : int, def : ?) -> ? {
-	either(elementAtM(a, idx), def)
+	if (existsIndex(a, idx)) {
+		a[idx]
+	} else {
+		def
+	}
 }
 
 stylesEqual(s1: [?], s2: [?]) -> bool {

--- a/lib/ds/arrayutils.flow
+++ b/lib/ds/arrayutils.flow
@@ -110,6 +110,9 @@ export {
 	// Returns array of calls to x(), repeated n times
 	arrayRepeatDeferred : (x : () -> ?, n : int)->[?];
 
+	// Gets an array element by index wrapped in Some, or None if out of bounds
+	elementAtM(a : [?], idx : int) -> Maybe<?>;
+
 	elementAtMap(a : [?], idx : int, fn : (?) -> ??, def : ??) -> ??;
 }
 
@@ -403,6 +406,14 @@ reorderArray(a : [?], indexes : [int]) -> [?] {
 
 arrayRepeatDeferred(x : () -> ?, n : int) -> [?] {
 	if (n <= 0) [] else map(enumFromTo(1, n), \__ -> x());
+}
+
+elementAtM(a : [?], idx : int) -> Maybe<?> {
+	if (existsIndex(a, idx)) {
+		Some(a[idx])
+	} else {
+		None()
+	}
 }
 
 elementAtMap(a : [?], idx : int, fn : (?) -> ??, def : ??) -> ?? {


### PR DESCRIPTION
In the flow language itself, the construct `array[index]` will cause a crash if the index is out of bounds. A possible alternative is the `elementAt` function, but it's default value must be of the same type as the array elements. In this PR, I implemented a function called `elementAtM` that returns the element in `Maybe`, so it doesn't have such a limitation.