### PR TITLE
Use absolute path to default fontconfig in resources

### DIFF
--- a/tools/common/compilerconfig.flow
+++ b/tools/common/compilerconfig.flow
@@ -111,7 +111,7 @@ getCompilerConfig() {
     partialevaluate = getUrlParameterDef("pe", "");
     prettyprint = getUrlParameterDef("pp", "");
 
-    fontconfig = getUrlParameterDef("fontconfig-file", "");
+    fontconfigFile = getUrlParameterDef("fontconfig-file", "");
     dumpids = getUrlParameter("dump-ids");
 
     htmlMinify = isUrlParameterTrue("html-minify");
@@ -209,14 +209,20 @@ getCompilerConfig() {
             Pair("dce-remove-main", dceRemoveMain),
             Pair("dce-force-remove-globals", fcDceForceRemoveGlobals),
             Pair("keep-sources", fcKeepSources),
-            Pair("fontconfig-file", fontconfig),
+            Pair("fontconfig-file", fontconfigFile),
             Pair("js-call-main", jsCallMain),
             Pair("force-build", fcForceBuild),
             Pair("incremental", if (fcIncremental) "1" else ""),
             Pair("js-no-otc", noOtc),
             Pair("server-port", fcServerPort),
         ]), configFile);
-        fc = getConfigParameterDef(configFile, "fontconfig-file", fontconfig);
+
+        // FontConfig
+        configFC = getConfigParameterDef(configFile, "fontconfig-file", fontconfigFile);
+        defaultFC = "resources/fontconfig.json";
+        relativeFC = if (configFC == "") defaultFC else configFC;
+        fontconfig = if (fileExists(relativeFC)) relativeFC else flowDir + defaultFC;
+
         dceRemoveMainParam = isConfigParameterTrue(configTree, "dce-remove-main");
         jsCallMainParam = isConfigParameterTrue(configTree, "js-call-main");
         Some(CompilerConfig(
@@ -241,7 +247,7 @@ getCompilerConfig() {
                 beautify,
                 verbose,
                 nwjsmode,
-                if (fc == "") flowDir + "resources/fontconfig.json" else fc,
+                fontconfig,
                 dcePreservedNames,
                 dceRemoveMainParam,
                 jsCallMainParam

--- a/tools/common/compilerconfig.flow
+++ b/tools/common/compilerconfig.flow
@@ -241,7 +241,7 @@ getCompilerConfig() {
                 beautify,
                 verbose,
                 nwjsmode,
-                if (fc == "") "resources/fontconfig.json" else fc,
+                if (fc == "") flowDir + "resources/fontconfig.json" else fc,
                 dcePreservedNames,
                 dceRemoveMainParam,
                 jsCallMainParam

--- a/tools/common/compilerconfig.flow
+++ b/tools/common/compilerconfig.flow
@@ -217,7 +217,8 @@ getCompilerConfig() {
             Pair("server-port", fcServerPort),
         ]), configFile);
 
-        // FontConfig
+        // FontConfig. When empty - fallback to default fontconfig filename.
+        // If default filename doesn't exist as relative path - fallback to absolute path in flowDir.
         configFC = getConfigParameterDef(configFile, "fontconfig-file", fontconfigFile);
         defaultFC = "resources/fontconfig.json";
         relativeFC = if (configFC == "") defaultFC else configFC;


### PR DESCRIPTION
This allows to use the default fontconfig from `resources/`, even when it's not specified in flow.config.

I'm not sure if I should recompile any binaries, so would be glad for some tips. Thanks!