### PR TITLE
wigi: we should track detached words for cursor related stuff

### DIFF
--- a/lib/form/paragraph.flow
+++ b/lib/form/paragraph.flow
@@ -45,7 +45,7 @@ export {
 			TextFragmentMoreLineBreaks();
 			TextFragmentLastChild();
 			// Index of current paragraph element the fragment belongs to.
-			// Needed to handle features that belong to whole paragraph element. 
+			// Needed to handle features that belong to whole paragraph element.
 			ParaElemIdx(index : int);
 
 	replaceDoubleNL(s : string) -> string {
@@ -558,7 +558,7 @@ makeZeroSpaceElement(style : [CharacterStyle]) -> Form {
 }
 
 makeEmptyLineInspectElement(indexing : int, style : [CharacterStyle]) -> WrapElement {
-	InspectElement(indexing, make(0.0), make(0.0), makeWH(), make(0.0), make(-1), makeZeroSpaceElement(style))
+	InspectElement(indexing, make(0.0), make(0.0), makeWH(), make(0.0), make(-1), makeZeroSpaceElement(style), make(false))
 }
 
 // Analogue of likely named function in tparagraph.flow
@@ -586,7 +586,7 @@ breakTextFragment(
 
 	toInspectingElementIfNecessary : (int, int, InspectableElement) -> WrapElement = \indexing, offset, f -> {
 		wElem = if (0 <= indexing) {
-			InspectElement(offset, make(0.0), make(0.0), makeWH(), make(0.0), make(-1), f)
+			InspectElement(offset, make(0.0), make(0.0), makeWH(), make(0.0), make(-1), f, make(false))
 		} else {
 			f
 		}
@@ -951,4 +951,3 @@ formatParagraph(s : string, defaultStyle : [CharacterStyle], p : [ParagraphEleme
 
 	elements
 }
-

--- a/lib/form/paragraph3.flow
+++ b/lib/form/paragraph3.flow
@@ -3,6 +3,8 @@ import form/formtransforms;
 import form/line;
 import text/bidi_text;
 
+import text/blueprint;
+
 export {
 	renderParagraph(p : [ParagraphElement], s : [ParagraphStyle]) -> Form;
 }
@@ -34,7 +36,7 @@ GhostForm ::= Form, Ghosted; // It is important that GhostForm is a super type o
 
 // For dynamic elements, we use a ghost to allow reuse of the physical forms
 Ghosted ::= Empty, Ghost, CoordinateInspectElement, InspectGhost;
-	CoordinateInspectElement(index : int, xc : DynamicBehaviour<double>, yc : DynamicBehaviour<double>, wh : DynamicBehaviour<WidthHeight>, lineHeight : DynamicBehaviour<double>, form : Form);
+	CoordinateInspectElement(index : int, xc : DynamicBehaviour<double>, yc : DynamicBehaviour<double>, wh : DynamicBehaviour<WidthHeight>, lineHeight : DynamicBehaviour<double>, form : Form, detached : DynamicBehaviour<bool>);
 	InspectGhost(
 		xc : DynamicBehaviour<double>,
 		yc : DynamicBehaviour<double>,
@@ -181,7 +183,7 @@ expandGlueFragments(
 					NewLine(): acc2;
 					Space(f): Cons(f, acc2);
 					LinePart(pr, i, po): Cons(i, acc2);
-					InspectElement(i, x, y, wh, lh, ln, e): {
+					InspectElement(i, x, y, wh, lh, ln, e, __): {
 						switch (e : InspectableElement) {
 							Space(f): Cons(f, acc2);
 							Text(t, s): Cons(e, acc2);
@@ -219,7 +221,7 @@ expandGlueFragments(
 						InteractiveParaAtomic(cast(wElem : WrapElement -> ParaAtomic), id)
 					}
 					default: cast(e : ParaElement -> ParaAtomic);
-				} 
+				}
 				if (glueNext) {
 					expandGlueFragments(rest, false, Cons(en, running), acc, runLength + 1);
 				} else {
@@ -253,11 +255,12 @@ makeInteractiveParaWord(w : ParaAtomic, interactivityIdM : Maybe<int>) -> ParaWo
 			line : Form = Line(oc);
 			getDynamicFormSize(line) |> s2w;
 		}
-		InspectElement(i, x, y, wh, lh, ln, e): {
+		InspectElement(i, x, y, wh, lh, ln, e, detached): {
 			makeWord = \word, form -> ParaWord(
 				word,
 				const(getStaticFormSize(form)),
-				CoordinateInspectElement(i, x, y, wh, lh, form), Empty(),
+				CoordinateInspectElement(i, x, y, wh, lh, form, detached),
+				Empty(),
 				interactivityIdM
 			);
 			switch (e : InspectableElement) {
@@ -337,6 +340,18 @@ reflowParaWords2(
 		if (cw != []) arrayPush(lines, ParaLine(cw, indent)) else lines;
 	}
 
+	detachWord = \w : ParaWord, detach : bool -> {
+		switch (w.ghosted) {
+			CoordinateInspectElement(index, __, __, __, __, __, detached): nextDistinct(detached, detach);
+			default: {
+				switch (w.form) {
+					CoordinateInspectElement(index, __, __, __, __, __, detached): nextDistinct(detached, detach);
+					default: {}
+				}
+			}
+		}
+	}
+
 	lineIndex = length(lines);
 	lineIndent = getLineIndent(paraIndent, lineIndex);
 	nextLineWidth = availableWidth + lineIndent - getLineIndent(paraIndent, lineIndex + 1);
@@ -345,12 +360,13 @@ reflowParaWords2(
 		addLine(currentWords, lineIndent)
 	} else {
 		word = words[0];
+		detachWord(word, false);
 		rest = subrange(words, 1, length(words) - 1);
 		extractParaAtomicForm = \word1 -> {
 			w : ParaAtomic = word1.word;
 			f : Form = switch(w : ParaAtomic) {
 				ParaOneWord(__): Empty();
-				InspectElement(__, __, __, __, __, __, __): Empty();
+				InspectElement(__, __, __, __, __, __, __, __): Empty();
 				LinePart(first, inline, last): inline;
 				Space(s): s;
 				default: cast(w : ParaAtomic -> Form);
@@ -363,7 +379,7 @@ reflowParaWords2(
 				Empty(): extractParaAtomicForm(word1);
 				Ghost(xc, yc, fm): g;
 				InspectGhost(__, __, __, __, __, fm): g;
-				CoordinateInspectElement(index, x, y, wh, lh, fm): g;
+				CoordinateInspectElement(index, x, y, wh, lh, fm, __): g;
 			}
 		};
 		makeParaWord2 = \word2, form2 -> {
@@ -373,7 +389,7 @@ reflowParaWords2(
 					Empty(): Empty();
 					Ghost(xc, yc, __): Ghost(xc, yc, form2);
 					InspectGhost(xc, yc, wh, lh, ln, __): InspectGhost(xc, yc, wh, lh, ln, form2);
-					CoordinateInspectElement(index, x, y, wh, lh, __): CoordinateInspectElement(index, x, y, wh, lh, form2);
+					CoordinateInspectElement(index, x, y, wh, lh, __, detached): CoordinateInspectElement(index, x, y, wh, lh, form2, detached);
 				}
 				r;
 			};
@@ -421,6 +437,7 @@ reflowParaWords2(
 				if (width < remaining) {
 					reflowParaWords2(rest, availableWidth, remaining - width, arrayPush(currentWords, setWordForm(word, getWordGhostedForm(word))), lines, paraIndent);
 				} else {
+					detachWord(word, true);
 					reflowParaWords2(rest, nextLineWidth, nextLineWidth, [], addLine(currentWords, lineIndent), paraIndent);
 				}
 			}
@@ -432,7 +449,7 @@ reflowParaWords2(
 						Empty(): extractParaAtomicForm(word1);
 						Ghost(xc, yc, f): f;
 						InspectGhost(__, __, __, __, __, f): f;
-						CoordinateInspectElement(index, x, y, wh, lh, f): f;
+						CoordinateInspectElement(index, x, y, wh, lh, f, detached): f;
 					};
 				};
 
@@ -675,7 +692,7 @@ RenderLine(
 				nextDistinct(ln, lineNumber);
 				Some(applyStylesAndOffset(Empty()));
 			}
-			CoordinateInspectElement(in, xc, yc, wh, lh, fm): {
+			CoordinateInspectElement(in, xc, yc, wh, lh, fm, detached): {
 				fo = applyStylesAndOffset(fm);
 				nextDistinct(xc, ^alignmentOffset);
 				nextDistinct(yc, y + dy);
@@ -826,7 +843,7 @@ constructDynamicParaForms(
 			Empty(): None();
 			Ghost(x, y, f): Some(Translate(x, y, applyStyles(f)));
 			InspectGhost(xc, yc, __, __, __, f): Some(Translate(xc, yc, applyStyles(f)));
-			CoordinateInspectElement(i, x, y, wh, lh, f): None();
+			CoordinateInspectElement(i, x, y, wh, lh, f, detached): None();
 		}
 	})
 }
@@ -856,7 +873,7 @@ setWordText(w: ParaWord, t: string) -> ParaWord {
 		Text(__, s): ParaWord(
 			Text(t, s), w.metrics, w.ghosted,
 			switch(w.form) {
-				CoordinateInspectElement(index, xc, yc, wh, lineHeight, form): CoordinateInspectElement(index, xc, yc, wh, lineHeight, Text(t, getFormTextStyle(form)));
+				CoordinateInspectElement(index, xc, yc, wh, lineHeight, form, detached): CoordinateInspectElement(index, xc, yc, wh, lineHeight, Text(t, getFormTextStyle(form)), detached);
 				Text(__, fs): Text(t, fs);
 				default: w.form;
 			},

--- a/lib/form/paragraphtypes.flow
+++ b/lib/form/paragraphtypes.flow
@@ -30,10 +30,10 @@ export {
 		DynamicBlockDelay(n : int);
 
 		ParagraphBorder(top : double, bottom : double);
-		
+
 		ParagraphBorderStyle(width : double, color : int);
 		ParagraphColoredBorder(top : ParagraphBorderStyle, bottom : ParagraphBorderStyle);
-		
+
 		// Mapping from idx of paragraphElement to Interactive styles for that paragraphElement.
 		// Needed because paragraph elements get expanded to words before rendering of paragraph lines.
 		ParagraphInteractiveStyleTree(styleTree : Tree<int, [ParaElementInteractiveStyle]>);
@@ -72,7 +72,8 @@ export {
 			size : DynamicBehaviour<WidthHeight>,
 			lineHeight : DynamicBehaviour<double>,
 			lineNumber : DynamicBehaviour<int>,
-			element : InspectableElement
+			element : InspectableElement,
+			detached : DynamicBehaviour<bool>
 		);
 			InspectableElement ::= Space, Form, LinePart;
 

--- a/lib/formats/html/html2form.flow
+++ b/lib/formats/html/html2form.flow
@@ -846,7 +846,7 @@ renderHtmlAcc(node : XmlNode, availableWidth : Behaviour<double>, stylesheet : T
 									NewLine(): tf;
 									Space(sf): Space(buttonify(sf));
 									GlueFragments(): tf;
-									InspectElement(__, __, __, __, __, __, __): tf;
+									InspectElement(__, __, __, __, __, __, __, __): tf;
 									default: {
 										fm = cast(tf : WrapElement -> Form);
 										buttonify(fm);


### PR DESCRIPTION
In edit mode, wigi traverse interactive elements (IE) list made from paragraph in order to find the real position of the cursor on the screen. but reflow procedure removes last space on the each line that does not fit the width so such IE does not recieve updates of it's coordinates and the positionin of the cursor gets wrong.
We can't just keep such spaces because it would lead to horizontal scroll appear and we can't put them on the next line because it will break align.
So we have to introduce attach/detach property for the words.