### PR TITLE
MStepper new style proposal

### DIFF
--- a/lib/material/internal/material_steppers.flow
+++ b/lib/material/internal/material_steppers.flow
@@ -211,6 +211,7 @@ makeStepper(parent : MFocusGroup, m : MStepper, type : [MStepsType], m2t : (Mate
 	enabledSteps = map(steps, \step -> extractStruct(step.state, MEnabled(const(true))).enabled);
 	stepsEnabledArr = fmerge(enabledSteps);
 	stepIconSize = extractStruct(m.style, MIconSize(24.0)).size;
+	noHeaderSeparators = contains(m.style, MHStepperNoHeaderSeparators());
 
 	makeLetterIcon = \style, id ->
 		(
@@ -373,14 +374,14 @@ makeStepper(parent : MFocusGroup, m : MStepper, type : [MStepsType], m2t : (Mate
 	(
 		if (horizontal)
 			[
-				MSeparator(true),
+				if (noHeaderSeparators) MEmpty() else MSeparator(true),
 				createHeader(
 					parent, steps, completes, clickableSteps, editableSteps, showFirstOnStartB,
 					selectedId, alternativeLabel, linearStepper, showErrorMessage,
 					stepEditableOnComplete, intervalBtwTitles, warningIcon, activeLetterIcon,
 					editIcon, checkCircleIcon, inactiveLetterIcon, m2t
 				),
-				MSeparator(true),
+				if (noHeaderSeparators) MEmpty() else MSeparator(true),
 				MIf(
 					fand(fselect(selectedId, FLift(\id -> existsIndex(steps, id))), showFirstOnStartB),
 					MLines2(

--- a/lib/material/material.flow
+++ b/lib/material/material.flow
@@ -1549,7 +1549,7 @@ export {
 					MActiveIconColor, MInactiveIconColor, MEditIconColor, MCheckCircleIconColor, MBackButton, MContinueButton, MCompleteButton,
 					MCancelButton, MStepperAddScroll, MHideCancelButton, MSetIntervalBetweenTitles, MUpdatingStepsNumLabels,
 					MHideFirstStepOnStart, MHeaderTextStyles, MHStepperContentBorder, MHStepperFooterBorder, MStepperCustomFooter,
-					MStepperTestSupport;
+					MStepperTestSupport, MHStepperNoHeaderSeparators;
 
 				MWarningIconColor(color : MColor);
 				MActiveIconColor(color : MColor);
@@ -1576,6 +1576,8 @@ export {
 				// Allows to change the footer layout for hstepper
 				MStepperCustomFooter(layout : (previous : Material, cancel : Material, next : Material, borders : (Material) -> Material) -> Material);
 				MStepperTestSupport(support : MWTestSupport, isTestPlaybackMode : () -> bool);
+				// allows to remove upper and lower horizontal lines from the header
+				MHStepperNoHeaderSeparators();
 
 			MStepState ::= MStepperFeedback, MultilineErrorState, MContinueFn, MCancelFn, MCompleteStatus, MEnabled,
 					MBackButton, MContinueButton, MCompleteButton, MCancelButton;


### PR DESCRIPTION
This style allows to remove upper and lower horizontal lines from the stepper's header, so instead of: 
![image](https://user-images.githubusercontent.com/13785267/56501533-d6912380-6517-11e9-8d2d-e6d9c96a61b4.png)

we will have: 
![image](https://user-images.githubusercontent.com/13785267/56501569-f6284c00-6517-11e9-8b31-fbda0e0a9add.png)

