### PR TITLE
arrayDiff: remove reverse and fix tests

### DIFF
--- a/lib/ds/array_diff.flow
+++ b/lib/ds/array_diff.flow
@@ -8,6 +8,14 @@ export {
 	arrayDiff(old : [?], new : [?], fullProtocol : bool) -> [ArrayOperation<?>];
 	arrayDiffFast(old : [?], new : [?]) -> [ArrayOperation<?>];
 
+	applyProtocol(
+		source : [?],
+		protocol : [ArrayOperation<?>],
+		insertFn : (newValue : ?) -> ?, //
+		replaceFn : (oldValue : ?, newValue : ?) -> ?,
+		removeFn : (oldValue : ?) -> Maybe<?> // if None() then element will be removed, if Some - replaced
+	) -> [?];
+
 	ArrayOperation<?> ::= ArrayNop, ArrayInsert<?>, ArrayReplace<?>, ArrayRemove;
 		ArrayNop(oldindex : int, newindex : int);
 		ArrayInsert(oldindex : int, newindex : int, value : ?);
@@ -100,6 +108,140 @@ makeArrayDiffOps(d : [[ref Pair<int, ArrayOperation<?>>]], y : int, x : int, acc
 	}
 }
 
+// ArrayNop is used as ArrayMove
+// Isn't replaceable with arrayDiff since has a bit different logic
+arrayDiffFast(old : [?], new : [?]) -> [ArrayOperation<?>] {
+	// println("arrayDiffFast");
+	// println(old);
+	// println(new);
+
+	// t = timestamp();
+
+	removeOp : ref Tree<int, ArrayOperation> = ref makeTree();
+	insertOp : ref Tree<int, ArrayInsert> = ref makeTree();
+	moveOp : ref Tree<int, ArrayOperation> = ref makeTree();
+	replaceOp : ref Tree<int, ArrayOperation> = ref makeTree();
+
+	newTree = foldi(new, makeTree(), \i, acc, n -> eitherFn(lookupTree(acc, n), \v -> setTree(acc, n, arrayPush(v, i)), \ -> setTree(acc, n, [i])));
+
+	removeCounter = ref 0;
+
+	newFilteredTree = foldi(old, newTree, \k, acc, o -> {
+		eitherFn(
+			lookupTree(acc, o),
+			\a -> {
+				n = fold(tail(a), a[0], \n, v -> if (iabs(v - k) < iabs(n - k)) v else n);
+				moveOp := setTree(^moveOp, k, ArrayNop(k, n));
+
+				if (length(a) > 1) {
+					setTree(acc, o, removeFirst(a, n));
+				} else {
+					removeFromTree(acc, o);
+				}
+			},
+			\ -> {
+				i = k - ^removeCounter;
+				removeCounter := ^removeCounter + 1;
+
+				removeOp := setTree(^removeOp, k, ArrayRemove(i, i));
+
+				acc
+			}
+		)
+	});
+
+	traverseInOrder(newFilteredTree, \k, v -> {
+		iter(v, \i -> {
+			insertOp := setTree(^insertOp, i, ArrayInsert(i, i, k));
+		});
+	});
+
+	i = ref -1;
+
+	newMoveOp = ref makeTree();
+
+	traverseInOrder(^moveOp, \k, v -> {
+		i := ^i + 1;
+		newMoveOp := setTree(^newMoveOp, v.newindex, ArrayNop(^i, v.newindex));
+	});
+
+	i := -1;
+
+	moveOp := makeTree();
+
+	traverseInOrder(^newMoveOp, \k, v -> {
+		i := ^i + 1;
+		moveOp := setTree(^moveOp, ^i, ArrayNop(v.oldindex, ^i));
+	});
+
+	map(getTreeKeys(^moveOp), \k -> {
+		maybeApply(lookupTree(^moveOp, k), \m : ArrayOperation<?> -> {
+			if (m.newindex > m.oldindex) {
+				moveOp := mapTree(^moveOp, \m2 -> {
+					if (m2.newindex > m.newindex && m2.oldindex > m.oldindex && m2.oldindex <= m.newindex)
+						ArrayNop(m2.oldindex - 1, m2.newindex)
+					else
+						m2
+				});
+			} else if (m.newindex < m.oldindex) {
+				moveOp := mapTree(^moveOp, \m2 -> {
+					if (m2.newindex > m.newindex && m2.oldindex >= m.newindex && m2.oldindex < m.oldindex)
+						ArrayNop(m2.oldindex + 1, m2.newindex)
+					else
+						m2
+				});
+			}
+		});
+	});
+
+	concat3(
+		concat(
+			getTreeValues(^removeOp),
+			getTreeValues(^replaceOp)
+		),
+		filter(getTreeValues(^moveOp), \m -> m.oldindex != m.newindex),
+		getTreeValues(^insertOp)
+	);
+
+	// println(timestamp() - t);
+
+	// println(length(old));
+	// println(length(new));
+	// println(sizeTree(^removeOp));
+	// println(sizeTree(^insertOp));
+
+	// r;
+}
+
+applyProtocol(
+	source : [?],
+	protocol : [ArrayOperation<?>],
+	insertFn : (?) -> ?,
+	replaceFn : (?, ?) -> ?,
+	removeFn : (?) -> Maybe<?>
+) -> [?] {
+	fold(protocol, source, \acc, op -> {
+		switch (op : ArrayOperation) {
+			ArrayNop(__, __): acc;
+			ArrayInsert(__, __, __): insertArray(acc, op.oldindex, insertFn(op.value));
+			ArrayReplace(i, j, v): replace(acc, op.oldindex, replaceFn(acc[op.oldindex], op.value));
+			ArrayRemove(i, j): {
+				eitherFn(
+					removeFn(acc[op.oldindex]),
+					\newVal -> replace(acc, op.oldindex, newVal),
+					\ -> removeIndex(acc, op.oldindex)
+				)
+			}
+		}
+	});
+}
+
+// Test cases.
+// printInfo(title : string, arr : [?]) -> void {
+// 	println(title + ":");
+// 	iteri(arr, \i, a : ? -> println("  " + lpad(i2s(i), " ", 3) + " " + toString(a)));
+// }
+
 // main() {
 // 	fullProtocol = false;
 // 	assertEquals(arrayDiff([], [], fullProtocol), []);
