### PR TITLE
MDropDownOrAutoComplete

### DIFF
--- a/lib/material/internal/material_dropdown.flow
+++ b/lib/material/internal/material_dropdown.flow
@@ -9,6 +9,7 @@ MDropDown2T(manager : MaterialManager, parent : MFocusGroup, m : MDropDown, m2t 
 	rightDecorations = extractStruct(m.style, MRightDecorations([])).extraItems;
 	groups = extractStruct(m.style, MGroups([])).groups;
 	nonSpec = MMenuSingleLine(m.nonSpecified, []);
+	border = extractStruct(m.style, MDropDownBorder(0., 0., 0., 0.));
 
 	lLen = length(leftDecorations);
 	rLen = length(rightDecorations);
@@ -35,6 +36,7 @@ MDropDown2T(manager : MaterialManager, parent : MFocusGroup, m : MDropDown, m2t 
 		),
 		m2t
 	)
+	|> (\t -> TBorder(border.left, border.top, border.right, border.bottom, t))
 }
 
 MDropDownStyle2MDropDownMenuStyle(style : [MDropDownStyle]) -> [MDropDownMenuStyle] {

--- a/lib/material/internal/material_menu.flow
+++ b/lib/material/internal/material_menu.flow
@@ -416,21 +416,7 @@ MDropDownMenu2T(manager : MaterialManager, parent : MFocusGroup, m : MDropDownMe
 
 	icon =
 		MDropDownIcon(openMenu.opened, iconSize)
-		|> (\t -> if (addClear)
-			MCols2(t,
-				MIconButton2T(
-					manager, 
-					parent,
-					MIconButton("clear", \ -> nextDistinct(current, -1), [
-						MIconSize(iconSize / 1.5),
-						MIconButtonBorder(0.),
-						MCircleBackground(MGrey(400), iconSize)
-					], []),
-					m2t
-				)
-				|> (\t2 -> TAlpha(fselect(current, FLift(\cur -> b2d(cur != -1))), t2))
-			)
-			else t)
+		|> (\t -> if (addClear)	MCols2(t, MDropDownClearIcon(current, -1, iconSize)) else t)
 		|> MCenterY;
 
 	addIcons = \f : MDropDownMenuLine ->
@@ -614,11 +600,15 @@ MMultiSelectDropDown2T(manager : MaterialManager, parent : MFocusGroup, m : MMul
 	selectedTextColor = selectedStyle.textColor;
 	selectedBgColor = selectedStyle.bgColor;
 
+	addClear = contains(style, MAddClearButton());
+
 	opened = make(false);
 	onClick = \ -> nextDistinct(opened, true);
 
+	iconSize = 20.;
 	icon =
-		MDropDownIcon(opened, 20.)
+		MDropDownIcon(opened, iconSize)
+		|> (\t -> if (addClear)	MCols2(t, MDropDownClearIcon(selected, [], iconSize)) else t)
 		|> MCenterY;
 
 	MMenu2T(
@@ -1454,4 +1444,14 @@ MDropDownIcon(opened : Transform<bool>, iconSize : double) -> Material {
 		true
 	))
 	|> (\m -> MFixSize(m, TFixed(iconSize, iconSize)))
+}
+
+MDropDownClearIcon(selected : DynamicBehaviour<?>, emptySelection : ?, iconSize : double) -> Material {
+	MIconButton("clear", \ -> nextDistinct(selected, emptySelection), [
+			MIconSize(iconSize / 1.5),
+			MIconButtonBorder(0.),
+			MCircleBackground(MGrey(400), iconSize)
+		], []
+	)
+	|> (\m -> MShow(fneq(selected, emptySelection), m))
 }

--- a/lib/material/material.flow
+++ b/lib/material/material.flow
@@ -637,13 +637,14 @@ export {
 		// The non-specified string is used when the current item is outside the range of items
 		// [Material Guidelines | Dropdown Buttons](https://www.google.com/design/spec/components/buttons.html#buttons-dropdown-buttons)
 		MDropDown(current : DynamicBehaviour<int>, nonSpecified : string, items : [string], style : [MDropDownStyle]);
-			MDropDownStyle ::= MDropDownMenuStyle, MGroups, MLeftDecorations, MRightDecorations;
+			MDropDownStyle ::= MDropDownMenuStyle, MGroups, MLeftDecorations, MRightDecorations, MDropDownBorder;
 
 				// Unclickable items: first parameter is id of item it should be displayed before, second is caption
 				MGroups(groups : [Pair<int, string>]);
 				// Place next to item corresponding Material, length of extraItems should be equal length of items.
 				MLeftDecorations(extraItems : [Material]);
 				MRightDecorations(extraItems : [Material]);
+				MDropDownBorder(left : double, top : double, right : double, bottom : double);
 
 		MMultiSelectDropDown(selected : DynamicBehaviour<[int]>, items : [string], style : [MMultiSelectDropDownStyle]);
 			MMultiSelectDropDownStyle ::= MNonSpecifiedString, MMaxHeight, MWidth, MCustomLineHeight, MCustomTextStyle, MSelectedItemStyle, MOnItemClick,

--- a/lib/material/material.flow
+++ b/lib/material/material.flow
@@ -621,7 +621,7 @@ export {
 					MCustomButton(button : Material);
 					MCroppedButton();
 					MSeparators(separators : bool);
-					// Adds an icon button, which sets current to -1 (non-specified).
+					// Adds an icon button, which sets current selection to non-specified (-1 for MDropDownMenu or [] for MMultiSelectDropDown).
 					MAddClearButton();
 
 		// Menu panel that takes full width.
@@ -647,7 +647,7 @@ export {
 
 		MMultiSelectDropDown(selected : DynamicBehaviour<[int]>, items : [string], style : [MMultiSelectDropDownStyle]);
 			MMultiSelectDropDownStyle ::= MNonSpecifiedString, MMaxHeight, MWidth, MCustomLineHeight, MCustomTextStyle, MSelectedItemStyle, MOnItemClick,
-				MAddDoneButton, MEnabled;
+				MAddDoneButton, MEnabled, MAddClearButton;
 
 				MSelectedItemStyle(textColor : MColor, bgColor : MColor);
 				MNonSpecifiedString(item : string); // "Pick" by default

--- a/lib/material/material_ui.flow
+++ b/lib/material/material_ui.flow
@@ -658,20 +658,19 @@ MDropDownOrAutoComplete(
 
 		autoCompleteStyle =
 			extractStruct(style, StyleMAutoComplete([])).style
-			|> (\styleAutoComplete ->
+			|> (\st -> eitherMap(labelM,
+				\labelStyle -> replaceStruct(st, MLabel(labelStyle.label)),
+				st
+			));
+		autoCompleteState =
+			extractStruct(style, StateMAutoComplete([])).state
+			|> (\st ->
 				if (isRequired) {
-					error = fif(feq(flength(selected), 0), const(Some(Pair("", true))), const(None()));
-					replaceStruct(styleAutoComplete, MInputError(error, []));
+					error = fif(feq(flength(selected), 0), const(Some(Pair("Required field", true))), const(None()));
+					replaceStruct(st, MInputError(error, [MRequiredField()]));
 				} else
-					styleAutoComplete
-			)
-			|> (\styleAutoComplete ->
-				eitherMap(
-					labelM,
-					\labelStyle -> replaceStruct(styleAutoComplete, MLabel(labelStyle.label)),
-					styleAutoComplete
-				));
-		autoCompleteState = extractStruct(style, StateMAutoComplete([])).state;
+					st
+			);
 
 		MConstruct(
 			[\-> bidirectionalLink(selectedStrB, selected, string2idxs, idxs2string)],

--- a/lib/material/material_ui.flow
+++ b/lib/material/material_ui.flow
@@ -74,7 +74,7 @@ export {
 
 	MDropDownOrAutoComplete(
 		items : [string],
-		selected : DynamicBehaviour<[int]>,
+		selected : DynamicBehaviour<int>,
 		style : [MDropDownOrAutoCompleteStyle],
 	) -> Material;
 
@@ -83,7 +83,7 @@ export {
 		ItemsLimit, MRequiredField, MLabel;
 
 		StyleMDropDown(style : [MDropDownStyle]);
-		StyleMMultiSelectDropDown(style : [MMultiSelectDropDownStyle]);
+		StyleMMultiSelectDropDown(selected : DynamicBehaviour<[int]>, style : [MMultiSelectDropDownStyle]);
 		StyleMAutoComplete(style : [MAutoCompleteStyle]);
 		StateMAutoComplete(state : [MTextInputState]);
 		ItemsLimit(limit : int);
@@ -636,29 +636,38 @@ MAddShortcutDialog(manager : MaterialManager) -> () -> void {
 
 MDropDownOrAutoComplete(
 	items : [string],
-	selected : DynamicBehaviour<[int]>,
+	selected : DynamicBehaviour<int>,
 	style : [MDropDownOrAutoCompleteStyle]
 ) -> Material {
 
 	limit = extractStruct(style, ItemsLimit(15)).limit;
 	isRequired = contains(style, MRequiredField());
 	labelM = tryExtractStruct(style, MLabel(""));
+	multiSelection = tryExtractStruct(style, StyleMMultiSelectDropDown(make([]), []));
 
-	multiSelection = tryExtractStruct(style, StyleMMultiSelectDropDown([])); 
+	isError =
+		eitherMap(
+			multiSelection,
+			\ms -> fOr(feq(ms.selected, []), feq(ms.selected, [-1])),
+			feq(selected, -1)
+		);
 
 	makeMAutoCompleteControl = \ -> {
-		trimStr = \s -> trim(s) |> toLowerCase;
 		idxs2string = \idxs -> strGlue(map(idxs, \idx -> elementAt(items, idx, "")), ", ");
-		string2idxs =
-			if (isSome(multiSelection))
-				\str ->
-					filtermap(strSplit2WithoutLeave(str, [",", ";"]), \sel ->
-						findi(items, \item -> trimStr(item) == trimStr(sel))
-					)
-			else
-				\str -> [findiDef(items, \item -> trimStr(item) == trimStr(str), -1)];
 
-		selectedStrB = make(idxs2string(getValue(selected)));
+		trimStr = \s -> trim(s) |> toLowerCase;
+		string2idxsMulti = \str ->
+			filtermap(strSplit2WithoutLeave(str, [",", ";"]), \sel ->
+				findi(items, \item -> trimStr(item) == trimStr(sel))
+			);
+		string2idxs = \str -> findiDef(items, \item -> trimStr(item) == trimStr(str), -1);
+
+		selectedStrB =
+			eitherMap(multiSelection,
+				\ms -> idxs2string(getValue(ms.selected)),	
+				idxs2string([getValue(selected)])
+			)
+			|> make;
 
 		autoCompleteStyle =
 			extractStruct(style, StyleMAutoComplete([])).style
@@ -670,34 +679,30 @@ MDropDownOrAutoComplete(
 			extractStruct(style, StateMAutoComplete([])).state
 			|> (\st ->
 				if (isRequired) {
-					error = fif(feq(flength(selected), 0), const(Some(Pair("Required field", true))), const(None()));
+					error = fif(isError, const(Some(Pair("Required field", true))), const(None()));
 					replaceStruct(st, MInputError(error, [MRequiredField()]));
 				} else
 					st
 			);
 
 		MConstruct(
-			[\-> bidirectionalLink(selectedStrB, selected, string2idxs, idxs2string)],
+			[\ -> 
+				eitherMap(multiSelection,
+					\ms -> bidirectionalLink(selectedStrB, ms.selected, string2idxsMulti, idxs2string),
+					bidirectionalLink(selectedStrB, selected, string2idxs, \idx -> idxs2string([idx]))
+				)
+			],
 			MAutoComplete(selectedStrB, items, autoCompleteStyle, autoCompleteState)
-		)
-	}
-
-	makeMDropDownControl = \ -> {
-		singleSelected = make(firstElement(getValue(selected), -1));
-		dropDownStyle = extractStruct(style, StyleMDropDown([])).style;
-		MConstruct(
-			[\-> bidirectionalLink(singleSelected, selected, v2a, \sel -> if (sel == []) -1 else sel[0])],
-			MDropDown(singleSelected, "", items, dropDownStyle)
 		)
 	}
 
 	if (length(items) > limit)		
 		makeMAutoCompleteControl()
 	else
-		eitherFn(
+		eitherMap(
 			multiSelection,
-			\multiSelect -> MMultiSelectDropDown(selected, items, concat(multiSelect.style, [MAddDoneButton(), MAddClearButton()])),
-			makeMDropDownControl
+			\multiSelect -> MMultiSelectDropDown(multiSelect.selected, items, concat(multiSelect.style, [MAddDoneButton(), MAddClearButton()])),
+			MDropDown(selected, "", items, extractStruct(style, StyleMDropDown([])).style)
 		)
 		|> (\m -> eitherMap(labelM,	\labelStyle ->
 			MLines2(
@@ -710,7 +715,7 @@ MDropDownOrAutoComplete(
 			MLines2(
 				m,
 				MText("Required field", [MErrorColor(), MCaptionSolid()])
-				|> (\m2 -> MVisible(fOr(feq(selected, []), feq(selected, [-1])), m2))
+				|> (\m2 -> MVisible(isError, m2))
 				|> MBorderTop(4.0)
 			)
 			else m

--- a/lib/material/material_ui.flow
+++ b/lib/material/material_ui.flow
@@ -644,15 +644,19 @@ MDropDownOrAutoComplete(
 	isRequired = contains(style, MRequiredField());
 	labelM = tryExtractStruct(style, MLabel(""));
 
+	multiSelection = tryExtractStruct(style, StyleMMultiSelectDropDown([])); 
+
 	makeMAutoCompleteControl = \ -> {
+		trimStr = \s -> trim(s) |> toLowerCase;
 		idxs2string = \idxs -> strGlue(map(idxs, \idx -> elementAt(items, idx, "")), ", ");
-		string2idxs = \str -> filtermap(
-			strSplit2WithoutLeave(str, [",", ";"]),
-			\sel -> {
-				trimStr = \s -> trim(s) |> toLowerCase;
-				findi(items, \item -> trimStr(item) == trimStr(sel))
-			}
-		);
+		string2idxs =
+			if (isSome(multiSelection))
+				\str ->
+					filtermap(strSplit2WithoutLeave(str, [",", ";"]), \sel ->
+						findi(items, \item -> trimStr(item) == trimStr(sel))
+					)
+			else
+				\str -> [findiDef(items, \item -> trimStr(item) == trimStr(str), -1)];
 
 		selectedStrB = make(idxs2string(getValue(selected)));
 
@@ -691,7 +695,7 @@ MDropDownOrAutoComplete(
 		makeMAutoCompleteControl()
 	else
 		eitherFn(
-			tryExtractStruct(style, StyleMMultiSelectDropDown([])),
+			multiSelection,
 			\multiSelect -> MMultiSelectDropDown(selected, items, concat(multiSelect.style, [MAddDoneButton(), MAddClearButton()])),
 			makeMDropDownControl
 		)

--- a/lib/material/material_ui.flow
+++ b/lib/material/material_ui.flow
@@ -683,7 +683,7 @@ MDropDownOrAutoComplete(
 		singleSelected = make(firstElement(getValue(selected), -1));
 		dropDownStyle = extractStruct(style, StyleMDropDown([])).style;
 		MConstruct(
-			[\-> connectSelectDistinctu(singleSelected, selected, v2a)],
+			[\-> bidirectionalLink(singleSelected, selected, v2a, \sel -> if (sel == []) -1 else sel[0])],
 			MDropDown(singleSelected, "", items, dropDownStyle)
 		)
 	}
@@ -703,10 +703,13 @@ MDropDownOrAutoComplete(
 			),
 			m
 		))
-		|> (\m -> MLines2(
-			m,
-			MText("Required field", [MErrorColor(), MCaptionSolid()])
-			|> (\m2 -> MVisible(fOr(feq(selected, []), feq(selected, [-1])), m2))
-			|> MBorderTop(4.0)
-		))
+		|> (\m -> if (isRequired)
+			MLines2(
+				m,
+				MText("Required field", [MErrorColor(), MCaptionSolid()])
+				|> (\m2 -> MVisible(fOr(feq(selected, []), feq(selected, [-1])), m2))
+				|> MBorderTop(4.0)
+			)
+			else m
+		)
 }

--- a/lib/material/material_ui.flow
+++ b/lib/material/material_ui.flow
@@ -79,14 +79,14 @@ export {
 	) -> Material;
 
 	// MRequiredField, MLabel replace corresponding inner autocomplete styles
-	MDropDownOrAutoCompleteStyle ::= StyleMDropDown, StyleMMultiSelectDropDown, StyleMAutoComplete, StateMAutoComplete,
-		ItemsLimit, MRequiredField, MLabel, MShowAnyItem;
+	MDropDownOrAutoCompleteStyle ::= MDropDownStyles, MAutoCompleteStyles, MAutoCompleteState, MMultipleSelection,
+		MItemsLimit, MRequiredField, MLabel, MShowAnyItem;
 
-		StyleMDropDown(style : [MDropDownStyle]);
-		StyleMMultiSelectDropDown(selected : DynamicBehaviour<[int]>, style : [MMultiSelectDropDownStyle]);
-		StyleMAutoComplete(style : [MAutoCompleteStyle]);
-		StateMAutoComplete(state : [MTextInputState]);
-		ItemsLimit(limit : int);
+		MDropDownStyles(style : [MDropDownStyle]);
+		MMultipleSelection(selected : DynamicBehaviour<[int]>, style : [MMultiSelectDropDownStyle]);
+		MAutoCompleteStyles(style : [MAutoCompleteStyle]);
+		MAutoCompleteState(state : [MTextInputState]);
+		MItemsLimit(limit : int);
 		MShowAnyItem(); // Adds "Any" option. Doesn`t work with multi-selection.
 }
 
@@ -641,10 +641,10 @@ MDropDownOrAutoComplete(
 	style : [MDropDownOrAutoCompleteStyle]
 ) -> Material {
 
-	limit = extractStruct(style, ItemsLimit(15)).limit;
+	limit = extractStruct(style, MItemsLimit(15)).limit;
 	isRequired = contains(style, MRequiredField());
 	labelM = tryExtractStruct(style, MLabel(""));
-	multiSelection = tryExtractStruct(style, StyleMMultiSelectDropDown(make([]), []));
+	multiSelection = tryExtractStruct(style, MMultipleSelection(make([]), []));
 
 	showAnyItem = contains(style, MShowAnyItem()) && isNone(multiSelection);
 	items = concat(if (showAnyItem) ["Any"] else [], items0);
@@ -674,13 +674,13 @@ MDropDownOrAutoComplete(
 			|> make;
 
 		autoCompleteStyle =
-			extractStruct(style, StyleMAutoComplete([])).style
+			extractStruct(style, MAutoCompleteStyles([])).style
 			|> (\st -> eitherMap(labelM,
 				\labelStyle -> replaceStruct(st, MLabel(labelStyle.label)),
 				st
 			));
 		autoCompleteState =
-			extractStruct(style, StateMAutoComplete([])).state
+			extractStruct(style, MAutoCompleteState([])).state
 			|> (\st ->
 				if (isRequired) {
 					error = fif(isError, const(Some(Pair("Required field", true))), const(None()));
@@ -708,7 +708,7 @@ MDropDownOrAutoComplete(
 			\multiSelect -> MMultiSelectDropDown(multiSelect.selected, items, concat(multiSelect.style, [MAddDoneButton(), MAddClearButton()])),
 			MConstruct(
 				[makeSubscribe(selected, \i -> if (showAnyItem && i == 0) nextDistinct(selected, -1))],
-				MDropDown(selected, "", items, extractStruct(style, StyleMDropDown([])).style)
+				MDropDown(selected, "", items, extractStruct(style, MDropDownStyles([])).style)
 			)
 		)
 		|> (\m -> eitherMap(labelM,	\labelStyle ->

--- a/lib/material/material_ui.flow
+++ b/lib/material/material_ui.flow
@@ -87,8 +87,6 @@ export {
 		StyleMAutoComplete(style : [MAutoCompleteStyle]);
 		StateMAutoComplete(state : [MTextInputState]);
 		ItemsLimit(limit : int);
-
-	MRequiredMessage(msg : string) -> Material;
 }
 
 MRadios(index : DynamicBehaviour<int>, style : [MCheckableStyle], captions : [Material]) -> [Material] {
@@ -639,109 +637,76 @@ MAddShortcutDialog(manager : MaterialManager) -> () -> void {
 MDropDownOrAutoComplete(
 	items : [string],
 	selected : DynamicBehaviour<[int]>,
-	style : [MDropDownOrAutoCompleteStyle],
+	style : [MDropDownOrAutoCompleteStyle]
 ) -> Material {
+
 	limit = extractStruct(style, ItemsLimit(15)).limit;
-	isRequired = containsStruct(style, MRequiredField());
+	isRequired = contains(style, MRequiredField());
 	labelM = tryExtractStruct(style, MLabel(""));
-	if (length(items) > limit) {
-		autoCompleteStyle = extractStruct(style, StyleMAutoComplete([])).style
-		|> (\styleAutoComplete -> {
-			if (isRequired) {
-				error = fselect(selected, FLift(\selectedArr ->
-					if (length(selectedArr) == 0) {
-						Some(Pair("", true))
-					} else {
-						None()
-					}
-				));
-				replaceStruct(styleAutoComplete, MInputError(error, []));
-			} else {
-				styleAutoComplete
+
+	makeMAutoCompleteControl = \ -> {
+		idxs2string = \idxs -> strGlue(map(idxs, \idx -> elementAt(items, idx, "")), ", ");
+		string2idxs = \str -> filtermap(
+			strSplit2WithoutLeave(str, [",", ";"]),
+			\sel -> {
+				trimStr = \s -> trim(s) |> toLowerCase;
+				findi(items, \item -> trimStr(item) == trimStr(sel))
 			}
-		})
-		|> (\styleAutoComplete -> {
-			eitherMap(
-				labelM,
-				\labelStyle -> replaceStruct(styleAutoComplete, MLabel(labelStyle.label)),
-				styleAutoComplete
+		);
+
+		selectedStrB = make(idxs2string(getValue(selected)));
+
+		autoCompleteStyle =
+			extractStruct(style, StyleMAutoComplete([])).style
+			|> (\styleAutoComplete ->
+				if (isRequired) {
+					error = fif(feq(flength(selected), 0), const(Some(Pair("", true))), const(None()));
+					replaceStruct(styleAutoComplete, MInputError(error, []));
+				} else
+					styleAutoComplete
 			)
-		});
+			|> (\styleAutoComplete ->
+				eitherMap(
+					labelM,
+					\labelStyle -> replaceStruct(styleAutoComplete, MLabel(labelStyle.label)),
+					styleAutoComplete
+				));
 		autoCompleteState = extractStruct(style, StateMAutoComplete([])).state;
-		
-		makeMAutoCompleteControl(items, selected, autoCompleteStyle, autoCompleteState)
-	} else {
+
+		MConstruct(
+			[\-> bidirectionalLink(selectedStrB, selected, string2idxs, idxs2string)],
+			MAutoComplete(selectedStrB, items, autoCompleteStyle, autoCompleteState)
+		)
+	}
+
+	makeMDropDownControl = \ -> {
+		singleSelected = make(firstElement(getValue(selected), -1));
 		dropDownStyle = extractStruct(style, StyleMDropDown([])).style;
-		eitherMap(
+		MConstruct(
+			[\-> connectSelectDistinctu(singleSelected, selected, v2a)],
+			MDropDown(singleSelected, "", items, dropDownStyle)
+		)
+	}
+
+	if (length(items) > limit)		
+		makeMAutoCompleteControl()
+	else
+		eitherFn(
 			tryExtractStruct(style, StyleMMultiSelectDropDown([])),
-			\multiSelect -> makeMMultiSelectDropDownControl(items, selected, multiSelect.style),
-			makeMDropDownControl(items, selected, dropDownStyle)
-		) |> (\m ->	eitherMap(
-			labelM,
-			\labelStyle -> MLines2(
-				MText(labelStyle.label, [MCaption()]) |> MBorderBottom(-4.0),
+			\multiSelect -> MMultiSelectDropDown(selected, items, concat(multiSelect.style, [MAddDoneButton(), MAddClearButton()])),
+			makeMDropDownControl
+		)
+		|> (\m -> eitherMap(labelM,	\labelStyle ->
+			MLines2(
+				MText(labelStyle.label, [MCaption()]) |> MBorderBottom(4.0),
 				m
 			),
 			m
-		)) |> (\m -> MLines2(
-			m,
-			MVisible(
-				fOr(feq(selected, []), feq(selected, [-1])),
-				MRequiredMessage("Required field") |> MBorderTop(-4.0)
-			)
 		))
-	}
-}
-
-makeMAutoCompleteControl(
-	items : [string],
-	selected : DynamicBehaviour<[int]>,
-	style : [MAutoCompleteStyle],
-	state : [MTextInputState]
-) -> Material {
-	idxs2string = \idxs -> strGlue(map(idxs, \idx -> elementAt(items, idx, "")), ", ");
-	string2idxs = \str -> filtermap(
-		strSplit2WithoutLeave(str, [",", ";"]),
-		\sel -> {
-			trimStr = \s -> trim(s) |> toLowerCase;
-			findi(items, \item -> trimStr(item) == trimStr(sel))
-		}
-	);
-
-	selectedStrB = make(idxs2string(getValue(selected)));
-
-	MConstruct(
-		[\-> bidirectionalLink(selectedStrB, selected, string2idxs, idxs2string)],
-		MAutoComplete(selectedStrB, items, style, state)
-	);
-}
-
-makeMMultiSelectDropDownControl(
-	items : [string],
-	selected : DynamicBehaviour<[int]>,
-	style : [MMultiSelectDropDownStyle]
-) -> Material {
-	MBaselineCols2(
-		MMultiSelectDropDown(selected, items, arrayPush(style, MAddDoneButton())),
-		MVisible(
-			fneq(selected, []),
-			MIconButton("clear", \-> nextDistinct(selected, []), [], [])
-		)
-	)
-}
-
-makeMDropDownControl(
-	items : [string],
-	selected : DynamicBehaviour<[int]>,
-	style : [MDropDownStyle]
-) -> Material {
-	singleSelected = make(firstElement(getValue(selected), -1));
-	MConstruct(
-		[\-> connectSelectDistinctu(singleSelected, selected, \sel : int -> [sel])],
-		MDropDown(singleSelected, "", items, style)
-	)
-}
-
-MRequiredMessage(msg : string) -> Material {
-	MText(msg, [MErrorColor(), MCustomFont(12.0, "Roboto", 1.0)]);
+		|> (\m -> MLines2(
+			m,
+			MText("Required field", [MErrorColor(), MCaptionSolid()])
+			|> (\m2 -> MVisible(fOr(feq(selected, []), feq(selected, [-1])), m2))
+			|> MBorderTop(4.0)
+		))
 }

--- a/lib/material/material_ui.flow
+++ b/lib/material/material_ui.flow
@@ -71,6 +71,24 @@ export {
 	) -> Material;
 
 	MAddShortcutDialog(manager : MaterialManager) -> () -> void;
+
+	MDropDownOrAutoComplete(
+		items : [string],
+		selected : DynamicBehaviour<[int]>,
+		style : [MDropDownOrAutoCompleteStyle],
+	) -> Material;
+
+	// MRequiredField, MLabel replace corresponding inner autocomplete styles
+	MDropDownOrAutoCompleteStyle ::= StyleMDropDown, StyleMMultiSelectDropDown, StyleMAutoComplete, StateMAutoComplete,
+		ItemsLimit, MRequiredField, MLabel;
+
+		StyleMDropDown(style : [MDropDownStyle]);
+		StyleMMultiSelectDropDown(style : [MMultiSelectDropDownStyle]);
+		StyleMAutoComplete(style : [MAutoCompleteStyle]);
+		StateMAutoComplete(state : [MTextInputState]);
+		ItemsLimit(limit : int);
+
+	MRequiredMessage(msg : string) -> Material;
 }
 
 MRadios(index : DynamicBehaviour<int>, style : [MCheckableStyle], captions : [Material]) -> [Material] {
@@ -616,4 +634,114 @@ MAddShortcutDialog(manager : MaterialManager) -> () -> void {
 	} else {
 		nop;
 	}
+}
+
+MDropDownOrAutoComplete(
+	items : [string],
+	selected : DynamicBehaviour<[int]>,
+	style : [MDropDownOrAutoCompleteStyle],
+) -> Material {
+	limit = extractStruct(style, ItemsLimit(15)).limit;
+	isRequired = containsStruct(style, MRequiredField());
+	labelM = tryExtractStruct(style, MLabel(""));
+	if (length(items) > limit) {
+		autoCompleteStyle = extractStruct(style, StyleMAutoComplete([])).style
+		|> (\styleAutoComplete -> {
+			if (isRequired) {
+				error = fselect(selected, FLift(\selectedArr ->
+					if (length(selectedArr) == 0) {
+						Some(Pair("", true))
+					} else {
+						None()
+					}
+				));
+				replaceStruct(styleAutoComplete, MInputError(error, []));
+			} else {
+				styleAutoComplete
+			}
+		})
+		|> (\styleAutoComplete -> {
+			eitherMap(
+				labelM,
+				\labelStyle -> replaceStruct(styleAutoComplete, MLabel(labelStyle.label)),
+				styleAutoComplete
+			)
+		});
+		autoCompleteState = extractStruct(style, StateMAutoComplete([])).state;
+		
+		makeMAutoCompleteControl(items, selected, autoCompleteStyle, autoCompleteState)
+	} else {
+		dropDownStyle = extractStruct(style, StyleMDropDown([])).style;
+		eitherMap(
+			tryExtractStruct(style, StyleMMultiSelectDropDown([])),
+			\multiSelect -> makeMMultiSelectDropDownControl(items, selected, multiSelect.style),
+			makeMDropDownControl(items, selected, dropDownStyle)
+		) |> (\m ->	eitherMap(
+			labelM,
+			\labelStyle -> MLines2(
+				MText(labelStyle.label, [MCaption()]) |> MBorderBottom(-4.0),
+				m
+			),
+			m
+		)) |> (\m -> MLines2(
+			m,
+			MVisible(
+				fOr(feq(selected, []), feq(selected, [-1])),
+				MRequiredMessage("Required field") |> MBorderTop(-4.0)
+			)
+		))
+	}
+}
+
+makeMAutoCompleteControl(
+	items : [string],
+	selected : DynamicBehaviour<[int]>,
+	style : [MAutoCompleteStyle],
+	state : [MTextInputState]
+) -> Material {
+	idxs2string = \idxs -> strGlue(map(idxs, \idx -> elementAt(items, idx, "")), ", ");
+	string2idxs = \str -> filtermap(
+		strSplit2WithoutLeave(str, [",", ";"]),
+		\sel -> {
+			trimStr = \s -> trim(s) |> toLowerCase;
+			findi(items, \item -> trimStr(item) == trimStr(sel))
+		}
+	);
+
+	selectedStrB = make(idxs2string(getValue(selected)));
+
+	MConstruct(
+		[\-> bidirectionalLink(selectedStrB, selected, string2idxs, idxs2string)],
+		MAutoComplete(selectedStrB, items, style, state)
+	);
+}
+
+makeMMultiSelectDropDownControl(
+	items : [string],
+	selected : DynamicBehaviour<[int]>,
+	style : [MMultiSelectDropDownStyle]
+) -> Material {
+	MBaselineCols2(
+		MMultiSelectDropDown(selected, items, arrayPush(style, MAddDoneButton())),
+		MVisible(
+			fneq(selected, []),
+			MIconButton("clear", \-> nextDistinct(selected, []), [], [])
+		)
+	)
+}
+
+makeMDropDownControl(
+	items : [string],
+	selected : DynamicBehaviour<[int]>,
+	style : [MDropDownStyle]
+) -> Material {
+	singleSelected = make(firstElement(getValue(selected), -1));
+	MConstruct(
+		[\-> connectSelectDistinctu(singleSelected, selected, \sel : int -> [sel])],
+		MDropDown(singleSelected, "", items, style)
+	)
+}
+
+MRequiredMessage(msg : string) -> Material {
+	MText(msg, [MErrorColor(), MCustomFont(12.0, "Roboto", 1.0)]);
 }

--- a/lib/material/material_ui.flow
+++ b/lib/material/material_ui.flow
@@ -80,13 +80,14 @@ export {
 
 	// MRequiredField, MLabel replace corresponding inner autocomplete styles
 	MDropDownOrAutoCompleteStyle ::= StyleMDropDown, StyleMMultiSelectDropDown, StyleMAutoComplete, StateMAutoComplete,
-		ItemsLimit, MRequiredField, MLabel;
+		ItemsLimit, MRequiredField, MLabel, MShowAnyItem;
 
 		StyleMDropDown(style : [MDropDownStyle]);
 		StyleMMultiSelectDropDown(selected : DynamicBehaviour<[int]>, style : [MMultiSelectDropDownStyle]);
 		StyleMAutoComplete(style : [MAutoCompleteStyle]);
 		StateMAutoComplete(state : [MTextInputState]);
 		ItemsLimit(limit : int);
+		MShowAnyItem(); // Adds "Any" option. Doesn`t work with multi-selection.
 }
 
 MRadios(index : DynamicBehaviour<int>, style : [MCheckableStyle], captions : [Material]) -> [Material] {
@@ -635,7 +636,7 @@ MAddShortcutDialog(manager : MaterialManager) -> () -> void {
 }
 
 MDropDownOrAutoComplete(
-	items : [string],
+	items0 : [string],
 	selected : DynamicBehaviour<int>,
 	style : [MDropDownOrAutoCompleteStyle]
 ) -> Material {
@@ -645,6 +646,9 @@ MDropDownOrAutoComplete(
 	labelM = tryExtractStruct(style, MLabel(""));
 	multiSelection = tryExtractStruct(style, StyleMMultiSelectDropDown(make([]), []));
 
+	showAnyItem = contains(style, MShowAnyItem()) && isNone(multiSelection);
+	items = concat(if (showAnyItem) ["Any"] else [], items0);
+
 	isError =
 		eitherMap(
 			multiSelection,
@@ -653,7 +657,7 @@ MDropDownOrAutoComplete(
 		);
 
 	makeMAutoCompleteControl = \ -> {
-		idxs2string = \idxs -> strGlue(map(idxs, \idx -> elementAt(items, idx, "")), ", ");
+		idxs2string = \idxs -> strGlue(map(idxs, \idx -> elementAt(items, idx, if (showAnyItem) items[0] else "")), ", ");
 
 		trimStr = \s -> trim(s) |> toLowerCase;
 		string2idxsMulti = \str ->
@@ -696,13 +700,16 @@ MDropDownOrAutoComplete(
 		)
 	}
 
-	if (length(items) > limit)		
+	if (length(items0) > limit)
 		makeMAutoCompleteControl()
 	else
 		eitherMap(
 			multiSelection,
 			\multiSelect -> MMultiSelectDropDown(multiSelect.selected, items, concat(multiSelect.style, [MAddDoneButton(), MAddClearButton()])),
-			MDropDown(selected, "", items, extractStruct(style, StyleMDropDown([])).style)
+			MConstruct(
+				[makeSubscribe(selected, \i -> if (showAnyItem && i == 0) nextDistinct(selected, -1))],
+				MDropDown(selected, "", items, extractStruct(style, StyleMDropDown([])).style)
+			)
 		)
 		|> (\m -> eitherMap(labelM,	\labelStyle ->
 			MLines2(

--- a/lib/material/tests/test_dropdown_or_autocomplete.flow
+++ b/lib/material/tests/test_dropdown_or_autocomplete.flow
@@ -12,16 +12,16 @@ main () {
 	fpprint("selected")(selected);
 
 	style = [
-		StyleMMultiSelectDropDown(make([]), [
+		MMultipleSelection(make([]), [
 			MWidth(240.0),
 			MNonSpecifiedString("Test string"),
 		]),
-		StyleMDropDown([
+		MDropDownStyles([
 			MWidth(340.0)
 		]),
-		StyleMAutoComplete([MWidth(540.0)]),
-		StateMAutoComplete([]),
-		ItemsLimit(10),
+		MAutoCompleteStyles([MWidth(540.0)]),
+		MAutoCompleteState([]),
+		MItemsLimit(10),
 		MRequiredField(),
 		MLabel("Test label"),
 		MShowAnyItem()
@@ -205,12 +205,12 @@ getDropDownOrAutoCompleteFixed(
 		});
 
 	styles = [
-		eitherMap(maxDropDownLength, \m -> [ItemsLimit(m)], []),
+		eitherMap(maxDropDownLength, \m -> [MItemsLimit(m)], []),
 		if (showAnyItem) [MShowAnyItem()] else [],
 		[
-			StyleMDropDown(dropDownStyle),
-			StyleMAutoComplete(autoCompleteStyles),
-			StateMAutoComplete(buttonStateA)
+			MDropDownStyles(dropDownStyle),
+			MAutoCompleteStyles(autoCompleteStyles),
+			MAutoCompleteState(buttonStateA)
 		]
 	]
 	|> concatA;

--- a/lib/material/tests/test_dropdown_or_autocomplete.flow
+++ b/lib/material/tests/test_dropdown_or_autocomplete.flow
@@ -1,0 +1,31 @@
+import material/material_ui;
+
+main () {
+	items1 = generate(0, 5, i2s);
+	items2 = generate(0, 50, i2s);
+
+	selected = make([]);
+
+	style = [
+		StyleMMultiSelectDropDown([
+			MWidth(240.0),
+			MNonSpecifiedString("Test string"),
+		]),
+		StyleMDropDown([
+			MWidth(340.0)
+		]),
+		StyleMAutoComplete([MWidth(540.0)]),
+		StateMAutoComplete([]),
+		ItemsLimit(10),
+		MRequiredField(),
+		MLabel("Test label"),
+	];
+
+	view = MLines([
+		MDropDownOrAutoComplete(items1, selected, style),
+		MFixedY(16.0),
+		MDropDownOrAutoComplete(items2, selected, style)
+	]);
+
+	mrender(makeMaterialManager([]), true, view);
+}

--- a/lib/material/tests/test_dropdown_or_autocomplete.flow
+++ b/lib/material/tests/test_dropdown_or_autocomplete.flow
@@ -1,13 +1,18 @@
 import material/material_ui;
 
+MDropDownCombinedStyle ::= MDropDownStyle, MAutoCompleteStyle, MHideAllOnEmpty;
+	// With this style, autocomplete result of getDropDownOrAutoComplete will not shown the list list without some text in the field
+	MHideAllOnEmpty();
+
 main () {
 	items1 = generate(0, 5, i2s);
 	items2 = generate(0, 50, i2s);
 
-	selected = make([]);
+	selected = make(-1);
+	fpprint("selected")(selected);
 
 	style = [
-		StyleMMultiSelectDropDown([
+		StyleMMultiSelectDropDown(make([]), [
 			MWidth(240.0),
 			MNonSpecifiedString("Test string"),
 		]),
@@ -19,13 +24,196 @@ main () {
 		ItemsLimit(10),
 		MRequiredField(),
 		MLabel("Test label"),
+		MShowAnyItem()
 	];
+
+	selecteD = make(-1);
+	selecteD2 = make(-1);
+
+	fpprint("indexB")(selecteD);
+	fpprint("indexB2")(selecteD2);
+
+	getDropDownAutocomplete1 =
+		getDropDownOrAutoComplete(
+			selecteD,
+			items2,
+			true,
+			None(),
+			-1,
+			"non-specified",
+			[MDropDownBorder(100., 0., 0., 0.)]
+		);
+
+	getDropDownAutocomplete2 =
+		getDropDownOrAutoCompleteFixed(
+			selecteD2,
+			items2,
+			true,
+			None(),
+			-1,
+			"non-specified",
+			[MDropDownBorder(100., 0., 0., 0.)]
+		);
 
 	view = MLines([
 		MDropDownOrAutoComplete(items1, selected, style),
 		MFixedY(16.0),
-		MDropDownOrAutoComplete(items2, selected, style)
+		MDropDownOrAutoComplete(items2, selected, style),
+		getDropDownAutocomplete1 |> MBorderTop(4.),
+		getDropDownAutocomplete2 |> MBorderTop(4.),
 	]);
 
 	mrender(makeMaterialManager([]), true, view);
+}
+
+getDropDownOrAutoComplete(
+	indexB : DynamicBehaviour<int>,
+	items : [string],
+	showAnyItem : bool,
+	maxDropDownLength : Maybe<int>,
+	defaultIndex : int,
+	nonSpecified : string,
+	style : [MDropDownCombinedStyle]
+) -> Material {
+
+	maxCountItems = either(maxDropDownLength, 15);
+	allItems = concat(if (showAnyItem) ["Any"] else [], map(items, \i -> substring(i, 0, 200)));
+	if (length(items) <= maxCountItems) {
+		dropDownStyle = filtermap(style, \s -> switch (s : MDropDownCombinedStyle) {
+			MDropDownStyle(): {
+				v : Maybe<MDropDownStyle> = Some(s);
+				v;
+			}
+			default: None();
+		});
+
+		MConstruct(
+			[makeSubscribe(indexB, \i -> if (showAnyItem && i == 0) nextDistinct(indexB, -1))],
+			MDropDown(indexB, nonSpecified, allItems, removeAllStructs(dropDownStyle, MLabel("")))
+		);
+	} else {
+		itemB = make("");
+
+		metaAppAutocompleteStyles = [
+			MWidth(250.0),
+			MLabel(_("Start typing")),
+			MShowDropDownArrow(true),
+			MShowUnderline(true),
+			MCurrentMatches(\arr -> {
+				nextDistinct(indexB,
+					either(
+						findmap(arr, \item ->
+							if (item.third.score == i2d(intMax))
+								Some(if (showAnyItem && item.first == 0) -1 else item.first)
+							else None()
+						),
+						defaultIndex
+					)
+				)
+			})
+		];
+
+		styleA = filtermap(style, \s -> switch (s : MDropDownCombinedStyle) {
+			MAutoCompleteStyle(): {
+				v : Maybe<MAutoCompleteStyle> = Some(s);
+				v;
+			};
+			default: None();
+		});
+		buttonStateA = filtermap(style, \s -> switch (s : MDropDownCombinedStyle) {
+			MButtonState(): {
+				v : Maybe<MButtonState> = Some(s);
+				v;
+			};
+			default: None();
+		});
+		autoCompleteStyles = replaceStructMany(metaAppAutocompleteStyles, styleA);
+
+		MConstruct([
+			\ -> connectSelectDistinctu(indexB, itemB, \index -> elementAt(
+				allItems,
+				index,
+				if (showAnyItem) allItems[0] else ""
+			))
+		], MAutoComplete(
+			itemB,
+			allItems,
+			if (!containsStruct(style, MHideAllOnEmpty())) {
+				replaceStructMany(autoCompleteStyles, [MShowAllOnEmpty(), extractStruct(autoCompleteStyles, MMaxHeight(200.))])
+			} else { autoCompleteStyles },
+			buttonStateA
+		))
+	}
+}
+
+getDropDownOrAutoCompleteFixed(
+	selected : DynamicBehaviour<int>,
+	items : [string],
+	showAnyItem : bool,
+	maxDropDownLength : Maybe<int>,
+	defaultIndex : int,
+	nonSpecified : string,
+	style : [MDropDownCombinedStyle]
+) -> Material {
+
+	cuttedItems = map(items, \i -> substring(i, 0, 200));
+	
+	border = extractStruct(style, MDropDownBorder(0., 12., 0., 0.));
+
+	dropDownStyle = filtermap(style, \st -> switch (st) {
+		MDropDownStyle(): {v : Maybe<MDropDownStyle> = Some(st); v}
+		default: None();
+	})
+	|> (\st -> if (nonSpecified == "") st else replaceStruct(st, MNonSpecified(MMenuSingleLine(nonSpecified, []))))
+	|> (\st -> replaceStruct(st, border))
+	|> (\st -> removeAllStructs(st, MLabel("")));
+
+	metaAppAutocompleteStyles = [
+		MWidth(250.0),
+		MLabel(_("Start typing")),
+		MShowDropDownArrow(true),
+		MShowUnderline(true),
+		MCurrentMatches(\arr ->
+			nextDistinct(selected,
+				either(
+					findmap(arr, \item ->
+						if (item.third.score == i2d(intMax))
+							Some(if (showAnyItem && item.first == 0) -1 else item.first)
+						else None()
+					),
+					defaultIndex
+				)
+			)
+		)
+	];
+
+	styleA =
+		filtermap(style, \s -> switch (s : MDropDownCombinedStyle) {
+			MAutoCompleteStyle(): {v : Maybe<MAutoCompleteStyle> = Some(s); v};
+			default: None();
+		});
+	autoCompleteStyles =
+		replaceStructMany(metaAppAutocompleteStyles, styleA)
+		|> (\st ->
+				if (contains(style, MHideAllOnEmpty())) st
+				else replaceStructMany(st, [MShowAllOnEmpty(), extractStruct(st, MMaxHeight(200.))])
+		);
+	buttonStateA =
+		filtermap(style, \s -> switch (s : MDropDownCombinedStyle) {
+			MButtonState(): {v : Maybe<MButtonState> = Some(s); v};
+			default: None();
+		});
+
+	styles = [
+		eitherMap(maxDropDownLength, \m -> [ItemsLimit(m)], []),
+		if (showAnyItem) [MShowAnyItem()] else [],
+		[
+			StyleMDropDown(dropDownStyle),
+			StyleMAutoComplete(autoCompleteStyles),
+			StateMAutoComplete(buttonStateA)
+		]
+	]
+	|> concatA;
+
+	MDropDownOrAutoComplete(cuttedItems, selected, styles)
 }


### PR DESCRIPTION
When there are a lot of items in MDropDown it starts to hang, works slow. The idea is to use MAutoComplete if the count of items more set limit.
Introduced code is already used mainly in customdb component. If it's OK to move the code to Material like this, the customdb code will be removed.