### PR TITLE
Attempt to prevent the loss of Japanese chars in paragraphs

### DIFF
--- a/lib/form/paragraph.flow
+++ b/lib/form/paragraph.flow
@@ -681,7 +681,8 @@ breakTextFragment(
 						PositionAllowBreakAfter() : {
 							toInspectingElementIfNecessary(indexing,
 								indexing + keyPosRelative,
-								makeSpace(getCharAt(text, keyPos),
+								if (getLang() == "ja") Space(Empty())
+								else makeSpace(getCharAt(text, keyPos),
 									style
 								)
 							);
@@ -732,7 +733,8 @@ breakTextFragment(
 						Cons(keyFragment, Cons(makeTextFn(indexing, word), acc));
 						//to make the function tail recursive
 					} else {
-						doNotSkipSymbolDelta = if (posType == PositionCharCat()) 1 else 0;
+						skipCondition = if (getLang() == "ja") posType == PositionAllowBreakAfter() || posType == PositionCharCat() else posType == PositionCharCat();
+						doNotSkipSymbolDelta = if (skipCondition) 1 else 0;
 						word = substring(text, i, keyPos - i + doNotSkipSymbolDelta); //println("word:" + word);
 						^loop1(
 							keyPos + 1, indexing + keyPosRelative + 1,


### PR DESCRIPTION
In some cases, a Japanese character on the end of line is thrown away and not shown. This is caused by previous changes in paragraph rendering.

Not ready for merge, must be tested well, and maybe better solution can be found.