### PR TITLE
Implement proper handling of baseline shift

### DIFF
--- a/lib/tropic/tropic_paragraph.flow
+++ b/lib/tropic/tropic_paragraph.flow
@@ -546,9 +546,7 @@ TRenderLine(
 	iteri(inspectors, \i : int, inspector -> {
 		elemWidth = getValue(inspector.size).width;
 		elemHeight = getValue(inspector.size).height;
-		elemBaseline = getValue(inspector.baseline);
-		dy = if (elemBaseline > 0.) max(lineAsc - elemBaseline, 0.0) else 0.0;
-		yOffset = y + dy;
+		yOffset = y + lineAsc - getValue(inspector.baseline);
 		nextDistinct(inspector.y, yOffset);
 		nextDistinct(inspector.x, ^alignmentOffset + generalIndent);
 		nextDistinct(inspector.lineHeight, lineHeight);

--- a/lib/tropic/tropic_paragraph_preparation.flow
+++ b/lib/tropic/tropic_paragraph_preparation.flow
@@ -34,7 +34,8 @@ makeTZeroSpaceElement(style : [CharacterStyle]) -> Tropic {
 
 addBaselineShiftToTropic(form : Tropic, fontSize : double, shift : double) -> Tropic {
 	if (shift != 0.0) {
-		size = if (fontSize != 0.0) fontSize else getTropicMetrics(form).height;
-		TBaseline(const(size * shift), form);
+		metrics = getTropicMetrics(form);
+		size = if (fontSize != 0.0) fontSize else metrics.height;
+		TBaseline(const(-size * shift + metrics.baseline), form);
 	} else form;
 }


### PR DESCRIPTION
I made mistake when implemented tropic paragraph and misunderstood the meaning of baseline. Now sub/super scritp work as canonical baseline shift.