### PR TITLE
Remove cutting of the circle over "A" when zooming

### DIFF
--- a/src/RenderSupportJSPixi.hx
+++ b/src/RenderSupportJSPixi.hx
@@ -238,7 +238,7 @@ class RenderSupportJSPixi {
 		PixiWorkarounds.workaroundTextMetrics();
 
 		// Required for MaterialIcons measurements
-		untyped __js__("PIXI.TextMetrics.METRICS_STRING = '|Éq█'");
+		untyped __js__("PIXI.TextMetrics.METRICS_STRING = '|Éq█Å'");
 		PixiWorkarounds.workaroundRendererDestroy();
 		PixiWorkarounds.workaroundProcessInteractive();
 


### PR DESCRIPTION
https://trello.com/c/33g3j1Nw/4760-letter-%C3%A5-is-cut-of
![image](https://user-images.githubusercontent.com/38577106/56588941-fe9e8680-65ec-11e9-8eb2-46865acebc08.png)
