### PR TITLE
Adding way to use useMobileUI in CCL

### DIFF
--- a/lib/form/adaptivescale.flow
+++ b/lib/form/adaptivescale.flow
@@ -28,8 +28,19 @@ export {
 
 	// Same as AdaptiveScale, but also scales Available down
 	AdaptiveAvailableAndScale(form : Form) -> Form;
+
+	useMobileUI() -> bool;
+	setForceMobileUI(force: bool) -> void;
+}
 	
-	useMobileUI() isUrlParameterTrue("mobileui") && isPhoneScreen();
+forceMobileUI = ref false;
+
+setForceMobileUI(force : bool) -> void {
+	forceMobileUI := force;
+}
+
+useMobileUI() -> bool {
+	(isUrlParameterTrue("mobileui") || ^forceMobileUI) && isPhoneScreen();
 }
 
 isWidthEconomyOn() {


### PR DESCRIPTION
Since smart options were moved to /smartbuilder code, we need a way to set useMobileUI() function to true in CCL when corresponding smart option is set.

goes with: https://github.com/area9innovation/flowapps/pull/807