### PR TITLE
Haxe js md5 port

### DIFF
--- a/platforms/js/JsMd5.hx
+++ b/platforms/js/JsMd5.hx
@@ -1,0 +1,291 @@
+/*
+ * Copyright (C)2005-2017 Haxe Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+package haxe.crypto;
+
+/**
+	Creates a MD5 of a String.
+**/
+class Md5 {
+
+	public static function encode( s : String ) : String {
+		#if neko
+			return untyped new String(base_encode(make_md5(s.__s),"0123456789abcdef".__s));
+		#elseif php
+			return untyped __call__("md5", s);
+		#else
+			var m = new Md5();
+			var h = m.doEncode(str2blks(s));
+			return m.hex(h);
+		#end
+	}
+
+	public static function make( b : haxe.io.Bytes ) : haxe.io.Bytes {
+		#if neko
+			return haxe.io.Bytes.ofData(make_md5(b.getData()));
+		#elseif php
+			return haxe.io.Bytes.ofData( haxe.io.BytesData.ofString(untyped __call__("md5", b.getData().toString(), true)));
+		#else
+			var h = new Md5().doEncode(bytes2blks(b));
+			var out = haxe.io.Bytes.alloc(16);
+			var p = 0;
+			for( i in 0...4 ) {
+				out.set(p++,h[i]&0xFF);
+				out.set(p++,(h[i]>>8)&0xFF);
+				out.set(p++,(h[i]>>16)&0xFF);
+				out.set(p++,h[i]>>>24);
+			}
+			return out;
+		#end
+	}
+
+	#if neko
+	static var base_encode = neko.Lib.load("std","base_encode",2);
+	static var make_md5 = neko.Lib.load("std","make_md5",1);
+	#elseif !php
+
+/*
+ * A JavaScript implementation of the RSA Data Security, Inc. MD5 Message
+ * Digest Algorithm, as defined in RFC 1321.
+ * Copyright (C) Paul Johnston 1999 - 2000.
+ * Updated by Greg Holt 2000 - 2001.
+ * See http://pajhome.org.uk/site/legal.html for details.
+ */
+
+	function new() {
+	}
+
+	function bitOR(a, b){
+		var lsb = (a & 0x1) | (b & 0x1);
+		var msb31 = (a >>> 1) | (b >>> 1);
+		return (msb31 << 1) | lsb;
+	}
+
+	function bitXOR(a, b){
+		var lsb = (a & 0x1) ^ (b & 0x1);
+		var msb31 = (a >>> 1) ^ (b >>> 1);
+		return (msb31 << 1) | lsb;
+	}
+
+	function bitAND(a, b){
+		var lsb = (a & 0x1) & (b & 0x1);
+		var msb31 = (a >>> 1) & (b >>> 1);
+		return (msb31 << 1) | lsb;
+	}
+
+	function addme(x, y) {
+		var lsw = (x & 0xFFFF)+(y & 0xFFFF);
+		var msw = (x >> 16)+(y >> 16)+(lsw >> 16);
+		return (msw << 16) | (lsw & 0xFFFF);
+	}
+
+	function hex( a : Array<Int> ){
+		var str = "";
+		var hex_chr = "0123456789abcdef";
+		for( num in a )
+			for( j in 0...4 )
+				str += hex_chr.charAt((num >> (j * 8 + 4)) & 0x0F) +
+							 hex_chr.charAt((num >> (j * 8)) & 0x0F);
+		return str;
+	}
+
+	static function bytes2blks( b : haxe.io.Bytes ){
+		var nblk = ((b.length + 8) >> 6) + 1;
+		var blks = new Array();
+
+		//preallocate size
+		var blksSize = nblk * 16;
+		#if (neko || cs || cpp || java || hl)
+		blks[blksSize - 1] = 0;
+		#end
+
+		#if !(cpp || cs || hl) //C++ and C# will already initialize them with zeroes.
+		for( i in 0...blksSize ) blks[i] = 0;
+		#end
+
+		var i = 0;
+		while( i < b.length ) {
+			blks[i >> 2] |= b.get(i) << ((((b.length << 3) + i) & 3) << 3);
+			i++;
+		}
+		blks[i >> 2] |= 0x80 << (((b.length * 8 + i) % 4) * 8);
+		var l = b.length * 8;
+		var k = nblk * 16 - 2;
+		blks[k] = (l & 0xFF);
+		blks[k] |= ((l >>> 8) & 0xFF) << 8;
+		blks[k] |= ((l >>> 16) & 0xFF) << 16;
+		blks[k] |= ((l >>> 24) & 0xFF) << 24;
+		return blks;
+	}
+
+	static function str2blks( str : String ){
+#if !(neko || cpp || php)
+		var str = haxe.io.Bytes.ofString(str);
+#end
+		var nblk = ((str.length + 8) >> 6) + 1;
+		var blks = new Array();
+
+		//preallocate size
+		var blksSize = nblk * 16;
+		#if (neko || cs || cpp || java || hl)
+		blks[blksSize - 1] = 0;
+		#end
+
+		#if !(cpp || cs || hl) //C++ and C# will already initialize them with zeroes.
+		for( i in 0...blksSize ) blks[i] = 0;
+		#end
+
+		var i = 0;
+		var max = str.length;
+		var l = max * 8;
+		while( i < max ) {
+			blks[i >> 2] |= #if !(neko || cpp || php) str.get(i) #else StringTools.fastCodeAt(str, i) #end << (((l + i) % 4) * 8);
+			i++;
+		}
+		blks[i >> 2] |= 0x80 << (((l + i) % 4) * 8);
+		var k = nblk * 16 - 2;
+		blks[k] = (l & 0xFF);
+		blks[k] |= ((l >>> 8) & 0xFF) << 8;
+		blks[k] |= ((l >>> 16) & 0xFF) << 16;
+		blks[k] |= ((l >>> 24) & 0xFF) << 24;
+		return blks;
+	}
+
+	function rol(num, cnt){
+		return (num << cnt) | (num >>> (32 - cnt));
+	}
+
+	function cmn(q, a, b, x, s, t){
+		return addme(rol((addme(addme(a, q), addme(x, t))), s), b);
+	}
+
+	function ff(a, b, c, d, x, s, t){
+		return cmn(bitOR(bitAND(b, c), bitAND((~b), d)), a, b, x, s, t);
+	}
+
+	function gg(a, b, c, d, x, s, t){
+		return cmn(bitOR(bitAND(b, d), bitAND(c, (~d))), a, b, x, s, t);
+	}
+
+	function hh(a, b, c, d, x, s, t){
+		return cmn(bitXOR(bitXOR(b, c), d), a, b, x, s, t);
+	}
+
+	function ii(a, b, c, d, x, s, t){
+		return cmn(bitXOR(c, bitOR(b, (~d))), a, b, x, s, t);
+	}
+
+	function doEncode( x : Array<Int> ) : Array<Int> {
+
+		var a =  1732584193;
+		var b = -271733879;
+		var c = -1732584194;
+		var d =  271733878;
+
+		var step;
+
+		var i = 0;
+		while( i < x.length )  {
+			var olda = a;
+			var oldb = b;
+			var oldc = c;
+			var oldd = d;
+
+			step = 0;
+			a = ff(a, b, c, d, x[i+ 0], 7 , -680876936);
+			d = ff(d, a, b, c, x[i+ 1], 12, -389564586);
+			c = ff(c, d, a, b, x[i+ 2], 17,  606105819);
+			b = ff(b, c, d, a, x[i+ 3], 22, -1044525330);
+			a = ff(a, b, c, d, x[i+ 4], 7 , -176418897);
+			d = ff(d, a, b, c, x[i+ 5], 12,  1200080426);
+			c = ff(c, d, a, b, x[i+ 6], 17, -1473231341);
+			b = ff(b, c, d, a, x[i+ 7], 22, -45705983);
+			a = ff(a, b, c, d, x[i+ 8], 7 ,  1770035416);
+			d = ff(d, a, b, c, x[i+ 9], 12, -1958414417);
+			c = ff(c, d, a, b, x[i+10], 17, -42063);
+			b = ff(b, c, d, a, x[i+11], 22, -1990404162);
+			a = ff(a, b, c, d, x[i+12], 7 ,  1804603682);
+			d = ff(d, a, b, c, x[i+13], 12, -40341101);
+			c = ff(c, d, a, b, x[i+14], 17, -1502002290);
+			b = ff(b, c, d, a, x[i+15], 22,  1236535329);
+			a = gg(a, b, c, d, x[i+ 1], 5 , -165796510);
+			d = gg(d, a, b, c, x[i+ 6], 9 , -1069501632);
+			c = gg(c, d, a, b, x[i+11], 14,  643717713);
+			b = gg(b, c, d, a, x[i+ 0], 20, -373897302);
+			a = gg(a, b, c, d, x[i+ 5], 5 , -701558691);
+			d = gg(d, a, b, c, x[i+10], 9 ,  38016083);
+			c = gg(c, d, a, b, x[i+15], 14, -660478335);
+			b = gg(b, c, d, a, x[i+ 4], 20, -405537848);
+			a = gg(a, b, c, d, x[i+ 9], 5 ,  568446438);
+			d = gg(d, a, b, c, x[i+14], 9 , -1019803690);
+			c = gg(c, d, a, b, x[i+ 3], 14, -187363961);
+			b = gg(b, c, d, a, x[i+ 8], 20,  1163531501);
+			a = gg(a, b, c, d, x[i+13], 5 , -1444681467);
+			d = gg(d, a, b, c, x[i+ 2], 9 , -51403784);
+			c = gg(c, d, a, b, x[i+ 7], 14,  1735328473);
+			b = gg(b, c, d, a, x[i+12], 20, -1926607734);
+			a = hh(a, b, c, d, x[i+ 5], 4 , -378558);
+			d = hh(d, a, b, c, x[i+ 8], 11, -2022574463);
+			c = hh(c, d, a, b, x[i+11], 16,  1839030562);
+			b = hh(b, c, d, a, x[i+14], 23, -35309556);
+			a = hh(a, b, c, d, x[i+ 1], 4 , -1530992060);
+			d = hh(d, a, b, c, x[i+ 4], 11,  1272893353);
+			c = hh(c, d, a, b, x[i+ 7], 16, -155497632);
+			b = hh(b, c, d, a, x[i+10], 23, -1094730640);
+			a = hh(a, b, c, d, x[i+13], 4 ,  681279174);
+			d = hh(d, a, b, c, x[i+ 0], 11, -358537222);
+			c = hh(c, d, a, b, x[i+ 3], 16, -722521979);
+			b = hh(b, c, d, a, x[i+ 6], 23,  76029189);
+			a = hh(a, b, c, d, x[i+ 9], 4 , -640364487);
+			d = hh(d, a, b, c, x[i+12], 11, -421815835);
+			c = hh(c, d, a, b, x[i+15], 16,  530742520);
+			b = hh(b, c, d, a, x[i+ 2], 23, -995338651);
+			a = ii(a, b, c, d, x[i+ 0], 6 , -198630844);
+			d = ii(d, a, b, c, x[i+ 7], 10,  1126891415);
+			c = ii(c, d, a, b, x[i+14], 15, -1416354905);
+			b = ii(b, c, d, a, x[i+ 5], 21, -57434055);
+			a = ii(a, b, c, d, x[i+12], 6 ,  1700485571);
+			d = ii(d, a, b, c, x[i+ 3], 10, -1894986606);
+			c = ii(c, d, a, b, x[i+10], 15, -1051523);
+			b = ii(b, c, d, a, x[i+ 1], 21, -2054922799);
+			a = ii(a, b, c, d, x[i+ 8], 6 ,  1873313359);
+			d = ii(d, a, b, c, x[i+15], 10, -30611744);
+			c = ii(c, d, a, b, x[i+ 6], 15, -1560198380);
+			b = ii(b, c, d, a, x[i+13], 21,  1309151649);
+			a = ii(a, b, c, d, x[i+ 4], 6 , -145523070);
+			d = ii(d, a, b, c, x[i+11], 10, -1120210379);
+			c = ii(c, d, a, b, x[i+ 2], 15,  718787259);
+			b = ii(b, c, d, a, x[i+ 9], 21, -343485551);
+
+			a = addme(a, olda);
+			b = addme(b, oldb);
+			c = addme(c, oldc);
+			d = addme(d, oldd);
+
+			i += 16;
+		}
+		return [a,b,c,d];
+	}
+
+	#end
+
+
+}

