### PR TITLE
Use concat instead of arrayPush

### DIFF
--- a/lib/ds/tree.flow
+++ b/lib/ds/tree.flow
@@ -565,13 +565,13 @@ sizeTree(t) {
 
 treePushToArrayValue(tree, key, value) {
 	c = lookupTreeDef(tree, key, []);
-	setTree(tree, key, arrayPush(c, value))
+	setTree(tree, key, concat(c, [value]))
 }
 
 treePushToArrayUnique(tree, key, value) {
 	c = lookupTreeDef(tree, key, []);
 	if (!contains(c, value)) {
-		setTree(tree, key, arrayPush(c, value))
+		setTree(tree, key, concat(c, [value]))
 	} else {
 		tree
 	}
@@ -738,7 +738,7 @@ convertTreeToArray(tree : Tree<?, ??>, conv : (?, ??) -> ???) -> [???] {
 	if (largeTree(tree)) {
 		list2array(foldTree(tree, EmptyList(), \k, v, l -> Cons(conv(k, v), l)))
 	} else {
-		foldTree(tree, [], \key, value, acc -> arrayPush(acc, conv(key, value)));
+		foldTree(tree, [], \key, value, acc -> concat(acc, [conv(key, value)]));
 	}
 }
 


### PR DESCRIPTION
Better to apply concat here because arrayPush is not optimal in case of using convertTreeToArray etc. in fold/recursion