### PR TITLE
Implement serializing KeyValues for use in URLs

### DIFF
--- a/lib/net/http_request_util.flow
+++ b/lib/net/http_request_util.flow
@@ -66,6 +66,31 @@ export {
 	filterRequestRecordHeaders(headers : [KeyValue]) -> [KeyValue];
 
 	filterRequestRecordParams(params : [KeyValue]) -> [KeyValue];
+
+	/** Converts a list of KeyValue pairs to application/x-www-form-urlencoded.
+	 *
+	 * If in any of KeyValue pairs the key or the value is an empty string,
+	 * that pair will not be included in the resulting string.
+	 */
+	serializeRequestParameters(params : [KeyValue]) -> string;
+
+	/** Creates a URL query string, e.g. "?k1=v1&k2=v2".
+	 *
+	 * If in any of KeyValue pairs the key or the value is an empty string,
+	 * that pair will not be included in the resulting string.
+	 *
+	 * If a resulting query string is empty, the question mark is not added.
+	 */
+	urlQuery(params : [KeyValue]) -> string;
+
+	/** Creates a URL fragment string, e.g. "#k1=v1&k2=v2".
+	 *
+	 * If in any of KeyValue pairs the key or the value is an empty string,
+	 * that pair will not be included in the resulting string.
+	 *
+	 * If a resulting fragment string is empty, the hash sign is not added.
+	 */
+	urlFragment(params : [KeyValue]) -> string;
 }
 
 httpRequestHandleRules : ref Maybe<[ HttpRequestRecordHandleRule ]> = ref None();
@@ -328,4 +353,23 @@ getHttpRequestHandleRules() -> [ HttpRequestRecordHandleRule ] {
 
 isHttpRequestHandleRulesSet() -> bool {
 	isSome(^httpRequestHandleRules)
+}
+
+serializeRequestParameters(params : [KeyValue]) -> string {
+	serializeKeyValue : ((KeyValue) -> Maybe<string>) = \kv ->
+		if (kv.key == "" || kv.value == "")
+			None()
+		else
+			Some(kv.key + "=" + urlEncode(kv.value));
+	strGlue(filtermap(params, serializeKeyValue), "&");
+}
+
+urlQuery(params : [KeyValue]) -> string {
+	serializedParams = serializeRequestParameters(params);
+	if (serializedParams == "") "" else "?" + serializedParams;
+}
+
+urlFragment(params : [KeyValue]) -> string {
+	serializedParams = serializeRequestParameters(params);
+	if (serializedParams == "") "" else "#" + serializedParams;
 }


### PR DESCRIPTION
Required for Trello card:
https://trello.com/c/3mBgptzZ/6437-invalid-link-url-in-invitation-emails

Add functions that convert a list of `KeyValue`s to a string in format
`application/x-www-form-urlencoded`