### PR TITLE
Add utf8Decode to support Arabic language

### DIFF
--- a/lib/formats/base64.flow
+++ b/lib/formats/base64.flow
@@ -145,9 +145,9 @@ encodeBase64(binary : string) -> string {
 }
 
 expandUtf8(s : string) -> string {
-  bytes = string2utf8(s);
-  chars = map(bytes, fromCharCode);
-  concatStrings(chars);
+	bytes = string2utf8(s);
+	chars = map(bytes, fromCharCode);
+	concatStrings(chars);
 }
 
 /*

--- a/lib/formats/html/html.flow
+++ b/lib/formats/html/html.flow
@@ -555,7 +555,7 @@ utf8DecodeBytes(s : string, extractor : (string) -> Pair<int, string>) -> Pair<i
 		} else if (hexcode <= 0xF7) { // 4 bytes
 			secondByte = extractor(pair.second);
 			thirdByte = extractor(secondByte.second);
-			fourthByte = extractor(secondByte.second);
+			fourthByte = extractor(thirdByte.second);
 			if (secondByte.first == -1 || thirdByte.first == -1 || fourthByte.first == -1) {
 				// Crap. We need 4 bytes
 				pair

--- a/lib/formats/html/html.flow
+++ b/lib/formats/html/html.flow
@@ -30,6 +30,10 @@ export {
 	// '+' decodes to ' '; '%2B' decodes to '+'
 	urlDecode2(s : string) -> string;
 
+	// Decodes UTF-8 string
+	utf8Decode(s : string) -> string;
+
+
 	// presents string characters as corresponding htmlentity codes
 	encode2htmlentities (s : string) -> string;
 	// The tree contains characters/symbols with their corresponding htmlentity codes.
@@ -490,67 +494,91 @@ urlEncode(s){
 	|> r("™", "%E2%84%A2")
 }
 
-urlDecode(s) {
+urlDecode(s : string) -> string {
 	urlDecode0("", s)
 }
 
-urlDecode0(acc, s) {
+urlDecode0(acc : string, s : string) -> string {
 	percent = strIndexOf(s, "%");
 	if (percent == -1) {
 		acc + s;
 	} else {
 		left = strLeft(s, percent);
 		right = strRight(s, percent);
-		percentPair = extractPercentHex(right);
-		hexcode = percentPair.first;
-		c = if (hexcode < 0xC0) {
-			percentPair
-		} else {
-			// OK, it must be UTF-8 encoded
-			if (0xC0 <= hexcode && hexcode <= 0xDF) {
-				// 2 bytes
-				secondByte = extractPercentHex(percentPair.second);
-				if (secondByte.first == -1) {
-					// OK, it is some crap, because we expect a second percent here
-					percentPair
-				} else {
-					Pair((hexcode - 192) * 64 + (secondByte.first - 128), secondByte.second)
-				}
-			} else if (hexcode <= 0xEF) { // 3 bytes
-				secondByte = extractPercentHex(percentPair.second);
-				thirdByte = extractPercentHex(secondByte.second);
-				if (secondByte.first == -1 || thirdByte.first == -1) {
-					// OK, it is some crap, because we expect a second and third percent here
-					percentPair
-				} else {
-					Pair((hexcode - 224) * 4096
-						+ (secondByte.first - 128) * 64
-						+ (thirdByte.first - 128),
-						thirdByte.second
-					)
-				}
-			} else if (hexcode <= 0xF7) { // 4 bytes
-				secondByte = extractPercentHex(percentPair.second);
-				thirdByte = extractPercentHex(secondByte.second);
-				fourthByte = extractPercentHex(secondByte.second);
-				if (secondByte.first == -1 || thirdByte.first == -1 || fourthByte.first == -1) {
-					// Crap. We need 4 bytes
-					percentPair
-				} else {
-					Pair((hexcode - 240) * 262144
-						+ (secondByte.first - 128) * 4096
-						+ (thirdByte.first - 128) * 64
-						+ (fourthByte.first - 128),
-						fourthByte.second
-					)
-				}
-			} else {
-				// TODO: We did not implement support for 6 bytes
-				percentPair
-			}
-		};
-
+		c = utf8DecodeBytes(right, extractPercentHex);
 		urlDecode0(acc + left + fromCharCode(c.first), c.second);
+	}
+}
+
+utf8Decode(s : string) -> string {
+	utf8DecodeRecursive("", s)
+}
+
+utf8DecodeRecursive(acc : string, s : string) -> string {
+	if (s == "") {
+		acc 
+	} else {
+		c = utf8DecodeBytes(s, getCharCode);
+		utf8DecodeRecursive(acc + fromCharCode(c.first), c.second)
+	}
+}
+
+utf8DecodeBytes(s : string, extractor : (string) -> Pair<int, string>) -> Pair<int, string> {
+	pair = extractor(s);
+	hexcode = pair.first;
+	if (hexcode < 0xC0) {
+		pair
+	} else {
+		// OK, it must be UTF-8 encoded
+		if (0xC0 <= hexcode && hexcode <= 0xDF) {
+			// 2 bytes
+			secondByte = extractor(pair.second);
+			if (secondByte.first == -1) {
+				// OK, it is some crap, because we expect a second percent here
+				pair
+			} else {
+				Pair((hexcode - 192) * 64 + (secondByte.first - 128), secondByte.second)
+			}
+		} else if (hexcode <= 0xEF) { // 3 bytes
+			secondByte = extractor(pair.second);
+			thirdByte = extractor(secondByte.second);
+			if (secondByte.first == -1 || thirdByte.first == -1) {
+				// OK, it is some crap, because we expect a second and third percent here
+				pair
+			} else {
+				Pair((hexcode - 224) * 4096
+					+ (secondByte.first - 128) * 64
+					+ (thirdByte.first - 128),
+					thirdByte.second
+				)
+			}
+		} else if (hexcode <= 0xF7) { // 4 bytes
+			secondByte = extractor(pair.second);
+			thirdByte = extractor(secondByte.second);
+			fourthByte = extractor(secondByte.second);
+			if (secondByte.first == -1 || thirdByte.first == -1 || fourthByte.first == -1) {
+				// Crap. We need 4 bytes
+				pair
+			} else {
+				Pair((hexcode - 240) * 262144
+					+ (secondByte.first - 128) * 4096
+					+ (thirdByte.first - 128) * 64
+					+ (fourthByte.first - 128),
+					fourthByte.second
+				)
+			}
+		} else {
+			// TODO: We did not implement support for 6 bytes
+			pair
+		}
+	}
+}
+
+getCharCode(s : string) -> Pair<int, string> {
+	if (s == "") {
+		Pair(-1, s)
+	} else {
+		Pair(getCharCodeAt(s, 0), strRight(s, 1))
 	}
 }
 


### PR DESCRIPTION
https://trello.com/c/BCWznbXV/6441-module-filter-is-not-working-on-educator

Added utf8Decode which is based on urlDecode0 but just getCharCodeAt instead of extractPercentHex as Asger suggested, works perfectly.

`
import runtime;
import formats/base64;
import formats/html/html;

main() {
	arabic = "أساسيات مراكز الاتصال";
	// println(arabic);
	expanded = expandUtf8(arabic);
	encoded = encodeBase64(expanded);
	decoded = decodeBase64(encoded);
	result = utf8Decode(decoded);
	println(arabic == result);

	quit(0);
}
`

Prints "true" in the console.