### PR TITLE
pebbles - allow custom hierarchy item name and ability to hide chips

### DIFF
--- a/lib/pebbles/pebble_hierarchy.flow
+++ b/lib/pebbles/pebble_hierarchy.flow
@@ -26,7 +26,7 @@ export {
 	);
 
 	makePebbledHierarchyItem(name : string, id2label : (int) -> string, children : [PebbledHierarchyItem]) -> PebbledHierarchyItem;
-	makePebbledHierarchyItem2(name : string, customHierarchyParameterName : string, id2label : (int) -> string, children : [PebbledHierarchyItem]) -> PebbledHierarchyItem;
+	makePebbledHierarchyItem2(name : string, customParameter : string, id2label : (int) -> string, children : [PebbledHierarchyItem]) -> PebbledHierarchyItem;
 
 	// Build a material corresponding to the current values of pebbled hierarchy parameters.
 	// Appends UI element (chips) to visually represent and edit pebbled hierarchy filters.
@@ -40,6 +40,7 @@ export {
 	PebbledHierarchyBodyStyle ::= PebbledHierarchyBodyAdditionalChips, PebbledHierarchyBodyErrorView, PebbledHierarchyBodyHideChips;
 		PebbledHierarchyBodyAdditionalChips(chips : Transform<[Material]>);
 		PebbledHierarchyBodyErrorView(fn : (itemName : string, itemId : string) -> Material);
+		// useful when hierarchy view does not depend on chip filtration and uses visual elements like breadcrumbs
 		PebbledHierarchyBodyHideChips();
 
 	// Display view corresponding to selected item preserving pebble parameters.
@@ -104,10 +105,10 @@ makePebbledHierarchyItem(name : string, id2label : (int) -> string, children : [
 	)
 }
 
-makePebbledHierarchyItem2(name : string, customHierarchyParameterName : string, id2label : (int) -> string, children : [PebbledHierarchyItem]) -> PebbledHierarchyItem {
+makePebbledHierarchyItem2(name : string, customParameter : string, id2label : (int) -> string, children : [PebbledHierarchyItem]) -> PebbledHierarchyItem {
 	PebbledHierarchyItem(
 		name,
-		customHierarchyParameterName,
+		customParameter,
 		id2label,
 		children
 	)

--- a/lib/pebbles/pebble_hierarchy.flow
+++ b/lib/pebbles/pebble_hierarchy.flow
@@ -26,6 +26,7 @@ export {
 	);
 
 	makePebbledHierarchyItem(name : string, id2label : (int) -> string, children : [PebbledHierarchyItem]) -> PebbledHierarchyItem;
+	makePebbledHierarchyItem2(name : string, customHierarchyParameterName : string, id2label : (int) -> string, children : [PebbledHierarchyItem]) -> PebbledHierarchyItem;
 
 	// Build a material corresponding to the current values of pebbled hierarchy parameters.
 	// Appends UI element (chips) to visually represent and edit pebbled hierarchy filters.
@@ -36,9 +37,10 @@ export {
 		style : [PebbledHierarchyBodyStyle]
 	) -> Material;
 
-	PebbledHierarchyBodyStyle ::= PebbledHierarchyBodyAdditionalChips, PebbledHierarchyBodyErrorView;
+	PebbledHierarchyBodyStyle ::= PebbledHierarchyBodyAdditionalChips, PebbledHierarchyBodyErrorView, PebbledHierarchyBodyHideChips;
 		PebbledHierarchyBodyAdditionalChips(chips : Transform<[Material]>);
 		PebbledHierarchyBodyErrorView(fn : (itemName : string, itemId : string) -> Material);
+		PebbledHierarchyBodyHideChips();
 
 	// Display view corresponding to selected item preserving pebble parameters.
 	// For example: open `organizations` table
@@ -94,17 +96,27 @@ PebbledHierarchyData ::= PebbledHierarchyItemsData, PebbledHierarchyError;
 	PebbledHierarchyError : (itemName : string, itemId : string);
 
 makePebbledHierarchyItem(name : string, id2label : (int) -> string, children : [PebbledHierarchyItem]) -> PebbledHierarchyItem {
-	PebbledHierarchyItem(
+	makePebbledHierarchyItem2(
 		name,
 		makePebbledHierarchyParameterName(name),
 		id2label,
-		children,
+		children
+	)
+}
+
+makePebbledHierarchyItem2(name : string, customHierarchyParameterName : string, id2label : (int) -> string, children : [PebbledHierarchyItem]) -> PebbledHierarchyItem {
+	PebbledHierarchyItem(
+		name,
+		customHierarchyParameterName,
+		id2label,
+		children
 	)
 }
 
 MPebbledHierarchyBody(controller : PebbleController, items : [PebbledHierarchyItem], content : (Tree<string, int>) -> Material, style : [PebbledHierarchyBodyStyle]) -> Material {
 	allItems = getAllPebbledHierarchyItems(items);
 	valuesBs = map(allItems, \__ -> make(""));
+	hideChips = containsStruct(style, PebbledHierarchyBodyHideChips());
 
 	MLinkPebbleParameters(
 		controller,
@@ -118,9 +130,11 @@ MPebbledHierarchyBody(controller : PebbleController, items : [PebbledHierarchyIt
 					valuesMap = fold(datas, makeTree(), \acc, data -> {
 						setTree(acc, data.item.parameter, s2i(data.value))
 					});
-
+					chips = if (hideChips) MEmpty() else {
+						buildPebbledHierarchyChips(controller, datas, style);
+					}
 					MLines([
-						buildPebbledHierarchyChips(controller, datas, style),
+						chips,
 						content(valuesMap)
 					])
 				}

--- a/lib/pebbles/pebble_hierarchy.flow
+++ b/lib/pebbles/pebble_hierarchy.flow
@@ -26,7 +26,6 @@ export {
 	);
 
 	makePebbledHierarchyItem(name : string, id2label : (int) -> string, children : [PebbledHierarchyItem]) -> PebbledHierarchyItem;
-	makePebbledHierarchyItem2(name : string, customParameter : string, id2label : (int) -> string, children : [PebbledHierarchyItem]) -> PebbledHierarchyItem;
 
 	// Build a material corresponding to the current values of pebbled hierarchy parameters.
 	// Appends UI element (chips) to visually represent and edit pebbled hierarchy filters.
@@ -97,18 +96,9 @@ PebbledHierarchyData ::= PebbledHierarchyItemsData, PebbledHierarchyError;
 	PebbledHierarchyError : (itemName : string, itemId : string);
 
 makePebbledHierarchyItem(name : string, id2label : (int) -> string, children : [PebbledHierarchyItem]) -> PebbledHierarchyItem {
-	makePebbledHierarchyItem2(
-		name,
-		makePebbledHierarchyParameterName(name),
-		id2label,
-		children
-	)
-}
-
-makePebbledHierarchyItem2(name : string, customParameter : string, id2label : (int) -> string, children : [PebbledHierarchyItem]) -> PebbledHierarchyItem {
 	PebbledHierarchyItem(
 		name,
-		customParameter,
+		makePebbledHierarchyParameterName(name),
 		id2label,
 		children
 	)


### PR DESCRIPTION
This is to reach 2 goals:
1) include in pebble hierarchy items with parameter names already in use which we should not change because they are used in notification emails being sent.
2) keep hierarchy parameters in a view sequence like this
v1 -> v3 -> v2 
where v1, v2 use chips and hierarchy filtering 
but v3 uses breadcrumbs and do not need the hierarchy filtering