### PR TITLE
Fixed 'quit' native for cgi

### DIFF
--- a/platforms/qt/qt-backend/CgiSupport.cpp
+++ b/platforms/qt/qt-backend/CgiSupport.cpp
@@ -75,10 +75,12 @@ StackSlot CgiSupport::quit(RUNNER_ARGS)
     RUNNER_PopArgs1(rawcode);
     RUNNER_CheckTag(TInt, rawcode);
 
-    QCoreApplication::exit(rawcode.GetInt());
+	if (!quitPending) {
+		quitPending = true;
+		quitCode = rawcode.GetInt();
+		QCoreApplication::exit(quitCode);
+	}
 
-    quitPending = true;
-    quitCode = rawcode.GetInt();
     RETVOID;
 }
 


### PR DESCRIPTION
This fix is intended to make code like
iter(...., \ -> doQuitOnSomeCondition);
quit(0);
work properly. Now such code always returns 0.