### PR TITLE
Simplify drawing of brackets

### DIFF
--- a/lib/form/mathdrawing.flow
+++ b/lib/form/mathdrawing.flow
@@ -276,20 +276,12 @@ createBracketWithColorAndSize(type, bodyHeight, color, fontSize) {
 			)
 		}
 		WriteRightBracket() : {
-			Size2(
-				const(WidthHeight(deepness + border, height)),
-				Graphics(
-					{
-						lx1 = 2.0 * deepness;
-						lx2 = lx1 - sqrt(deepness);
-						[
-							MoveTo(deepness * 0.2, 0.0),
-							CubicBezierTo(deepness * 0.2, height, lx1, height / 2.0),
-							CubicBezierTo(deepness * 0.2, 0.0, lx2, height / 2.0),
-							ClosePath()
-						];
-					},
-					[Fill(color)]
+			Translate(
+				const(deepness),
+				const(height),
+				Rotate(
+					const(180.0),
+					createBracketWithColorAndSize(WriteLeftBracket(), bodyHeight, color, fontSize)
 				)
 			)
 		}


### PR DESCRIPTION
Remove separate code for the right bracket, display it by mirroring the left bracket.
Decrease the complexity and the chance of different look of right and left brackets.