### PR TITLE
dceil and frac - use full values range, not only integers

### DIFF
--- a/lib/math/math.flow
+++ b/lib/math/math.flow
@@ -299,7 +299,7 @@ ceil(d) -floor(-d);
 
 round(d) floor(d + 0.5);
 
-frac(d) abs(d) - i2d(floor(abs(d)));
+frac(d) abs(d % 1.0);
 
 abs(x) { if (x < 0.0) -x else x; }
 
@@ -356,7 +356,9 @@ dpow2(x, m) {
 
 dfloor(d) { d - d % 1.0 }
 
-dceil(d) i2d(ceil(d));
+dceil(d) {
+	dfloor(d) + i2d(ceil(d % 1.0))
+}
 
 dround(x : double) -> double {
 	dfloor(x + (if (x < 0.0) -0.5 else 0.5))


### PR DESCRIPTION
When I see a function like fn(value : double) -> double, I expect it works actually with doubles and doesn't miss a huge range of data that's out of intMin - intMax.
What if we do the change, would it break something?