### PR TITLE
FontLoader: add support for custom text strings

### DIFF
--- a/platforms/js/FontLoader.hx
+++ b/platforms/js/FontLoader.hx
@@ -4,7 +4,7 @@ import pixi.loaders.Loader;
 import Platform;
 
 class FontLoader {
-	private static var FontLoadingTimeout = 5000; //ms
+	private static var FontLoadingTimeout = 30000; //ms
 
 	public static function loadWebFonts(onDone : Void -> Void) {
 		if (untyped __typeof__(WebFont) != "undefined") {
@@ -32,29 +32,39 @@ class FontLoader {
 	private static function workaroundWebFontLoading(config : Dynamic) {
 		var fontFields = ["google", "custom"];
 		var fontList = [];
+		var testStringsMap : Map<String, String> = [""=>""];
+
 		for (i in 0...fontFields.length) {
-			var fonts = Reflect.field(Reflect.field(config, fontFields[i]), "families");
-			if (fonts != null)
-				fontList = fontList.concat(fonts);
+			var fontFieldsConfig = Reflect.field(config, fontFields[i]);
+			var fonts = Reflect.field(fontFieldsConfig, "families");
+			if (fonts != null) fontList = fontList.concat(fonts);
+
+			var testStrings = Reflect.field(fontFieldsConfig, "testStrings");
+			if (testStrings != null) {
+				for (family in Reflect.fields(testStrings)) {
+					testStringsMap.set(family, Reflect.field(testStrings, family));
+				}
+			}
 		}
 
 		for (i in 0...fontList.length) {
 			var font = untyped fontList[i];
 			var parts : Array<String> = font.split(":");
 			var family = parts[0];
+			var testString = testStringsMap.get(family);
 			if (parts.length > 1) {
 				var weights = parts[1].split(",");
-				for (i in 0...weights.length)
-					addStyledText(family, untyped weights[i]);
+				for (j in 0...weights.length)
+					addStyledText(family, untyped weights[j], testString);
 			} else {
-				addStyledText(family);
+				addStyledText(family, "", testString);
 			}
 		}
 	}
 
-	private static function addStyledText(family : String, weight : String = "") {
+	private static function addStyledText(family : String, weight : String = "", testString : String = "") {
 		var text = Browser.document.createElement('span');
-		text.innerText = "Loading font...";
+		text.innerText = "Loading font '" + family + "' [" + testString + "]...";
 		text.style.fontFamily = family;
 		if (weight != "")
 			text.style.fontWeight = weight;


### PR DESCRIPTION
Now we can specify which test strings should be used for every font.
for example, in fontconfig.json we can write:

```
"webfontconfig": {
	"google": {
		"families": [
			"Material Icons",
			"Roboto:300,500,300italic,500italic",
			"Amiri:400,600,400italic,600italic"
		],
		"testStrings": {
			"Amiri" : "العصور"
		}
	},
	"custom": {
		"families": ["Dubai Regular", "Dubai Bold", "Scheherazade Regular", "Scheherazade Bold"],
		"urls": ["fonts/fonts.css"],
		"testStrings": {
			"Dubai Regular" : "العصور",
			"Dubai Bold" : "العصور",
			"Scheherazade Regular" : "العصور",
			"Scheherazade Bold" : "العصور"
		}
	}
},
```