--- a/platforms/js/JsMd5.hx
+++ b/platforms/js/JsMd5.hx
@@ -19,48 +19,16 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
  * DEALINGS IN THE SOFTWARE.
  */
-package haxe.crypto;
-
+import haxe.ds.Vector;
 /**
 	Creates a MD5 of a String.
 **/
-class Md5 {
-
-	public static function encode( s : String ) : String {
-		#if neko
-			return untyped new String(base_encode(make_md5(s.__s),"0123456789abcdef".__s));
-		#elseif php
-			return untyped __call__("md5", s);
-		#else
-			var m = new Md5();
-			var h = m.doEncode(str2blks(s));
-			return m.hex(h);
-		#end
+class JsMd5 {
+	public static function encode(s : String) : String {
+		var m = new JsMd5();
+		var h = m.doEncode(str2blks(s));
+		return m.hex(h);
 	}
-
-	public static function make( b : haxe.io.Bytes ) : haxe.io.Bytes {
-		#if neko
-			return haxe.io.Bytes.ofData(make_md5(b.getData()));
-		#elseif php
-			return haxe.io.Bytes.ofData( haxe.io.BytesData.ofString(untyped __call__("md5", b.getData().toString(), true)));
-		#else
-			var h = new Md5().doEncode(bytes2blks(b));
-			var out = haxe.io.Bytes.alloc(16);
-			var p = 0;
-			for( i in 0...4 ) {
-				out.set(p++,h[i]&0xFF);
-				out.set(p++,(h[i]>>8)&0xFF);
-				out.set(p++,(h[i]>>16)&0xFF);
-				out.set(p++,h[i]>>>24);
-			}
-			return out;
-		#end
-	}
-
-	#if neko
-	static var base_encode = neko.Lib.load("std","base_encode",2);
-	static var make_md5 = neko.Lib.load("std","make_md5",1);
-	#elseif !php
 
 /*
  * A JavaScript implementation of the RSA Data Security, Inc. MD5 Message
@@ -73,19 +41,19 @@ class Md5 {
 	function new() {
 	}
 
-	function bitOR(a, b){
+	function bitOR(a, b) {
 		var lsb = (a & 0x1) | (b & 0x1);
 		var msb31 = (a >>> 1) | (b >>> 1);
 		return (msb31 << 1) | lsb;
 	}
 
-	function bitXOR(a, b){
+	function bitXOR(a, b) {
 		var lsb = (a & 0x1) ^ (b & 0x1);
 		var msb31 = (a >>> 1) ^ (b >>> 1);
 		return (msb31 << 1) | lsb;
 	}
 
-	function bitAND(a, b){
+	function bitAND(a, b) {
 		var lsb = (a & 0x1) & (b & 0x1);
 		var msb31 = (a >>> 1) & (b >>> 1);
 		return (msb31 << 1) | lsb;
@@ -97,7 +65,7 @@ class Md5 {
 		return (msw << 16) | (lsw & 0xFFFF);
 	}
 
-	function hex( a : Array<Int> ){
+	function hex(a : Array<Int>) {
 		var str = "";
 		var hex_chr = "0123456789abcdef";
 		for( num in a )
@@ -107,93 +75,110 @@ class Md5 {
 		return str;
 	}
 
-	static function bytes2blks( b : haxe.io.Bytes ){
-		var nblk = ((b.length + 8) >> 6) + 1;
-		var blks = new Array();
-
-		//preallocate size
-		var blksSize = nblk * 16;
-		#if (neko || cs || cpp || java || hl)
-		blks[blksSize - 1] = 0;
-		#end
-
-		#if !(cpp || cs || hl) //C++ and C# will already initialize them with zeroes.
-		for( i in 0...blksSize ) blks[i] = 0;
-		#end
-
+	static function str2blks(s : String) : Vector<Int> {
+		// utf16-decode and utf8-encode
 		var i = 0;
-		while( i < b.length ) {
-			blks[i >> 2] |= b.get(i) << ((((b.length << 3) + i) & 3) << 3);
-			i++;
+		var count = 0;
+		
+		// Compute number of bytes first
+		while (i < s.length) {
+			var c : Int = StringTools.fastCodeAt(s, i++);
+			// surrogate pair
+			if (0xD800 <= c && c <= 0xDBFF) {
+				c = (c - 0xD7C0 << 10) | (StringTools.fastCodeAt(s, i++) & 0x3FF);
+			}
+			if (c <= 0x7F) {
+				count++;
+			} else if (c <= 0x7FF) {
+				count += 2;
+			} else if (c <= 0xFFFF) {
+				count += 3;
+			} else {
+				count += 4;
+			}
 		}
-		blks[i >> 2] |= 0x80 << (((b.length * 8 + i) % 4) * 8);
-		var l = b.length * 8;
-		var k = nblk * 16 - 2;
-		blks[k] = (l & 0xFF);
-		blks[k] |= ((l >>> 8) & 0xFF) << 8;
-		blks[k] |= ((l >>> 16) & 0xFF) << 16;
-		blks[k] |= ((l >>> 24) & 0xFF) << 24;
-		return blks;
+		// Allocate array of required length
+		var a = new Vector<Int>(count);
+		i = 0;
+		count = 0;
+		// Fill array with bytes
+		while (i < s.length) {
+			var c : Int = StringTools.fastCodeAt(s, i++);
+			// surrogate pair
+			if (0xD800 <= c && c <= 0xDBFF ) {
+				c = (c - 0xD7C0 << 10) | (StringTools.fastCodeAt(s, i++) & 0x3FF);
+			}
+			if (c <= 0x7F) {
+				a[count++] = c;
+			} else if (c <= 0x7FF) {
+				a[count++] = 0xC0 | (c >> 6);
+				a[count++] = 0x80 | (c & 63);
+			} else if (c <= 0xFFFF) {
+				a[count++] = 0xE0 | (c >> 12);
+				a[count++] = 0x80 | ((c >> 6) & 63);
+				a[count++] = 0x80 | (c & 63);
+			} else {
+				a[count++] = 0xF0 | (c >> 18);
+				a[count++] = 0x80 | ((c >> 12) & 63);
+				a[count++] = 0x80 | ((c >> 6) & 63);
+				a[count++] = 0x80 | (c & 63);
+			}
+		}
+		return a;
 	}
 
-	static function str2blks( str : String ){
-#if !(neko || cpp || php)
-		var str = haxe.io.Bytes.ofString(str);
-#end
-		var nblk = ((str.length + 8) >> 6) + 1;
-		var blks = new Array();
-
-		//preallocate size
-		var blksSize = nblk * 16;
-		#if (neko || cs || cpp || java || hl)
-		blks[blksSize - 1] = 0;
-		#end
-
-		#if !(cpp || cs || hl) //C++ and C# will already initialize them with zeroes.
-		for( i in 0...blksSize ) blks[i] = 0;
-		#end
-
-		var i = 0;
-		var max = str.length;
-		var l = max * 8;
-		while( i < max ) {
-			blks[i >> 2] |= #if !(neko || cpp || php) str.get(i) #else StringTools.fastCodeAt(str, i) #end << (((l + i) % 4) * 8);
-			i++;
-		}
-		blks[i >> 2] |= 0x80 << (((l + i) % 4) * 8);
-		var k = nblk * 16 - 2;
-		blks[k] = (l & 0xFF);
-		blks[k] |= ((l >>> 8) & 0xFF) << 8;
-		blks[k] |= ((l >>> 16) & 0xFF) << 16;
-		blks[k] |= ((l >>> 24) & 0xFF) << 24;
-		return blks;
-	}
-
-	function rol(num, cnt){
+	function rol(num, cnt) {
 		return (num << cnt) | (num >>> (32 - cnt));
 	}
 
-	function cmn(q, a, b, x, s, t){
+	function cmn(q, a, b, x, s, t) {
 		return addme(rol((addme(addme(a, q), addme(x, t))), s), b);
 	}
 
-	function ff(a, b, c, d, x, s, t){
+	function ff(a, b, c, d, x, s, t) {
 		return cmn(bitOR(bitAND(b, c), bitAND((~b), d)), a, b, x, s, t);
 	}
 
-	function gg(a, b, c, d, x, s, t){
+	function gg(a, b, c, d, x, s, t) {
 		return cmn(bitOR(bitAND(b, d), bitAND(c, (~d))), a, b, x, s, t);
 	}
 
-	function hh(a, b, c, d, x, s, t){
+	function hh(a, b, c, d, x, s, t) {
 		return cmn(bitXOR(bitXOR(b, c), d), a, b, x, s, t);
 	}
 
-	function ii(a, b, c, d, x, s, t){
+	function ii(a, b, c, d, x, s, t) {
 		return cmn(bitXOR(c, bitOR(b, (~d))), a, b, x, s, t);
 	}
 
-	function doEncode( x : Array<Int> ) : Array<Int> {
+	function setBlockData(b : Vector<Int>, x : Vector<Int>, blockNumber : Int, numberOfBlocks : Int) : Void {
+		var i = 0;
+		var byteOffset = blockNumber << 6;
+
+		var getByte = function (idx) {
+			if (idx < b.length) {
+				return b.get(idx);
+			} else if (idx == b.length) {
+				return 0x80;
+			} else {
+				return 0;
+			}
+		};
+
+		for (i in 0...16) {
+			if ((blockNumber + 1) == numberOfBlocks && i == 14) {
+				x[i] = b.length << 3;
+			} else {
+				x[i] = getByte(byteOffset) 
+					| (getByte(byteOffset + 1) << 8)
+					| (getByte(byteOffset + 2) << 16)
+					| (getByte(byteOffset + 3) << 24);
+			}
+			byteOffset += 4;
+		}
+	}
+
+	function doEncode(bytes : Vector<Int>) : Array<Int> {
 
 		var a =  1732584193;
 		var b = -271733879;
@@ -202,90 +187,91 @@ class Md5 {
 
 		var step;
 
-		var i = 0;
-		while( i < x.length )  {
+		var numberOfBlocks = ((bytes.length + 8) >> 6) + 1;
+		var x = new Vector<Int>(16);
+
+		var blockNumber = 0;
+		while (blockNumber < numberOfBlocks)  {
 			var olda = a;
 			var oldb = b;
 			var oldc = c;
 			var oldd = d;
 
+			setBlockData(bytes, x, blockNumber, numberOfBlocks);
+
 			step = 0;
-			a = ff(a, b, c, d, x[i+ 0], 7 , -680876936);
-			d = ff(d, a, b, c, x[i+ 1], 12, -389564586);
-			c = ff(c, d, a, b, x[i+ 2], 17,  606105819);
-			b = ff(b, c, d, a, x[i+ 3], 22, -1044525330);
-			a = ff(a, b, c, d, x[i+ 4], 7 , -176418897);
-			d = ff(d, a, b, c, x[i+ 5], 12,  1200080426);
-			c = ff(c, d, a, b, x[i+ 6], 17, -1473231341);
-			b = ff(b, c, d, a, x[i+ 7], 22, -45705983);
-			a = ff(a, b, c, d, x[i+ 8], 7 ,  1770035416);
-			d = ff(d, a, b, c, x[i+ 9], 12, -1958414417);
-			c = ff(c, d, a, b, x[i+10], 17, -42063);
-			b = ff(b, c, d, a, x[i+11], 22, -1990404162);
-			a = ff(a, b, c, d, x[i+12], 7 ,  1804603682);
-			d = ff(d, a, b, c, x[i+13], 12, -40341101);
-			c = ff(c, d, a, b, x[i+14], 17, -1502002290);
-			b = ff(b, c, d, a, x[i+15], 22,  1236535329);
-			a = gg(a, b, c, d, x[i+ 1], 5 , -165796510);
-			d = gg(d, a, b, c, x[i+ 6], 9 , -1069501632);
-			c = gg(c, d, a, b, x[i+11], 14,  643717713);
-			b = gg(b, c, d, a, x[i+ 0], 20, -373897302);
-			a = gg(a, b, c, d, x[i+ 5], 5 , -701558691);
-			d = gg(d, a, b, c, x[i+10], 9 ,  38016083);
-			c = gg(c, d, a, b, x[i+15], 14, -660478335);
-			b = gg(b, c, d, a, x[i+ 4], 20, -405537848);
-			a = gg(a, b, c, d, x[i+ 9], 5 ,  568446438);
-			d = gg(d, a, b, c, x[i+14], 9 , -1019803690);
-			c = gg(c, d, a, b, x[i+ 3], 14, -187363961);
-			b = gg(b, c, d, a, x[i+ 8], 20,  1163531501);
-			a = gg(a, b, c, d, x[i+13], 5 , -1444681467);
-			d = gg(d, a, b, c, x[i+ 2], 9 , -51403784);
-			c = gg(c, d, a, b, x[i+ 7], 14,  1735328473);
-			b = gg(b, c, d, a, x[i+12], 20, -1926607734);
-			a = hh(a, b, c, d, x[i+ 5], 4 , -378558);
-			d = hh(d, a, b, c, x[i+ 8], 11, -2022574463);
-			c = hh(c, d, a, b, x[i+11], 16,  1839030562);
-			b = hh(b, c, d, a, x[i+14], 23, -35309556);
-			a = hh(a, b, c, d, x[i+ 1], 4 , -1530992060);
-			d = hh(d, a, b, c, x[i+ 4], 11,  1272893353);
-			c = hh(c, d, a, b, x[i+ 7], 16, -155497632);
-			b = hh(b, c, d, a, x[i+10], 23, -1094730640);
-			a = hh(a, b, c, d, x[i+13], 4 ,  681279174);
-			d = hh(d, a, b, c, x[i+ 0], 11, -358537222);
-			c = hh(c, d, a, b, x[i+ 3], 16, -722521979);
-			b = hh(b, c, d, a, x[i+ 6], 23,  76029189);
-			a = hh(a, b, c, d, x[i+ 9], 4 , -640364487);
-			d = hh(d, a, b, c, x[i+12], 11, -421815835);
-			c = hh(c, d, a, b, x[i+15], 16,  530742520);
-			b = hh(b, c, d, a, x[i+ 2], 23, -995338651);
-			a = ii(a, b, c, d, x[i+ 0], 6 , -198630844);
-			d = ii(d, a, b, c, x[i+ 7], 10,  1126891415);
-			c = ii(c, d, a, b, x[i+14], 15, -1416354905);
-			b = ii(b, c, d, a, x[i+ 5], 21, -57434055);
-			a = ii(a, b, c, d, x[i+12], 6 ,  1700485571);
-			d = ii(d, a, b, c, x[i+ 3], 10, -1894986606);
-			c = ii(c, d, a, b, x[i+10], 15, -1051523);
-			b = ii(b, c, d, a, x[i+ 1], 21, -2054922799);
-			a = ii(a, b, c, d, x[i+ 8], 6 ,  1873313359);
-			d = ii(d, a, b, c, x[i+15], 10, -30611744);
-			c = ii(c, d, a, b, x[i+ 6], 15, -1560198380);
-			b = ii(b, c, d, a, x[i+13], 21,  1309151649);
-			a = ii(a, b, c, d, x[i+ 4], 6 , -145523070);
-			d = ii(d, a, b, c, x[i+11], 10, -1120210379);
-			c = ii(c, d, a, b, x[i+ 2], 15,  718787259);
-			b = ii(b, c, d, a, x[i+ 9], 21, -343485551);
+			a = ff(a, b, c, d, x[0], 7 , -680876936);
+			d = ff(d, a, b, c, x[1], 12, -389564586);
+			c = ff(c, d, a, b, x[2], 17,  606105819);
+			b = ff(b, c, d, a, x[3], 22, -1044525330);
+			a = ff(a, b, c, d, x[4], 7 , -176418897);
+			d = ff(d, a, b, c, x[5], 12,  1200080426);
+			c = ff(c, d, a, b, x[6], 17, -1473231341);
+			b = ff(b, c, d, a, x[7], 22, -45705983);
+			a = ff(a, b, c, d, x[8], 7 ,  1770035416);
+			d = ff(d, a, b, c, x[9], 12, -1958414417);
+			c = ff(c, d, a, b, x[10], 17, -42063);
+			b = ff(b, c, d, a, x[11], 22, -1990404162);
+			a = ff(a, b, c, d, x[12], 7 ,  1804603682);
+			d = ff(d, a, b, c, x[13], 12, -40341101);
+			c = ff(c, d, a, b, x[14], 17, -1502002290);
+			b = ff(b, c, d, a, x[15], 22,  1236535329);
+			a = gg(a, b, c, d, x[1], 5 , -165796510);
+			d = gg(d, a, b, c, x[6], 9 , -1069501632);
+			c = gg(c, d, a, b, x[11], 14,  643717713);
+			b = gg(b, c, d, a, x[0], 20, -373897302);
+			a = gg(a, b, c, d, x[5], 5 , -701558691);
+			d = gg(d, a, b, c, x[10], 9 ,  38016083);
+			c = gg(c, d, a, b, x[15], 14, -660478335);
+			b = gg(b, c, d, a, x[4], 20, -405537848);
+			a = gg(a, b, c, d, x[9], 5 ,  568446438);
+			d = gg(d, a, b, c, x[14], 9 , -1019803690);
+			c = gg(c, d, a, b, x[3], 14, -187363961);
+			b = gg(b, c, d, a, x[8], 20,  1163531501);
+			a = gg(a, b, c, d, x[13], 5 , -1444681467);
+			d = gg(d, a, b, c, x[2], 9 , -51403784);
+			c = gg(c, d, a, b, x[7], 14,  1735328473);
+			b = gg(b, c, d, a, x[12], 20, -1926607734);
+			a = hh(a, b, c, d, x[5], 4 , -378558);
+			d = hh(d, a, b, c, x[8], 11, -2022574463);
+			c = hh(c, d, a, b, x[11], 16,  1839030562);
+			b = hh(b, c, d, a, x[14], 23, -35309556);
+			a = hh(a, b, c, d, x[1], 4 , -1530992060);
+			d = hh(d, a, b, c, x[4], 11,  1272893353);
+			c = hh(c, d, a, b, x[7], 16, -155497632);
+			b = hh(b, c, d, a, x[10], 23, -1094730640);
+			a = hh(a, b, c, d, x[13], 4 ,  681279174);
+			d = hh(d, a, b, c, x[0], 11, -358537222);
+			c = hh(c, d, a, b, x[3], 16, -722521979);
+			b = hh(b, c, d, a, x[6], 23,  76029189);
+			a = hh(a, b, c, d, x[9], 4 , -640364487);
+			d = hh(d, a, b, c, x[12], 11, -421815835);
+			c = hh(c, d, a, b, x[15], 16,  530742520);
+			b = hh(b, c, d, a, x[2], 23, -995338651);
+			a = ii(a, b, c, d, x[0], 6 , -198630844);
+			d = ii(d, a, b, c, x[7], 10,  1126891415);
+			c = ii(c, d, a, b, x[14], 15, -1416354905);
+			b = ii(b, c, d, a, x[5], 21, -57434055);
+			a = ii(a, b, c, d, x[12], 6 ,  1700485571);
+			d = ii(d, a, b, c, x[3], 10, -1894986606);
+			c = ii(c, d, a, b, x[10], 15, -1051523);
+			b = ii(b, c, d, a, x[1], 21, -2054922799);
+			a = ii(a, b, c, d, x[8], 6 ,  1873313359);
+			d = ii(d, a, b, c, x[15], 10, -30611744);
+			c = ii(c, d, a, b, x[6], 15, -1560198380);
+			b = ii(b, c, d, a, x[13], 21,  1309151649);
+			a = ii(a, b, c, d, x[4], 6 , -145523070);
+			d = ii(d, a, b, c, x[11], 10, -1120210379);
+			c = ii(c, d, a, b, x[2], 15,  718787259);
+			b = ii(b, c, d, a, x[9], 21, -343485551);
 
 			a = addme(a, olda);
 			b = addme(b, oldb);
 			c = addme(c, oldc);
 			d = addme(d, oldd);
 
-			i += 16;
+			blockNumber++;
 		}
 		return [a,b,c,d];
 	}
-
-	#end
-
-
 }

--- a/platforms/js/Native.hx
+++ b/platforms/js/Native.hx
@@ -7,6 +7,7 @@ import haxe.CallStack;
 import js.Browser;
 import js.BinaryParser;
 import JSBinflowBuffer;
+import JsMd5;
 #end
 
 #if (flow_nodejs || nwjs)
@@ -1689,10 +1690,8 @@ class Native {
 		return function() { };
 	}
 
-	public static function md5(content: String) : String {
-		var bytes = haxe.io.Bytes.ofString(content);
-		var md5Bytes = haxe.crypto.Md5.make(bytes);
-		return md5Bytes.toHex();
+	public static function md5(content : String) : String {
+		return JsMd5.encode(content);
 	}
 
 	public static function concurrentAsync(fine : Bool, tasks : Array < Void -> Dynamic >, cb : Array < Dynamic >) : Void {


### PR DESCRIPTION
Removed haxe.io.Bytes.ofString because it was using Array without predefined size.
Encoding conversion code in JsMd5 is based on this part https://github.com/HaxeFoundation/haxe/blob/3.4.7/std/haxe/io/Bytes.hx#L523-L547
Which is haxe.io.Bytes.ofString.
And removed blocks array allocation from MD5 implementation. We don't need more than 64 bytes at a time for a single round - so no need to precompute all of them.
I didn't benchmark old and new implementation yet in terms of speed. But version from this pr doesn't produce extra memory overhead. And this was our original issue.

