### PR TITLE
show zoom icons on small screens

### DIFF
--- a/lib/formats/html/html2form.flow
+++ b/lib/formats/html/html2form.flow
@@ -259,7 +259,7 @@ getHtmlPictureMagnifyPDA(form : Form, popup : Form, fullscreen : bool)->Pair<For
 			if (mobile) [ButtonGhosted()] else []
 		),
 		^closeFullscreen
-	);
+	) |> postCropTransfrom;
 
 	Pair(resultForm, postCropTransfrom)
 }
@@ -308,7 +308,7 @@ getHtmlPictureMagnifyWithCloseButton(
 ) -> Pair<Form, (Form) -> Form> {
 	if (mobile) {
 		// small mobiles will better display fullscreen zoomed images
-		getHtmlPictureMagnifyPDA(scaledForm, fullForm, isPhoneScreen())
+		getHtmlPictureMagnifyPDA(scaledForm, fullForm, !isPhoneScreen())
 	} else if (extraZoom) {
 		Pair(makePopupWithLockAndWheel(scaledForm, fullForm, false, true, virtualScreenInfoM), idfn)
 	} else {


### PR DESCRIPTION
I am in doubt ... Can I change the current function? (Or create a new one? :( )

https://trello.com/c/MdQ2jQv7/8471-images-always-allow-zoom-although-option-is-disabled#comment-5e3a906e2b470d724e411037

![image](https://user-images.githubusercontent.com/19932962/74017192-d7ab1880-49a4-11ea-96dd-3faee243fed1.png)

