### PR TITLE
Image zoom is broken in Learner in Simulate

### DIFF
--- a/lib/form/virtual_screen_types.flow
+++ b/lib/form/virtual_screen_types.flow
@@ -5,8 +5,11 @@ import fusion;
 export {
 	VirtualScreenInfo : (
 		size : Behaviour<WidthHeight>,
-		position : Behaviour<PositionScale>
+		position : Behaviour<PositionScale>,
+		renderFn : (Form) -> void,
 	);
+
+	makeDefaultVirtualScreenInfo() -> VirtualScreenInfo;
 
 	CropPopupByVirtualScreenBox(
 		info : VirtualScreenInfo,
@@ -16,34 +19,23 @@ export {
 	) -> Form;
 }
 
+makeDefaultVirtualScreenInfo() -> VirtualScreenInfo {
+	VirtualScreenInfo(makeWH(), make(zeroPositionScale), nop1);
+}
+
 CropPopupByVirtualScreenBox(
 	info : VirtualScreenInfo,
 	popupContent : Form,
 	popupSize : Behaviour<WidthHeight>,
 	translateToVisibleArea : bool
 ) -> Form {
-	screenXB = make(0.0);
-	screenYB = make(0.0);
-	screenWB = make(0.0);
-	screenHB = make(0.0);
 	windowXB = make(0.0);
 	windowYB = make(0.0);
 	Constructor(
-		popupContent
-		|> (\f -> if (translateToVisibleArea) Translate(windowXB, windowYB, f) else f)
-		|> (\f -> Crop(screenXB, screenYB, screenWB, screenHB, f))
-		|> (\f -> Translate(screenXB, screenYB, f)),
-		make3Subscribe(info.size, info.position, popupSize, \size, p, windowWH -> {
-			nextDistinct(screenXB, p.pos.x);
-			nextDistinct(screenYB, p.pos.y);
-
-			screenWidth = size.width * p.scale.x;
-			screenHeight = size.height * p.scale.y;
-
-			nextDistinct(screenWB, screenWidth);
-			nextDistinct(screenHB, screenHeight);
-			nextDistinct(windowXB, p.pos.x + max(0.0, (screenWidth - windowWH.width) / 2.0));
-			nextDistinct(windowYB, p.pos.y + max(0.0, (screenHeight - windowWH.height) / 2.0));
+		if (translateToVisibleArea) Translate(windowXB, windowYB, popupContent) else popupContent,
+		make2Subscribe(info.size, popupSize, \size, windowWH -> {
+			nextDistinct(windowXB, max(0.0, (size.width - windowWH.width) / 2.0));
+			nextDistinct(windowYB, max(0.0, (size.height - windowWH.height) / 2.0));
 		})
 	);
 }

--- a/lib/formats/html/html2form.flow
+++ b/lib/formats/html/html2form.flow
@@ -589,7 +589,14 @@ getHtmlPictureMagnifyWithCloseButton(
 								wnd
 							);
 							windowInsideVirtualScreen2 = Group([adoptToVs(backgroundFrm(), false), adoptToVs(magnifyWindow, true)]);
-							closeMagnifyWindow := render(windowInsideVirtualScreen2);
+							closeMagnifyWindow := eitherMap(
+								virtualScreenInfoM,
+								\vsi -> \f -> {
+									vsi.renderFn(f);
+									\-> vsi.renderFn(Empty())
+								},
+								render
+							)(windowInsideVirtualScreen2);
 							true
 						} else {
 							false


### PR DESCRIPTION
We need to use special render function to display popups in wigi, not just render(...).
Popups shouldn't be on top of everything else, only above virtual screen.