### PR TITLE
no en-US is needed

### DIFF
--- a/lib/text/languages.flow
+++ b/lib/text/languages.flow
@@ -621,7 +621,7 @@ export {
 
 	languages = filter(allLanguages, \l -> {
 		languageCode = elementAt(l, 1, "");
-		neededLanguages = ["en-US", "en-GB", "pt-PT"];
+		neededLanguages = ["en-GB", "pt-PT"];
 		strlen(languageCode) == 2 || contains(neededLanguages, languageCode)
 	});
 }


### PR DESCRIPTION
Now we have "English" (it means English US) and English UK
![image](https://user-images.githubusercontent.com/3929589/68524261-7e204880-02e6-11ea-992d-73033fc4247b.png)
