### PR TITLE
Iscript. Fix crash when cpp target plays script recorded in js

### DIFF
--- a/lib/material/iscript/material_iscript_pack.flow
+++ b/lib/material/iscript/material_iscript_pack.flow
@@ -418,7 +418,9 @@ makeIScriptFixup(version : string) -> Tree<string, (args : [flow]) -> flow> {
 					if (version == "0.9b" || version == "") {
 						fold(args[1], makeTree(), \acc, a : Pair<double, IScriptRecord> -> treePushToArrayValue(acc, a.first, a.second))
 					} else {
-						pairs2tree(map(args[1], \p : Pair<double, [IScriptRecord]> -> Pair(p.first |> d2s |> s2d, p.second)))
+						//make sure that we have a number in a format that will not cause crashes
+						fixNumber = \number -> s2d(d2s(number));
+						pairs2tree(map(args[1], \p : Pair<double, [IScriptRecord]> -> Pair(p.first |> fixNumber, p.second)))
 					}
 				]
 			};


### PR DESCRIPTION
https://trello.com/c/EeTfdxMq/560-scripts-recorded-in-the-js-target-and-saved-as-a-local-file-cause-crash-of-the-cpp-target