@@ -127,10 +269,62 @@ makeArrayDiffOps(d : [[ref Pair<int, ArrayOperation<?>>]], y : int, x : int, acc
 // 	assertEquals(arrayDiff([0,1,2,3], [0,2,2,3,5], fullProtocol), [ArrayInsert(4,4,5), ArrayReplace(1,1,2)]);
 // 	assertEquals(arrayDiff([0,1,2,3,4], [1,2,3,5,6], fullProtocol), [ArrayReplace(4,4,6), ArrayInsert(4,3,5), ArrayRemove(0,0)]);
 
+// 	applyProtocolWithChange = \theSource, theProtocol ->
+// 		applyProtocol(theSource, theProtocol,
+// 			\newValue ->  {//insertFn
+// 				"INS[" + newValue + "]"
+// 			},
+// 			\oldValue, newValue -> { // replaceFn
+// 				"REPLACE[" + oldValue + " -> " + newValue + "]"
+// 			},
+// 			\oldValue -> { // removeFn
+// 				Some("DEL[" + oldValue + "]")
+// 			}
+// 		);
+
+// 	applyProtocolClean = \theSource, theProtocol ->
+// 		applyProtocol(theSource, theProtocol,
+// 			idfn,
+// 			\__, newValue -> newValue,
+// 			\__ -> None()
+// 		);
+
+// 	testData : [Pair<[string], [string]>] = [
+// 		Pair(
+// 			["The", " ", "boy", " ", "walked", " ", "down", " ", "the", " ", "street", "." ],
+// 			["The", " ", "boy", " ", "is", " ", "walks", " ", "down", " ", "the", " ", "street", "." ]
+// 		),
+// 		Pair(
+// 			["The", " ", "boy walked", " ", "down", " ", "the", " ", "street", "."],
+// 			["The", " ", "boy is walks down", " ", "the", " ", "street", "."]
+// 		)
+// 	];
+
+// 	iteri(testData, \i, t -> {
+// 		source = t.first;
+// 		target = t.second;
+// 		println("==============" + i2s(i+1) + "=============");
+// 		printInfo("source", source);
+// 		printInfo("target", target);
+
+// 		protocol = arrayDiff(source, target, false);
+// 		printInfo("protocol", protocol);
+
+// 		printInfo("targetWithChanges", applyProtocolWithChange(source, protocol));
+
+// 		restoredTarget = applyProtocolClean(source, protocol);
+// 		printInfo("restoredTarget", restoredTarget);
+// 		println("Comparing restoredTarget with target...");
+// 		assertEquals(target, restoredTarget);
+// 		println("   - OK");
+
+// 		println("===========================");
+// 	});
+
 // 	quit(0);
 // }
 
-
+// Old test cases
 // main() {
 // 	// assertEquals(arrayDiffFast([], []), []);
 // 	// assertEquals(arrayDiffFast([0], [0]), []);
@@ -255,108 +449,3 @@ makeArrayDiffOps(d : [[ref Pair<int, ArrayOperation<?>>]], y : int, x : int, acc
 
 // 	assertEquals(a2, a3);
 // }
-
-// ArrayNop is used as ArrayMove
-// Isn't replaceable with arrayDiff since has a bit different logic
-arrayDiffFast(old : [?], new : [?]) -> [ArrayOperation<?>] {
-	// println("arrayDiffFast");
-	// println(old);
-	// println(new);
-
-	// t = timestamp();
-
-	removeOp : ref Tree<int, ArrayOperation> = ref makeTree();
-	insertOp : ref Tree<int, ArrayInsert> = ref makeTree();
-	moveOp : ref Tree<int, ArrayOperation> = ref makeTree();
-	replaceOp : ref Tree<int, ArrayOperation> = ref makeTree();
-
-	newTree = foldi(new, makeTree(), \i, acc, n -> eitherFn(lookupTree(acc, n), \v -> setTree(acc, n, arrayPush(v, i)), \ -> setTree(acc, n, [i])));
-
-	removeCounter = ref 0;
-
-	newFilteredTree = foldi(old, newTree, \k, acc, o -> {
-		eitherFn(
-			lookupTree(acc, o),
-			\a -> {
-				n = fold(tail(a), a[0], \n, v -> if (iabs(v - k) < iabs(n - k)) v else n);
-				moveOp := setTree(^moveOp, k, ArrayNop(k, n));
-
-				if (length(a) > 1) {
-					setTree(acc, o, removeFirst(a, n));
-				} else {
-					removeFromTree(acc, o);
-				}
-			},
-			\ -> {
-				i = k - ^removeCounter;
-				removeCounter := ^removeCounter + 1;
-
-				removeOp := setTree(^removeOp, k, ArrayRemove(i, i));
-
-				acc
-			}
-		)
-	});
-
-	traverseInOrder(newFilteredTree, \k, v -> {
-		iter(v, \i -> {
-			insertOp := setTree(^insertOp, i, ArrayInsert(i, i, k));
-		});
-	});
-
-	i = ref -1;
-
-	newMoveOp = ref makeTree();
-
-	traverseInOrder(^moveOp, \k, v -> {
-		i := ^i + 1;
-		newMoveOp := setTree(^newMoveOp, v.newindex, ArrayNop(^i, v.newindex));
-	});
-
-	i := -1;
-
-	moveOp := makeTree();
-
-	traverseInOrder(^newMoveOp, \k, v -> {
-		i := ^i + 1;
-		moveOp := setTree(^moveOp, ^i, ArrayNop(v.oldindex, ^i));
-	});
-
-	map(getTreeKeys(^moveOp), \k -> {
-		maybeApply(lookupTree(^moveOp, k), \m : ArrayOperation<?> -> {
-			if (m.newindex > m.oldindex) {
-				moveOp := mapTree(^moveOp, \m2 -> {
-					if (m2.newindex > m.newindex && m2.oldindex > m.oldindex && m2.oldindex <= m.newindex)
-						ArrayNop(m2.oldindex - 1, m2.newindex)
-					else
-						m2
-				});
-			} else if (m.newindex < m.oldindex) {
-				moveOp := mapTree(^moveOp, \m2 -> {
-					if (m2.newindex > m.newindex && m2.oldindex >= m.newindex && m2.oldindex < m.oldindex)
-						ArrayNop(m2.oldindex + 1, m2.newindex)
-					else
-						m2
-				});
-			}
-		});
-	});
-
-	concat3(
-		concat(
-			getTreeValues(^removeOp),
-			getTreeValues(^replaceOp)
-		),
-		filter(getTreeValues(^moveOp), \m -> m.oldindex != m.newindex),
-		getTreeValues(^insertOp)
-	);
-
-	// println(timestamp() - t);
-
-	// println(length(old));
-	// println(length(new));
-	// println(sizeTree(^removeOp));
-	// println(sizeTree(^insertOp));
-
-	// r;
-}

--- a/lib/ds/array_diff.flow
+++ b/lib/ds/array_diff.flow
@@ -8,6 +8,9 @@ export {
 	arrayDiff(old : [?], new : [?], fullProtocol : bool) -> [ArrayOperation<?>];
 	arrayDiffFast(old : [?], new : [?]) -> [ArrayOperation<?>];
 
+	// reverse protocol, for backward compatibility
+	arrayDiffReversed(old : [?], new : [?], fullProtocol : bool) -> [ArrayOperation<?>];
+
 	applyProtocol(
 		source : [?],
 		protocol : [ArrayOperation<?>],
@@ -92,6 +95,10 @@ arrayDiff(s : [?], t : [?], fullProtocol : bool) -> [ArrayOperation<?>] {
 	});*/
 
 	makeArrayDiffOps(d, m, n, [], fullProtocol);
+}
+
+arrayDiffReversed(old : [?], new : [?], fullProtocol : bool) -> [ArrayOperation<?>] {
+	reverseA(arrayDiff(old, new, fullProtocol))
 }
 
 makeArrayDiffOps(d : [[ref Pair<int, ArrayOperation<?>>]], y : int, x : int, acc : [ArrayOperation<?>], fullProtocol : bool) -> [ArrayOperation<?>] {

--- a/lib/ds/array_diff.flow
+++ b/lib/ds/array_diff.flow
@@ -15,6 +15,7 @@ export {
 		replaceFn : (oldValue : ?, newValue : ?) -> ?,
 		removeFn : (oldValue : ?) -> Maybe<?> // if None() then element will be removed, if Some - replaced
 	) -> [?];
+	applyProtocolInvariant(source : [?], protocol : [ArrayOperation<?>]) -> [?];
 
 	ArrayOperation<?> ::= ArrayNop, ArrayInsert<?>, ArrayReplace<?>, ArrayRemove;
 		ArrayNop(oldindex : int, newindex : int);
@@ -236,6 +237,14 @@ applyProtocol(
 	});
 }
 
+applyProtocolInvariant(source : [?], protocol : [ArrayOperation<?>]) -> [?] {
+	applyProtocol(source, protocol,
+		idfn,
+		\__, newValue -> newValue,
+		\__ -> None()
+	);
+}
+
 // Test cases.
 // printInfo(title : string, arr : [?]) -> void {
 // 	println(title + ":");
@@ -282,13 +291,6 @@ applyProtocol(
 // 			}
 // 		);
 
-// 	applyProtocolClean = \theSource, theProtocol ->
-// 		applyProtocol(theSource, theProtocol,
-// 			idfn,
-// 			\__, newValue -> newValue,
-// 			\__ -> None()
-// 		);
-
 // 	testData : [Pair<[string], [string]>] = [
 // 		Pair(
 // 			["The", " ", "boy", " ", "walked", " ", "down", " ", "the", " ", "street", "." ],
@@ -312,7 +314,7 @@ applyProtocol(
 
 // 		printInfo("targetWithChanges", applyProtocolWithChange(source, protocol));
 
-// 		restoredTarget = applyProtocolClean(source, protocol);
+// 		restoredTarget = applyProtocolInvariant(source, protocol);
 // 		printInfo("restoredTarget", restoredTarget);
 // 		println("Comparing restoredTarget with target...");
 // 		assertEquals(target, restoredTarget);

--- a/lib/ds/array_diff.flow
+++ b/lib/ds/array_diff.flow
@@ -82,7 +82,7 @@ arrayDiff(s : [?], t : [?], fullProtocol : bool) -> [ArrayOperation<?>] {
 		}));
 	});*/
 
