### PR TITLE
We shouldn't terminate application while some deffered code is running

### DIFF
--- a/platforms/java/com/area9innovation/flow/Native.java
+++ b/platforms/java/com/area9innovation/flow/Native.java
@@ -737,7 +737,7 @@ public class Native extends NativeHost {
 
 	public final Object timer(int ms, final Func0<Object> cb) {
 		if (timer_obj == null)
-			timer_obj = new Timer(true);
+			timer_obj = new Timer(false);
 
 		TimerTask task = new TimerTask() {
 			public void run() {


### PR DESCRIPTION
From javadoc: 

```
public Timer(boolean isDaemon)
Creates a new timer whose associated thread may be specified to run as a daemon. A daemon thread is called for if the timer will be used to schedule repeating "maintenance activities", which must be performed as long as the application is running, but should not prolong the lifetime of the application.
```

I don't know what is the benefit of having thread as daemon, but having it as daemon cause following code working incorrect (at least different from other targets):

```
main() {
  ...
  deffered(\-> {
  ...
     foo()
  })
}
```

In Java `foo` will never be executed (`deffered` implemented using `timer`)