### PR TITLE
snackbar width by text width

### DIFF
--- a/lib/material/material_snackbar.flow
+++ b/lib/material/material_snackbar.flow
@@ -48,9 +48,7 @@ showMSnackbar(manager : MaterialManager, text : string, style : [MSnackbarStyle]
 
 	hght = getTWordMetrics(textForm, makeTree()).height;
 
-	snackText =
-		MEllipsis(textForm, TFixed(568.0 - 24.0 - 24.0 - 48.0, hght), [textColor, MBody()])
-		|> (\f -> MFixSize(f, TMinimumGroup2(textForm, TFixed(568.0 - 24.0 - 24.0 - 48.0, hght))))
+	snackText = textForm
 		|> (\f -> MBorderA(0.0, 16.0, 24.0 + 48.0, 24.0, f))
 		|> (\f -> MGroup([f, TFixed(width, 0.0)]))
 		|> (\f -> MGroup([f,


### PR DESCRIPTION
Small changes for card
https://trello.com/c/W4bbtEFb/6063-snack-bar-does-not-show-full-error
PR - just in case, maybe changes will affect something. MWidth style will also applied if style width exceeds real text width. It seems in current version it works the same. 