-	reverseA(makeArrayDiffOps(d, m, n, [], fullProtocol));
+	makeArrayDiffOps(d, m, n, [], fullProtocol);
 }
 
 makeArrayDiffOps(d : [[ref Pair<int, ArrayOperation<?>>]], y : int, x : int, acc : [ArrayOperation<?>], fullProtocol : bool) -> [ArrayOperation<?>] {
@@ -100,34 +100,36 @@ makeArrayDiffOps(d : [[ref Pair<int, ArrayOperation<?>>]], y : int, x : int, acc
 	}
 }
 
-/*
-main() {
-	assertEquals(arrayDiff([], []), []);
-	assertEquals(arrayDiff([0], [0]), []);
-	assertEquals(arrayDiff([0,1], [0,1]), []);
+// main() {
+// 	fullProtocol = false;
+// 	assertEquals(arrayDiff([], [], fullProtocol), []);
+// 	assertEquals(arrayDiff([0], [0], fullProtocol), []);
+// 	assertEquals(arrayDiff([0,1], [0,1], fullProtocol), []);
 
-	assertEquals(arrayDiff([], [0]), [ArrayInsert(0,0,0)]);
-	assertEquals(arrayDiff([], [0,1]), [ArrayInsert(0,1,1), ArrayInsert(0,0,0)]);
-	assertEquals(arrayDiff([], [0,1,2]), [ArrayInsert(0,2,2), ArrayInsert(0,1,1), ArrayInsert(0,0,0)]);
+// 	assertEquals(arrayDiff([], [0], fullProtocol), [ArrayInsert(0,0,0)]);
+// 	assertEquals(arrayDiff([], [0,1], fullProtocol), [ArrayInsert(0,1,1), ArrayInsert(0,0,0)]);
+// 	assertEquals(arrayDiff([], [0,1,2], fullProtocol), [ArrayInsert(0,2,2), ArrayInsert(0,1,1), ArrayInsert(0,0,0)]);
 
-	assertEquals(arrayDiff([0], [0,1,2]), [ArrayInsert(1,2,2), ArrayInsert(1,1,1)]);
-	assertEquals(arrayDiff([1], [0,1,2]), [ArrayInsert(1,2,2), ArrayInsert(0,0,0)]);
+// 	assertEquals(arrayDiff([0], [0,1,2], fullProtocol), [ArrayInsert(1,2,2), ArrayInsert(1,1,1)]);
+// 	assertEquals(arrayDiff([1], [0,1,2], fullProtocol), [ArrayInsert(1,2,2), ArrayInsert(0,0,0)]);
 
-	assertEquals(arrayDiff([0], []), [ArrayRemove(0,0)]);
-	assertEquals(arrayDiff([0,1], [0]), [ArrayRemove(1,1)]);
-	assertEquals(arrayDiff([0,1], [1]), [ArrayRemove(0,0)]);
+// 	assertEquals(arrayDiff([0], [], fullProtocol), [ArrayRemove(0,0)]);
+// 	assertEquals(arrayDiff([0,1], [0], fullProtocol), [ArrayRemove(1,1)]);
+// 	assertEquals(arrayDiff([0,1], [1], fullProtocol), [ArrayRemove(0,0)]);
 
-	assertEquals(arrayDiff([0], [1]), [ArrayReplace(0,0,1)]);
-	assertEquals(arrayDiff([0,1,2], [2,1,0]), [ArrayReplace(2,2,0), ArrayReplace(0,0,2)]);
-	assertEquals(arrayDiff([0,1,2], [2,2,2]), [ArrayReplace(1,1,2), ArrayReplace(0,0,2)]);
-	assertEquals(arrayDiff([0,1,2], [2,2,2]), [ArrayReplace(1,1,2), ArrayReplace(0,0,2)]);
+// 	assertEquals(arrayDiff([0], [1], fullProtocol), [ArrayReplace(0,0,1)]);
+// 	assertEquals(arrayDiff([0,1,2], [2,1,0], fullProtocol), [ArrayReplace(2,2,0), ArrayReplace(0,0,2)]);
+// 	assertEquals(arrayDiff([0,1,2], [2,2,2], fullProtocol), [ArrayReplace(1,1,2), ArrayReplace(0,0,2)]);
+// 	assertEquals(arrayDiff([0,1,2], [2,2,2], fullProtocol), [ArrayReplace(1,1,2), ArrayReplace(0,0,2)]);
 
-	assertEquals(arrayDiff([0,1,2,3], [0,2,4]), [ArrayReplace(3,2,4), ArrayRemove(1,1)]);
-	assertEquals(arrayDiff([0,1,2,3], [0,2,2,3,5]), [ArrayInsert(4,4,5), ArrayReplace(1,1,2)]);
-	assertEquals(arrayDiff([0,1,2,3], [0,2,2,3,5]), [ArrayInsert(4,4,5), ArrayReplace(1,1,2)]);
-	assertEquals(arrayDiff([0,1,2,3,4], [1,2,3,5,6]), [ArrayReplace(4,4,6), ArrayInsert(4,3,5), ArrayRemove(0,0)]);
-}
-*/
+// 	assertEquals(arrayDiff([0,1,2,3], [0,2,4], fullProtocol), [ArrayReplace(3,2,4), ArrayRemove(1,1)]);
+// 	assertEquals(arrayDiff([0,1,2,3], [0,2,2,3,5], fullProtocol), [ArrayInsert(4,4,5), ArrayReplace(1,1,2)]);
+// 	assertEquals(arrayDiff([0,1,2,3], [0,2,2,3,5], fullProtocol), [ArrayInsert(4,4,5), ArrayReplace(1,1,2)]);
+// 	assertEquals(arrayDiff([0,1,2,3,4], [1,2,3,5,6], fullProtocol), [ArrayReplace(4,4,6), ArrayInsert(4,3,5), ArrayRemove(0,0)]);
+
+// 	quit(0);
+// }
+
 
 // main() {
 // 	// assertEquals(arrayDiffFast([], []), []);

