### PR TITLE
show video as button in safari too

### DIFF
--- a/lib/sys/target.flow
+++ b/lib/sys/target.flow
@@ -308,5 +308,8 @@ isMobileBrowser() -> bool {
 }
 
 isChromeVideoBug() -> bool {
-	isUrlParameterTrue("chrome_test") && js && macosx() && strContains(toLowerCase(getBrowser()), "chrome")
+	js && macosx() && (
+		isUrlParameterTrue("chrome_test") && strContains(toLowerCase(getBrowser()), "chrome") ||
+		isUrlParameterTrue("safari_test") && strContains(toLowerCase(getBrowser()), "safari")
+	)
 }


### PR DESCRIPTION
Task https://trello.com/c/k4zJ1ywz/4747-safari-mac-loads-video-and-coach-speech-too-slowly-in-one-slide