### PR TITLE
Added urlDecode to MSelectPebbleParameters

### DIFF
--- a/lib/pebbles/pebble_parameters.flow
+++ b/lib/pebbles/pebble_parameters.flow
@@ -211,7 +211,7 @@ MSelectPebbleParameters(
 			makeCurrentPebbleLastParameterSubscribe(controller, key, \value -> {
 				//println("MSelectPebbleParameters, key=" + key + ", value=" + value);
 				switch(find(parameters, \x -> x.first == key)) {
-					Some(parameter): nextDistinct(parameter.second, value);
+					Some(parameter): nextDistinct(parameter.second, urlDecode(value));
 					None(): {}
 				}
 			})

--- a/tests/pebbles_bug.flow
+++ b/tests/pebbles_bug.flow
@@ -7,7 +7,8 @@ main () {
 	controller = makePebbleController(println);
 	mrender(mManager, true, getPebblesControlledView(controller));
 
-	registerDispatcher(controller, "home", \-> showView(controller, mManager));
+	// registerDispatcher(controller, "home", \-> showView(controller, mManager));
+	registerDispatcher(controller, "home", \-> showView2(controller, mManager));
 
 	validateCurrentPebbleAndInitView(controller, mManager, makeSimplePebble("home"));
 }
@@ -19,7 +20,7 @@ showView(controller : PebbleController, mManager : MaterialManager) -> Material 
 	value2B = make("");
 	value2ParameterB = cloneBehaviour(value2B);
 
-	confirmation = \key, parameterB -> {
+	confirmation = \key, parameterB : DynamicBehaviour<string> -> {
 		\callbackToApprove -> {
 			closeB = make(false);
 			onClose = \x -> {
@@ -79,6 +80,7 @@ showView(controller : PebbleController, mManager : MaterialManager) -> Material 
 					controller,
 					[KeyValue("param1", pprint("test : value1 : ")(value1))],
 					confirmation("param1", value1ParameterB),
+					None(),
 					m
 				)
 			)),
@@ -94,6 +96,7 @@ showView(controller : PebbleController, mManager : MaterialManager) -> Material 
 					controller,
 					[KeyValue("param2", value2)],
 					confirmation("param2", value2ParameterB),
+					None(),
 					m
 				)
 			)),
@@ -102,4 +105,33 @@ showView(controller : PebbleController, mManager : MaterialManager) -> Material 
 			})
 		])
 	)
+}
+
+showView2(controller : PebbleController, mManager : MaterialManager) -> Material {
+	valueB = make("");
+	valueParameterB = cloneBehaviour(valueB);
+
+	MLinkPebbleParameters(
+		controller,
+		[
+			PebbleStringLink(
+				"param",
+				valueParameterB,
+				\value -> {
+					println("call onChange");
+					nextDistinct(valueB, value);
+				},
+				RecordURLChange()
+			),
+		],
+		MSelect(valueB, \value -> {
+			MLines([
+				MTextButton("Click me to change parameter", \-> {
+					// due to the encoded value onChange well be called twice
+					next(valueParameterB, getValue(valueParameterB) + "%20Pebbles%20test%20")
+				}, [], []),
+				MText("Value is " + value, [])
+			])
+		})
+	)	
 }


### PR DESCRIPTION
Added test case shows that if PebbleStringLink uses encoded string as the valueB, it leads to a double call of onChange function inside changeParameterValue.
Using urlDecode(value) seems to me the logical solution. But I'm not sure wouldn't it break something.