### PR TITLE
add heading before opacity slider in opacity picker

### DIFF
--- a/lib/material/internal/material_pickers.flow
+++ b/lib/material/internal/material_pickers.flow
@@ -2269,7 +2269,7 @@ opacityPickerBody(
 					parent,
 					MSlider(
 						op.opacity,
-						[MSliderDisplayValue(true), MEnabled(enabled), MSliderTooltip(\v -> i2s(round(v*100.)) + "%")]
+						[MSliderDisplayValue(true), MEnabled(enabled)]
 					),
 					m2t
 				)

--- a/lib/material/internal/material_pickers.flow
+++ b/lib/material/internal/material_pickers.flow
@@ -2262,14 +2262,17 @@ opacityPickerBody(
 	eitherMap(
 		opacityPicker,
 		\op ->
-			MSlider2T(
-				manager,
-				parent,
-				MSlider(
-					op.opacity,
-					[MSliderDisplayValue(true), MEnabled(enabled)]
-				),
-				m2t
+			TLines2(
+				TBorder(16., 16., 0., 0., MText2T(parent, "Opacity:", [MBody()])),
+				MSlider2T(
+					manager,
+					parent,
+					MSlider(
+						op.opacity,
+						[MSliderDisplayValue(true), MEnabled(enabled), MSliderTooltip(\v -> i2s(round(v*100.)) + "%")]
+					),
+					m2t
+				)
 			),
 		TEmpty()
 	)

--- a/lib/material/internal/material_pickers.flow
+++ b/lib/material/internal/material_pickers.flow
@@ -2272,7 +2272,7 @@ opacityPickerBody(
 					),
 				],
 				TLines2(
-					TBorder(16., 16., 0., 0., MText2T(parent, "Opacity, %:", [MBody()])),
+					TBorder(16., 16., 0., 0., MText2T(parent, "Opacity %:", [MBody()])),
 					MSlider2T(
 						manager,
 						parent,

--- a/lib/material/internal/material_pickers.flow
+++ b/lib/material/internal/material_pickers.flow
@@ -2261,19 +2261,30 @@ opacityPickerBody(
 
 	eitherMap(
 		opacityPicker,
-		\op ->
-			TLines2(
-				TBorder(16., 16., 0., 0., MText2T(parent, "Opacity:", [MBody()])),
-				MSlider2T(
-					manager,
-					parent,
-					MSlider(
+		\op -> {
+			opacityInPercent = make(getValue(op.opacity) * 100.0);
+			TConstruct([
+					\ -> bidirectionalLink(
 						op.opacity,
-						[MSliderDisplayValue(true), MEnabled(enabled)]
+						opacityInPercent,
+						\v -> v * 100.0,
+						\v -> v / 100.0
 					),
-					m2t
+				],
+				TLines2(
+					TBorder(16., 16., 0., 0., MText2T(parent, "Opacity, %:", [MBody()])),
+					MSlider2T(
+						manager,
+						parent,
+						MSlider(
+							opacityInPercent,
+							[MSliderDisplayValue(true), MEnabled(enabled), MSliderRange(0., 100.), MSliderStep(1.0)]
+						),
+						m2t
+					)
 				)
-			),
+			)
+		},
 		TEmpty()
 	)
 }


### PR DESCRIPTION
@NikitaFil can you please approve this changes?
Changes made according to card: https://trello.com/c/I9eTFawW/1026-add-transparency-heading-before-the-slider-in-the-color-picker