### PR TITLE
TextClip: text and nativeWidged.textContent should be in sync

### DIFF
--- a/platforms/js/TextClip.hx
+++ b/platforms/js/TextClip.hx
@@ -392,6 +392,7 @@ class TextClip extends NativeWidgetClip {
 
 			nativeWidget.style.direction = newTextDirection;
 			this.textDirection = newTextDirection;
+			this.metrics = TextMetrics.measureText(this.text, this.style);
 
 			nativeWidget.style.opacity = alpha != 1 || Platform.isIE ? alpha : null;
 			nativeWidget.style.color = style.fill;

--- a/platforms/js/TextClip.hx
+++ b/platforms/js/TextClip.hx
@@ -1285,16 +1285,7 @@ class TextClip extends NativeWidgetClip {
 			metrics = TextMetrics.measureText(text, style);
 
 			if (isStringArabic(text)) {
-				if (nativeWidget == null) {
-					isNativeWidget = true;
-					createNativeWidget(isInput ? (multiline ? 'textarea' : 'input') : 'p');
-				}
-
 				updateNativeWidgetStyle();
-
-				if (RenderSupportJSPixi.RendererType != "html" && !isInput) {
-					deleteNativeWidget();
-				}
 			}
 		}
 	}

--- a/platforms/js/TextClip.hx
+++ b/platforms/js/TextClip.hx
@@ -382,17 +382,13 @@ class TextClip extends NativeWidgetClip {
 			var textContent = getContentGlyphs().modified;
 			var newTextContent = StringTools.replace(StringTools.startsWith(textContent, ' ') ? ' ' + textContent.substring(1) : textContent, "\t", " ");
 			nativeWidget.textContent = newTextContent;
-			this.text = newTextContent;
-
-			var newTextDirection = switch (getStringDirection(textContent, textDirection)) {
+			nativeWidget.style.direction = switch (getStringDirection(textContent, textDirection)) {
 				case 'RTL' : 'rtl';
 				case 'rtl' : 'rtl';
 				default : null;
 			}
 
-			nativeWidget.style.direction = newTextDirection;
-			this.textDirection = newTextDirection;
-			this.metrics = TextMetrics.measureText(this.text, this.style);
+			this.metrics = TextMetrics.measureText(newTextContent, this.style);
 
 			nativeWidget.style.opacity = alpha != 1 || Platform.isIE ? alpha : null;
 			nativeWidget.style.color = style.fill;

--- a/platforms/js/TextClip.hx
+++ b/platforms/js/TextClip.hx
@@ -1290,24 +1290,7 @@ class TextClip extends NativeWidgetClip {
 					createNativeWidget(isInput ? (multiline ? 'textarea' : 'input') : 'p');
 				}
 
-				var textNodeMetrics : Dynamic = null;
-
 				updateNativeWidgetStyle();
-				if (nativeWidget.parentNode == null) {
-					Browser.document.body.appendChild(nativeWidget);
-					textNodeMetrics = getTextNodeMetrics(nativeWidget);
-					Browser.document.body.removeChild(nativeWidget);
-				} else {
-					textNodeMetrics = getTextNodeMetrics(nativeWidget);
-				}
-
-				if (textNodeMetrics.width == null || textNodeMetrics.width <= 0) {
-					return;
-				}
-
-				if (textNodeMetrics.width > metrics.width + DisplayObjectHelper.TextGap || textNodeMetrics.width < metrics.width - DisplayObjectHelper.TextGap) {
-					metrics.width = textNodeMetrics.width;
-				}
 
 				if (RenderSupportJSPixi.RendererType != "html" && !isInput) {
 					deleteNativeWidget();

--- a/platforms/js/TextClip.hx
+++ b/platforms/js/TextClip.hx
@@ -380,13 +380,18 @@ class TextClip extends NativeWidgetClip {
 			}
 		} else {
 			var textContent = getContentGlyphs().modified;
-			nativeWidget.textContent = StringTools.replace(StringTools.startsWith(textContent, ' ') ? ' ' + textContent.substring(1) : textContent, "\t", " ");
+			var newTextContent = StringTools.replace(StringTools.startsWith(textContent, ' ') ? ' ' + textContent.substring(1) : textContent, "\t", " ");
+			nativeWidget.textContent = newTextContent;
+			this.text = newTextContent;
 
-			nativeWidget.style.direction = switch (getStringDirection(textContent, textDirection)) {
+			var newTextDirection = switch (getStringDirection(textContent, textDirection)) {
 				case 'RTL' : 'rtl';
 				case 'rtl' : 'rtl';
 				default : null;
 			}
+
+			nativeWidget.style.direction = newTextDirection;
+			this.textDirection = newTextDirection;
 
 			nativeWidget.style.opacity = alpha != 1 || Platform.isIE ? alpha : null;
 			nativeWidget.style.color = style.fill;

--- a/platforms/js/TextClip.hx
+++ b/platforms/js/TextClip.hx
@@ -334,6 +334,10 @@ class TextClip extends NativeWidgetClip {
 		return -1.0;
 	}
 
+	private static function convertContentGlyphs2TextContent(textContent : String) : String {
+		return StringTools.replace(StringTools.startsWith(textContent, ' ') ? ' ' + textContent.substring(1) : textContent, "\t", " ");
+	}
+
 	public override function updateNativeWidgetStyle() : Void {
 		super.updateNativeWidgetStyle();
 		var alpha = getNativeWidgetAlpha();
@@ -380,15 +384,13 @@ class TextClip extends NativeWidgetClip {
 			}
 		} else {
 			var textContent = getContentGlyphs().modified;
-			var newTextContent = StringTools.replace(StringTools.startsWith(textContent, ' ') ? ' ' + textContent.substring(1) : textContent, "\t", " ");
+			var newTextContent = convertContentGlyphs2TextContent(textContent);
 			nativeWidget.textContent = newTextContent;
 			nativeWidget.style.direction = switch (getStringDirection(textContent, textDirection)) {
 				case 'RTL' : 'rtl';
 				case 'rtl' : 'rtl';
 				default : null;
 			}
-
-			this.metrics = TextMetrics.measureText(newTextContent, this.style);
 
 			nativeWidget.style.opacity = alpha != 1 || Platform.isIE ? alpha : null;
 			nativeWidget.style.color = style.fill;
@@ -1278,10 +1280,10 @@ class TextClip extends NativeWidgetClip {
 
 	private function updateTextMetrics() : Void {
 		if (metrics == null && untyped text != "" && style.fontSize > 1.0) {
-			metrics = TextMetrics.measureText(text, style);
-
 			if (isStringArabic(text)) {
-				updateNativeWidgetStyle();
+				metrics = TextMetrics.measureText(convertContentGlyphs2TextContent(getContentGlyphs().modified), style);
+			} else {
+				metrics = TextMetrics.measureText(text, style);
 			}
 		}
 	}


### PR DESCRIPTION
In some cases,  glyphs used to draw text on the screen are changed by getActualGlyphsString. In this case we have to measure metrics for TextClip using the same set of glyphs or the result could be wrong

**in the branch without calculation of metrics by HTML**:
![image](https://user-images.githubusercontent.com/14361571/69412644-5ededd80-0d20-11ea-9ea7-5a014562c3f3.png)


**in the master without without calculation of metrics by HTML https://github.com/area9innovation/flow9/commit/a0fe170ba8ccd136c8f4d422f843afcc18297c01**:
![image](https://user-images.githubusercontent.com/14361571/69412512-158e8e00-0d20-11ea-80d6-4964837eae85.png)



```
import wigi/utils;

main() {
	setLang("ar");
	setDefaultRhapsodeFontMappingFn();

	// with this enabled baseline alignement works wrong
	if (isUrlParameterFalse("dom")) setRendererType("canvas") else setRendererType("html");

	arabic1 = "لوصف هذه البلاد في العصور";
//	arabic1 = "العصور";

	fontSize = 32.;
	pMDebug = \color -> \m -> MDebug(color, m);

	makeText = \str, family, doSplit -> {
		MLines([
			MText(family + if (doSplit) " split" else " non-split" + ":", [MCustomFont(fontSize, family, 0.87)]), TFixed(32., 0.),
			if (doSplit) MCols(map(strSplitLeave(str, " "), \t -> {
				MText(t, [MCustomFont(fontSize, family, 0.87)])
				|> \m -> if (t == " ") m else MDebug(red, m)
			}))
			else MText(str, [MCustomFont(fontSize, family, 0.87)]) |> pMDebug(red)
		])
	}

	doSplit = true;

	content = MLines(interleave([
		makeText(arabic1, "Scheherazade", doSplit),
		makeText(arabic1, "Non-exists", doSplit),
		makeText(arabic1, "Tahoma", doSplit),
		makeText(arabic1, "Amiri", doSplit),
		makeText(arabic1, "Dubai", doSplit),
	], MLines([
		TFixed(0.0, 32.),
		TRounded(0., 0., 0., 0., [Fill(red)], TFillXH(5.)),
		TFixed(0.0, 32.),
	])));

	mrender(makeMaterialManager([]), true, content) |> ignore;

}
```