### PR TITLE
hot fix for wrong getActualGlyphsString for some fonts

### DIFF
--- a/platforms/js/FlowFontStyle.hx
+++ b/platforms/js/FlowFontStyle.hx
@@ -2,7 +2,8 @@ typedef FontStyle = {
 	family : String,
 	weight : String,
 	size : Float,
-	style : String 		// normal, italic
+	style : String, 		// normal, italic,
+	doNotRemap : Bool
 }
 
 // Singleton used to map flow fonts to css styles
@@ -42,6 +43,6 @@ class FlowFontStyle {
 		}
 
 		var style : FontStyle = Reflect.field(flowFontStyles, name.toLowerCase());
-		return (style != null) ? style : {family: name, weight: "", size: 0.0, style: "normal"};
+		return (style != null) ? style : {family: name, weight: "", size: 0.0, style: "normal", doNotRemap : false};
 	}
 }

--- a/platforms/js/TextClip.hx
+++ b/platforms/js/TextClip.hx
@@ -25,6 +25,14 @@ class TextMappedModification {
 		this.modified = modified;
 		this.difPositionMapping = difPositionMapping;
 	}
+
+	public static function createInvariantForString(text : String) : TextMappedModification {
+		var positionsDiff : Array<Int> = [];
+		for (i in 0...text.length) {
+			positionsDiff.push(0);
+		}
+		return new TextMappedModification(text, positionsDiff);
+	}
 }
 
 class UnicodeTranslation {
@@ -128,6 +136,8 @@ class TextClip extends NativeWidgetClip {
 
 	private var baselineWidget : Dynamic;
 	private var widthDelta : Float = 0.0;
+
+	private var doNotRemap : Bool = false;
 
 	public function new(?worldVisible : Bool = false) {
 		super(worldVisible);
@@ -537,6 +547,7 @@ class TextClip extends NativeWidgetClip {
 		}
 
 		var fontStyle : FontStyle = FlowFontStyle.fromFlowFonts(fontFamilies);
+		this.doNotRemap = fontStyle.doNotRemap;
 
 		style.fontSize = Math.max(fontSize, 0.6);
 		style.fill = RenderSupportJSPixi.makeCSSColor(fillColor, fillOpacity);
@@ -1198,7 +1209,13 @@ class TextClip extends NativeWidgetClip {
 	}
 
 	public function getContentGlyphs() : TextMappedModification {
-		return (isInput && type == "password" ? getBulletsString(this.text) : getActualGlyphsString(this.text));
+		if (isInput && type == "password") {
+			return getBulletsString(this.text);
+		} else if (doNotRemap) {
+			return TextMappedModification.createInvariantForString(this.text);
+		} else {
+			return getActualGlyphsString(this.text);
+		}
 	}
 
 	public function getStyle() : TextStyle {


### PR DESCRIPTION
Scheherazade remapped using getActualGlyphsString  into glyphs that are not supported by the font so we just disable remapping as hot fix.

in the fontconfig.json we will write:

```
"Scheherazade": {
	"family": "Scheherazade Regular",
	"weight": 300,
	"style": "normal",
	"doNotRemap" : true
},
"ScheherazadeBold": {
	"family": "Scheherazade Bold",
	"weight": 900,
	"style": "normal",
	"doNotRemap" : true
},
"ScheherazadeItalic": {
	"family": "Scheherazade Regular",
	"weight": 300,
	"style": "italic",
	"doNotRemap" : true
},
"ScheherazadeBoldItalic": {
	"family": "Scheherazade Bold",
	"weight": 900,
	"style": "italic",
	"doNotRemap" : true
}
```

in the branch:
![image](https://user-images.githubusercontent.com/14361571/69421142-504cf200-0d31-11ea-95ae-d3924d444786.png)

in the master:
![image](https://user-images.githubusercontent.com/14361571/69421374-e6811800-0d31-11ea-8c18-e840076a2f38.png)

