### PR TITLE
pebbled tabs - ignore empty tab ids to avoid adding t pebble on inapp…

### DIFF
--- a/lib/pebbles/pebble_tabs.flow
+++ b/lib/pebbles/pebble_tabs.flow
@@ -82,7 +82,7 @@ buildCustomPebbledTabs(
 					\tabUid -> {
 						// It's for lost filters in case of opening tabs without preset "t" parameter
 						pebbleStack = getValue(controller.pebbleStackB);
-						if (!contains(tabUids, tabUid) && pebbleStack != [] && length(tabs) > 1) {
+						if (tabUid != "" && !contains(tabUids, tabUid) && pebbleStack != [] && length(tabs) > 1) {
 							last = length(pebbleStack) - 1;
 							fixedPebble = setLastPathPartParameter(pebbleStack[last], parameterName, zeroTabUid);
 							next(


### PR DESCRIPTION
…ropriate views.

PebbleStringLink changes linked behaviour to empty string when user goes to another view.
Same for other Pebble...Link functions. Probably, it would be better to disable pebble actions when leaving view where they are used.

https://trello.com/c/PnYY5BT0/6743-remove-t-parameter-from-url-when-leaving-the-workflow-page