--- a/lib/material/internal/material_tabs.flow
+++ b/lib/material/internal/material_tabs.flow
@@ -59,7 +59,7 @@ MDynamicTabs2T(manager : MaterialManager, parent : MFocusGroup, m : MDynamicTabs
 	(\p0 ->
 		(\p ->
 			MSelect2T(manager, p, "MTabsHeader", [AccessRole("tablist"), MFocusId(const(0))], m.tabs, \tbs : [MTab], p2 -> {
-				protocol : [ArrayOperation<MTab>] = arrayDiff(^oldTabs, tbs, false);
+				protocol : [ArrayOperation<MTab>] = arrayDiffReversed(^oldTabs, tbs, false);
 				tbsLength = length(tbs);
 
 				sel = ref getValue(m.selected);
@@ -294,13 +294,13 @@ MDynamicTabs2T(manager : MaterialManager, parent : MFocusGroup, m : MDynamicTabs
 		|> (\makeTabsHeader ->
 			eitherFn(
 				itemsColor,
-				\ic -> 
+				\ic ->
 					MComponentGroup2T(
 						manager,
 						p0,
 						"MTabs",
 						[
-							MaterialTheme(p0.theme with palette = 
+							MaterialTheme(p0.theme with palette =
 								MaterialPalette(getLightBackground(p0), ic, getAccentColor(p0), ic, ic, ic, ic)
 							)
 						],

--- a/lib/tropic/selecttarray.flow
+++ b/lib/tropic/selecttarray.flow
@@ -45,7 +45,7 @@ SelectTropicArray(values : Transform<[?]>, makeTropicFn : (index :  Transform<in
 				// println(map(^indexes, getValue));
 				// println(^ids);
 
-				iter(arrayDiff(^old, l, false), \op ->
+				iter(arrayDiffReversed(^old, l, false), \op ->
 					switch (op : ArrayOperation) {
 						ArrayNop(x, y): {
 							// println("nop " + i2s(x) + " " + i2s(y));

--- a/lib/tropic/tropic_array.flow
+++ b/lib/tropic/tropic_array.flow
@@ -79,7 +79,7 @@ makeTropicArray(initValues : [?], makeTropicFn : (index :  Transform<int>, id : 
 		// println(map(^indexes, getValue));
 		// println(^ids);
 
-		iter(arrayDiff(^old, l, false), \op ->
+		iter(arrayDiffReversed(^old, l, false), \op ->
 			switch (op : ArrayOperation) {
 				ArrayNop(x, y): {
 					// println("nop " + i2s(x) + " " + i2s(y));


### PR DESCRIPTION

test app:

in the master, we can't use protocol obtained from arrayDiff because it was reversed inside and attempt to apply it to the source array would lead to the wrong result

```
import ds/array_diff;

printInfo(title : string, arr : [?]) -> void {
	println(title + ":");
	iteri(arr, \i, a : ? -> println("  " + lpad(i2s(i), " ", 3) + " " + toString(a)));
}

main() {
	source = ["The", " ", "boy", " ", "walked", " ", "down", " ", "the", " ", "street", "." ];
	target = ["The", " ", "boy", " ", "is", " ", "walks", " ", "down", " ", "the", " ", "street", "." ];

	printInfo("source", source);
	printInfo("target", target);

	protocol = arrayDiff(source, target, false);
	printInfo("protocol", protocol);

	applyProtocol = \theSource, theProtocol ->
		fold(theProtocol, theSource, \acc, op -> {
			switch (op : ArrayOperation) {
				ArrayNop(__, __): acc;
				ArrayInsert(__, __, __): {
					insertArray(
						acc,
						op.oldindex,
						"INS[" + op.value + "]"
					)
				}
				ArrayReplace(i, j, v): {
					replace(
						acc,
						op.oldindex,
						"REPLACE[" + acc[op.oldindex] + " -> " + op.value + "]"
					)
				}
				ArrayRemove(i, j): {
					replace(
						acc,
						op.oldindex,
						"DEL[" + acc[op.oldindex] + "]"
					)
				}
			}
		});

	printInfo("newTarget", applyProtocol(source, protocol));
	printInfo("newTarget  reversed protocol", applyProtocol(source, reverseA(protocol)));
	quit(0);
}
```