### PR TITLE
renderFTexts. Fix text parts overlapping.

### DIFF
--- a/lib/fform/fformutils.flow
+++ b/lib/fform/fformutils.flow
@@ -996,17 +996,35 @@ renderFTexts(texts : Transform<[Text]>, style : [FTextStyle]) -> FRenderResult {
 		}
 	} else {
 		clip = makeClip();
+		widthsTree = make(makeTree());
+		textsOrderingMode = isUrlParameterTrue("texts_ordering");
 
 		FRenderResult(
 			[clip],
 			[
 				fiteriu(fmap(texts, \t -> renderFText(const(t.text), t.style)), \i, c -> {
 					alive = ref false;
+					childClip = c.clips[0];
 
 					concat(
 						[
-							makeSubscribe(i, \v -> addChildClipAt(clip, c.clips[0], v, alive))(),
-							\ -> removeChildClip(clip, c.clips[0], alive)
+							makeSubscribe(i, \v -> {
+								if (textsOrderingMode) nextDistinct(widthsTree, setTree(getValue(widthsTree), v, getClipWidth(childClip)));
+								addChildClipAt(clip, childClip, v, alive)
+							})(),
+
+							if (textsOrderingMode)
+								make2Subscribe(i, widthsTree, \v, tree -> {
+									setClipX(childClip, foldTree(tree, 0., \k, val, acc ->
+										if (k < v) acc + val else acc
+									))
+								})()
+							else nop,
+
+							\ -> {
+								removeChildClip(clip, childClip, alive);
+								if (textsOrderingMode) nextDistinct(widthsTree, removeFromTree(getValue(widthsTree), fgetValue(i)))
+							}
 						],
 						c.disposers
 					)

--- a/lib/material/tests/test_mtext.flow
+++ b/lib/material/tests/test_mtext.flow
@@ -1,0 +1,15 @@
+import material/material2tropic;
+
+main() {
+
+	text = make("SOME <i>ITALIC</i> TEXT");
+	timer(5000, \ -> next(text, "SOME <b>BOLD</b> TEXT"));
+
+	content =
+		FText(text, [EscapeHTML(false)]);
+	frender(content, make(WidthHeight(100., 100.)));
+
+	// content =
+	// 	MText("SOME <b>TEST</b> TEXT", [EscapeHTML(false)]);
+	// mrender(makeMaterialManager([]), true, content)
+}


### PR DESCRIPTION
Suggestion to fix texts overlapping when EscapeHTML(false) is used.

Before : 
![image](https://user-images.githubusercontent.com/27855185/69886458-b36af580-12ea-11ea-9fb1-00f270992fca.png)

After : 
![image](https://user-images.githubusercontent.com/27855185/69886486-d9909580-12ea-11ea-813c-8c7c80673e99.png)
