### PR TITLE
Fix for recursive containsHanScript

### DIFF
--- a/lib/material/internal/mstring.flow
+++ b/lib/material/internal/mstring.flow
@@ -410,8 +410,8 @@ containsHanScript(s : string) -> bool {
 	len = strlen(s);
 
 	if (len > 0) {
-		c = getCharCodeAt(s, 0);
-		(c >= 11904 && c <= 40959) || containsHanScript(substring(s, 1, len - 1))
+		cc = generate(0, len, \g -> getCharCodeAt(s, g));
+		exists(cc, \c -> (c >= 11904 && c <= 40959))
 	} else {
 		false
 	}


### PR DESCRIPTION
Sometimes js code in the browser encountered such an error.
Uncaught RangeError: Maximum call stack size exceeded

Locally, I checked and everything was decided if to avoid recursion