### PR TITLE
wigi renderParagraph: refactor and introduce setting paragraphDynamicBlockDelay

### DIFF
--- a/lib/form/paragraph3.flow
+++ b/lib/form/paragraph3.flow
@@ -117,18 +117,21 @@ renderParagraph(p : [ParagraphElement], s : [ParagraphStyle], rtl : bool) -> For
 	aw = make(0.0);
 	update = make(0);
 	lines : DynamicBehaviour<[ParaLine]> = make([]);
-	nonDynamic = Select(lines, \l -> renderParaLines(
+
+	// it renders all words but for dynamics it just reserves space and updates coordinates
+	renderedParagraph = Select(lines, \l -> renderParaLines(
 		getValue(aw), l, tightWidth, alignment, interlineSpacing, topLineBaseline, interactiveStyles, rtl
 	));
 	paragraphBorder = extractStruct(s, ParagraphBorder(0.0, 0.0));
 
 	// If there is less or equal then upper limit of dynamic elements, we do not need to postpone updates
-	ndynamic = fold(words, 0, \acc, w -> if (isConst(w.metrics)) acc else 1 + acc);
-	ndymamicUpper = extractStruct(s, DynamicBlockDelay(1)).n;
+	dynamicWords = filter(words, \w -> !isConst(w.metrics));
+	ndynamic = length(dynamicWords);
+	ndymamicUpper = extractStruct(s, DynamicBlockDelay(getParagraphDynamicBlockDelay())).n;
 
 	contentGroup = Group(concat(
-		[if (fill != []) Background(fill, nonDynamic) else nonDynamic],
-		constructDynamicParaForms(words, interactiveStyles)
+		[if (fill != []) Background(fill, renderedParagraph) else renderedParagraph],
+		constructDynamicParaForms(dynamicWords, interactiveStyles)
 	));
 
 	Constructor(
@@ -141,7 +144,11 @@ renderParagraph(p : [ParagraphElement], s : [ParagraphStyle], rtl : bool) -> For
 			}
 		),
 		\ -> {
-			updateFn = \wi -> {
+			cancelDeferredUpdate = ref nop;
+			updateFn = \wi-> {
+				^cancelDeferredUpdate();
+				cancelDeferredUpdate := nop;
+				next(update, 0);
 				// Ignore negative widths
 				// It's the safest way to simmulate single line, because reflowParaWords2 does a lot of useful staff.
 				w = if (isSingleLine) 100000.0 else max(0.0, wi);
@@ -150,37 +157,22 @@ renderParagraph(p : [ParagraphElement], s : [ParagraphStyle], rtl : bool) -> For
 				next(lines, newLines);
 			};
 
-			unsub1 = subscribe(aw, updateFn);
-
-			unsubs = filtermap(words, \w -> if (isConst(w.metrics)) None() else {
-				// Force an update by changing the available
-				Some(subscribe2(w.metrics, \m -> {
-					if (ndynamic <= ndymamicUpper) {
-						// There is less or equal than upper limit of dynamic elements here, so just update immediately
-						updateFn(getValue(aw))
-					} else {
-						// There are more, so to prevent unnecessary work, delay the update
-						nextDistinct(update, 1);
-					}
-				}))
-			});
-
-			// When an update from a dynamic element is requested, we do it in the next frame
-			unsub2 = subscribe(update, \u -> {
-				if (u == 1) {
-					timer(0, \ -> {
-						next(update, 0);
-						// Force an update
-						updateFn(getValue(aw))
+			uns = concatA([
+				[subscribe(aw, \v -> updateFn(v))],
+				if (ndymamicUpper == 0) [] else
+				[
+					subscribe2(update, \u -> {
+						// When an update from a dynamic element is requested, we do it in the next frame
+						// in JS it could introduce unwanted and unpredictable delay because
+						// there is only one "queue" which is used by all activities in the application
+						// and some activities schedules long work
+						if (u == 1) cancelDeferredUpdate := interruptibleTimer(0, \ -> updateFn(getValue(aw)))
 					})
-				}
-			});
+				],
+				mapi(dynamicWords, \i, w -> subscribe2(w.metrics, \m -> if (i < ndymamicUpper) updateFn(getValue(aw)) else nextDistinct(update, 1)))
+			]);
 
-			\ -> {
-				unsub1();
-				applyall(unsubs);
-				unsub2();
-			}
+			\ -> applyall(uns)
 		}
 	);
 }

--- a/lib/form/paragraphtypes.flow
+++ b/lib/form/paragraphtypes.flow
@@ -80,7 +80,7 @@ export {
 				GeneralLinePart(first : string, mid : string, end : string);
 				GeneralInspectElement(inspector : ParaElementInspector, element : GeneralWrapElement);
 				EmptyLineElement();
-		
+
 		ParaElementInspector : (
 			index : DynamicBehaviour<int>,
 			x : DynamicBehaviour<double>,
@@ -91,7 +91,18 @@ export {
 			detached : DynamicBehaviour<bool>
 		);
 
+	// n sets upper bound of dynamic blocks in paragraph for not making a delay at rendering
+	setParagraphDynamicBlockDelay(n : int) -> void;
+	getParagraphDynamicBlockDelay() -> int;
 }
+
+paragraphDynamicBlockDelay : ref int = ref 1;
+
+setParagraphDynamicBlockDelay(n : int) -> void {
+	paragraphDynamicBlockDelay := n;
+}
+
+getParagraphDynamicBlockDelay() -> int { ^paragraphDynamicBlockDelay; }
 
 peIsForm(pe) {
 	switch(pe : ParagraphElement) {

--- a/lib/tropic/tropic_paragraph.flow
+++ b/lib/tropic/tropic_paragraph.flow
@@ -66,7 +66,7 @@ TRenderParagraph(words : ref [TParaWord], s : [ParagraphStyle], rtl : bool) -> T
 
 	// If there is less or equal then upper limit of dynamic elements, we do not need to postpone updates
 	ndynamic = fold(^words, 0, \acc, w -> if (isConstMetrics(w.metrics)) acc else 1 + acc);
-	ndymamicUpper = extractStruct(s, DynamicBlockDelay(1)).n;
+	ndymamicUpper = extractStruct(s, DynamicBlockDelay(getParagraphDynamicBlockDelay())).n;
 
 	stackChanges = make([]);
 	initialWords = ref map(^words, translateWord);


### PR DESCRIPTION
used in https://git.area9lyceum.com/Lyceum/lyceum/pulls/877

**Test case**:

1) run curator with duration=0 and dev=1
2) create several (5 or more) Slide in different LO in module with the wigi doc below.
3) test the module with fast press to "cake"
4) observe that the line of text blinks
it happens because the text is rendered with first form of CalcCell that has 0 width, and then when the cell gets the values it width increased but the reflow of the paragraph that places texts and updates the coordinates of the CalcCell is deferred and happens later.

```
WigiStory(ref [WigiParagraph([WigiText("some text ", []), WigiBlock(WigiExternalBlock("material_calculated_cell", TreeNode("varName", "var_name_1", TreeNode("formula", "= a", TreeEmpty(), TreeEmpty(), 1), TreeNode("wigiName", "calculated_cell1", TreeNode("visible", "=true", TreeEmpty(), TreeEmpty(), 1), TreeEmpty(), 2), 3)), [WigiName("calculated_cell1")]), WigiText(" some text ", []), WigiBlock(WigiExternalBlock("material_calculated_cell", TreeNode("varName", "var_name_2", TreeNode("formula", "= b", TreeEmpty(), TreeEmpty(), 1), TreeNode("wigiName", "calculated_cell2", TreeNode("visible", "=true", TreeEmpty(), TreeEmpty(), 1), TreeEmpty(), 2), 3)), [WigiName("calculated_cell2")]), WigiText("  some text ", []), WigiBlock(WigiExternalBlock("material_calculated_cell", TreeNode("varName", "var_name_3", TreeNode("formula", "= c", TreeEmpty(), TreeEmpty(), 1), TreeNode("wigiName", "calculated_cell3", TreeNode("visible", "=true", TreeEmpty(), TreeEmpty(), 1), TreeEmpty(), 2), 3)), [WigiName("calculated_cell3")]), WigiText(" ", [])], []), WigiParagraph([WigiText("", [])], []), WigiParagraph([WigiBlock(WigiExternalBlock("material_random_data", TreeNode("name1", "a", TreeNode("maximum3", "10000", TreeNode("maximum1", "10000", TreeNode("condition", "=true", TreeEmpty(), TreeEmpty(), 1), TreeNode("maximum2", "10000", TreeEmpty(), TreeEmpty(), 1), 2), TreeNode("minimum2", "1000", TreeNode("minimum1", "1000", TreeEmpty(), TreeEmpty(), 1), TreeNode("minimum3", "1000", TreeEmpty(), TreeEmpty(), 1), 2), 3), TreeNode("step2", "1", TreeNode("name3", "c", TreeNode("name2", "b", TreeEmpty(), TreeEmpty(), 1), TreeNode("step1", "1", TreeEmpty(), TreeEmpty(), 1), 2), TreeNode("varName", "var_name_111", TreeNode("step3", "1", TreeEmpty(), TreeEmpty(), 1), TreeNode("wigiName", "random_data1", TreeEmpty(), TreeEmpty(), 1), 2), 3), 4)), [WigiName("random_data1")]), WigiText(" ", [])], [])], ref [], [ParagraphSpacing(3.0)])
```