### PR TITLE
Get rid of BytesOutput

### DIFF
--- a/platforms/js/Native.hx
+++ b/platforms/js/Native.hx
@@ -1690,11 +1690,9 @@ class Native {
 	}
 
 	public static function md5(content: String) : String {
-		var b = new StringBuf();
-		var c = string2utf8(content);
-		for (i in c)
-			b.addChar(i);
-		return Md5.encode(b.toString());
+		var bytes = haxe.io.Bytes.ofString(content);
+		var md5Bytes = haxe.crypto.Md5.make(bytes);
+		return md5Bytes.toHex();
 	}
 
 	public static function concurrentAsync(fine : Bool, tasks : Array < Void -> Dynamic >, cb : Array < Dynamic >) : Void {

--- a/platforms/js/Native.hx
+++ b/platforms/js/Native.hx
@@ -407,12 +407,9 @@ class Native {
 		return str.toUpperCase();
 	}
 
-	public static function string2utf8(str : String) : Array<Int> {
-		var a = new Array<Int>();
+	public static function string2utf8(str : String) : Array<Int> {		
 		var bytes = haxe.io.Bytes.ofString(str);
-		for (i in 0...bytes.length) {
-			a.push(bytes.get(i));
-		}
+		var a : Array<Int> = [for (i in 0...bytes.length) bytes.get(i)];
 		return a;
 	}
 

--- a/platforms/js/Native.hx
+++ b/platforms/js/Native.hx
@@ -409,11 +409,9 @@ class Native {
 
 	public static function string2utf8(str : String) : Array<Int> {
 		var a = new Array<Int>();
-		var buf = new haxe.io.BytesOutput();
-		buf.writeString(str);
-		var bytes = buf.getBytes();
+		var bytes = haxe.io.Bytes.ofString(str);
 		for (i in 0...bytes.length) {
-			a.push((bytes.get(i)));
+			a.push(bytes.get(i));
 		}
 		return a;
 	}


### PR DESCRIPTION
test:

> 	timeit(\ -> {
		s = "Hello World";
		generate(0, 100000, \__ -> {			
			string2utf8(s) |> ignore			
		}) |> ignore
	}) |> println;

shows 98 ms instead of 189 ms in average