### PR TITLE
Fix cursor for MSplitter

### DIFF
--- a/lib/material/internal/material_splitter.flow
+++ b/lib/material/internal/material_splitter.flow
@@ -73,12 +73,11 @@ MSplitter2T(manager : MaterialManager, parent : MFocusGroup, m : MSplitter, m2t 
 
 	splitter =
 		TGroup2(
-			TRectangle([MFill(splitterColor)], fillerSizeFn(dividerW)),
+			TCursor(cursor, TRectangle([MFill(splitterColor)], fillerSizeFn(dividerW))),
 			TCenterIn(handle, fillerSizeFn(dividerW))
 		)
 		|> (\t -> TTranslate(trans, t))
 		|> (\t -> TShow(enabled, t))
-		|> (\t -> TCursor(cursor, t))
 		|> (\t -> TInteractive([
 				if (splitterHandle) TMouseDown(pressed) else TMouseDownGhost(pressed),
 				TMouseXY(mouseXY),


### PR DESCRIPTION
https://trello.com/c/cqteTD3r/7749-cursor-does-not-change-when-moving-view-splitter-in-curator-todos