### PR TITLE
Reduce garbage amount for string operations

### DIFF
--- a/lib/string.flow
+++ b/lib/string.flow
@@ -843,19 +843,16 @@ strSplit2(s : string, separators : [string]) -> [string] {
 }
 
 strGlue(arr: [string], sep: string) -> string {
-	if (length(arr) > 35) {
-		list2string(doStrGlue(arr, sep, 1, length(arr), Cons(arr[0], makeList())));
-	} else fold(interleave(arr, sep), "", \acc, c -> acc + c)
-}
-
-doStrGlue(arr : [string], sep : string, i : int, n : int, acc : List<string>) -> List<string> {
-	if (i < n) {
-		doStrGlue(arr, sep, i + 1, n, Cons(arr[i], Cons(sep, acc)))
+	if (arr == [])
+		""
+	else if (length(arr) == 1) {
+			arr[0]
 	} else {
-		acc;
+		list2string(foldi(arr, makeList(), \idx, acc, e -> {
+			if (idx == 0) Cons(e, acc) else Cons(e, Cons(sep, acc));
+		}))
 	}
 }
-
 
 takeBefore(str : string, sep : string, def : string) -> string {
 	i = strIndexOf(str, sep);

--- a/platforms/java/com/area9innovation/flow/Native.java
+++ b/platforms/java/com/area9innovation/flow/Native.java
@@ -542,18 +542,24 @@ public class Native extends NativeHost {
 
 	public final String list2string(Struct list) {
 		String rv = "";
-		StringBuilder sb = new StringBuilder();
+		LinkedList<String> ll = new LinkedList<String>();
+		int len = 0;
 		for (Struct cur = list;;) {
 			Object[] data = cur.getFields();
-			if (data.length == 0)
-				break;
+			if (data.length == 0) break;
+
 			rv = ((String)data[0]);
-			// This line + return statement is equivalent of
-			// rv = ((String)data[0]) + rv;
-			sb.append(new StringBuilder(rv).reverse().toString());
+			len += rv.length();
+			ll.add(rv);
 			cur = (Struct)data[1];
 		}
-		return sb.reverse().toString();
+		StringBuilder sb = new StringBuilder(len);
+		// Load data from Cons'es to String builder in direct order
+		for (Iterator i = ll.descendingIterator(); i.hasNext();) {
+		    String x = (String)i.next();
+		    sb.append(x);
+		}
+		return sb.toString();
 	}
 
 	public final Object headList(Struct list, Object _default) {


### PR DESCRIPTION
This PR reduces amount of GC, produced by string operations `strGlue()` and `list2string()`.
These two produce literally gigabytes of garbage during its work.
In this PR functions logic remains the same, while memory consumption significantly reduced.