### PR TITLE
RealHtml: introduce RealHtmlHideHorizontalScroll style

### DIFF
--- a/lib/fform/renderfform.flow
+++ b/lib/fform/renderfform.flow
@@ -1112,8 +1112,9 @@ renderFForm(rform : FForm, zorder : Transform<[int]>) -> FRenderResult {
 			onError = extractStruct(style, OnError(nop1)).fn;
 			onDone = \s -> if (s == "OK") onPageLoaded() else onError(s);
 			shrink2fit = containsStruct(style, RealHtmlShrink2Fit());
+			hideHorizontalScroll = containsStruct(style, RealHtmlHideHorizontalScroll());
 
-			clip = makeWebClip(url, domain, updateCachedContent, reloadBlock, flowCallback, onDone, shrink2fit);
+			clip = makeWebClip(url, domain, updateCachedContent, reloadBlock, flowCallback, onDone, shrink2fit, hideHorizontalScroll);
 
 			disp =
 				fold(

--- a/lib/fform/sfform.flow
+++ b/lib/fform/sfform.flow
@@ -59,7 +59,7 @@ export {
 
 	SFRealHTML(url : string, wh : WidthHeight, style : [SFRealHTMLStyle]);
 		SFRealHTMLStyle ::= UpdateCachedContent, OverridePageDomain, SZoomEnabled, ReloadBlock, SMouseDisabled, SandBoxJS, RealHtmlShrink2Fit,
-			WhitelistDomains, SViewBounds;
+			WhitelistDomains, SViewBounds, RealHtmlHideHorizontalScroll;
 
 			SZoomEnabled(enabled : bool);
 			SMouseDisabled(disabled : bool);
@@ -262,6 +262,7 @@ RealHTMLStyle2SFRealHTMLStyle(style : [RealHTMLStyle]) -> [SFRealHTMLStyle] {
 			ReloadBlock(__) : Some(s);
 			WhitelistDomains(__) : Some(s);
 			ViewBounds(bounds) : Some(SViewBounds(fgetValue(bounds)));
+			RealHtmlHideHorizontalScroll(): Some(s);
 		}
 	)
 }
@@ -417,6 +418,7 @@ SFRealHTMLStyle2RealHTMLStyle(style : [SFRealHTMLStyle]) -> [RealHTMLStyle] {
 			ReloadBlock(__) : s;
 			WhitelistDomains(__) : s;
 			SViewBounds(bounds) : ViewBounds(const(bounds));
+			RealHtmlHideHorizontalScroll(): s;
 		}
 	)
 }

--- a/lib/form/form.flow
+++ b/lib/form/form.flow
@@ -96,7 +96,8 @@ Camera : (filename : string, parameters : [RecordParameter], listeners: [RecordS
 RealHTML2 : (url : string, wh : Behaviour<WidthHeight>, style : [RealHTMLStyle]);
 
 RealHTMLStyle ::= UpdateCachedContent, OverridePageDomain, FlowCallback, PageHostcallSetter,
-	OnError, OnPageLoaded, ZoomEnabled, ReloadBlock, PageEvalJS, MouseDisabled, SandBoxJS, RealHtmlShrink2Fit, WhitelistDomains, ViewBounds;
+	OnError, OnPageLoaded, ZoomEnabled, ReloadBlock, PageEvalJS, MouseDisabled, SandBoxJS,
+	RealHtmlShrink2Fit, WhitelistDomains, ViewBounds, RealHtmlHideHorizontalScroll;
 
 	// UpdateCachedContent - download the latest version of resources when online. true by default.
 	// When false WebView shows cached version even online.
@@ -119,6 +120,8 @@ RealHTMLStyle ::= UpdateCachedContent, OverridePageDomain, FlowCallback, PageHos
 	RealHtmlShrink2Fit();
 	// list of trusted domains to open inside RealHTML on mobiles
 	WhitelistDomains : (domains : [string]);
+	// hide horizontal scroll in resulting iframe
+	RealHtmlHideHorizontalScroll();
 
 	ViewBounds(bounds : Transform<Bounds>);
 

--- a/lib/form/renderform.flow
+++ b/lib/form/renderform.flow
@@ -1691,6 +1691,7 @@ renderForm(rform : Form, available : Behaviour<WidthHeight>, zorder : [int], tab
 		whitelist_domains = ref [];
 		shrink2fit = ref false;
 		viewBounds = ref None();
+		hideHorizontalScroll = ref false;
 
 		iter(style, \s -> {
 			switch (s : RealHTMLStyle) {
@@ -1716,6 +1717,7 @@ renderForm(rform : Form, available : Behaviour<WidthHeight>, zorder : [int], tab
 				);
 				WhitelistDomains(domains) : whitelist_domains := domains;
 				RealHtmlShrink2Fit(): shrink2fit := true;
+				RealHtmlHideHorizontalScroll(): hideHorizontalScroll := true;
 				ViewBounds(bounds): viewBounds := Some(bounds);
 			}
 		});
@@ -1723,7 +1725,7 @@ renderForm(rform : Form, available : Behaviour<WidthHeight>, zorder : [int], tab
 		callback = \args : [string] -> ^flow_callback(args);
 		ondone = \s : string -> if (s == "OK") ^on_page_loaded() else ^on_error(s);
 
-		bridge_clip = makeWebClip(url, ^domain, !^update_cached_content, ^reload_block, callback, ondone, ^shrink2fit);
+		bridge_clip = makeWebClip(url, ^domain, !^update_cached_content, ^reload_block, callback, ondone, ^shrink2fit, ^hideHorizontalScroll);
 
 		switch (^sandbox : Maybe) {
 			Some(sb) : setWebClipSandBox(bridge_clip, sb);

--- a/lib/rendersupport.flow
+++ b/lib/rendersupport.flow
@@ -152,7 +152,7 @@ export {
 	native setMaxChars : io (native, int) -> void = RenderSupport.setMaxChars;
 	native setCursor : io (string) -> void = RenderSupport.setCursor;
 	native getCursor : io () -> string = RenderSupport.getCursor;
-	native makeWebClip : (string, string,  bool, bool, ([string]) -> string, (string) -> void, bool)-> native = RenderSupport.makeWebClip;
+	native makeWebClip : (string, string,  bool, bool, ([string]) -> string, (string) -> void, bool, bool)-> native = RenderSupport.makeWebClip;
 	native setWebClipSandBox : (native, string) -> void = RenderSupport.setWebClipSandBox;
 	native setWebClipDisabled : (native, bool) -> void = RenderSupport.setWebClipDisabled;
 	native webClipHostCall : (native, string, [string]) -> string = RenderSupport.webClipHostCall;

--- a/platforms/java/com/area9innovation/flow/RenderSupport.java
+++ b/platforms/java/com/area9innovation/flow/RenderSupport.java
@@ -42,7 +42,7 @@ public class RenderSupport extends NativeHost {
 	public Object currentClip() {
 		return null;
 	}
-	public Object makeWebClip(String url,String domain,Boolean useCache, Boolean reloadBlock, Func1<String,Object[]> cb, Func1<Object,String> ondone, Boolean shrinkToFit) {
+	public Object makeWebClip(String url,String domain,Boolean useCache, Boolean reloadBlock, Func1<String,Object[]> cb, Func1<Object,String> ondone, Boolean shrinkToFit, Boolean hideHorizontalScroll) {
 		return null;
 	}
 	public String webClipHostCall(Object clip,String fn,Object[] args) {

--- a/platforms/java/javafx/com/area9innovation/flow/javafx/FxRenderSupport.java
+++ b/platforms/java/javafx/com/area9innovation/flow/javafx/FxRenderSupport.java
@@ -440,7 +440,7 @@ public class FxRenderSupport extends RenderSupport {
 		return stage_clip;
 	}
 	@Override
-	public Object makeWebClip(String url,String domain,Boolean useCache, Boolean reloadBlock, Func1<String,Object[]> cb, Func1<Object,String> ondone, Boolean shrinkToFit) {
+	public Object makeWebClip(String url,String domain,Boolean useCache, Boolean reloadBlock, Func1<String,Object[]> cb, Func1<Object,String> ondone, Boolean shrinkToFit, Boolean hideHorizontalScroll) {
 		System.out.println("makeWebClip not implemented");
 		return new Clip();
 	}

--- a/platforms/js/RenderSupport.hx
+++ b/platforms/js/RenderSupport.hx
@@ -2781,8 +2781,8 @@ class RenderSupport {
 	// cb - callback in the flow code which accepts [flow]
 	// To call it in the embedded HTML use frameElement.callflow([args]))
 	// Default web clip size = 100x100. Scale clip to resize
-	public static function makeWebClip(url : String, domain : String, useCache : Bool, reloadBlock : Bool, cb : Array<String> -> String, ondone : String -> Void, shrinkToFit : Bool) : WebClip {
-		return new WebClip(url, domain, useCache, reloadBlock, cb, ondone, shrinkToFit);
+	public static function makeWebClip(url : String, domain : String, useCache : Bool, reloadBlock : Bool, cb : Array<String> -> String, ondone : String -> Void, shrinkToFit : Bool, hideHorizontalScroll : Bool) : WebClip {
+		return new WebClip(url, domain, useCache, reloadBlock, cb, ondone, shrinkToFit, hideHorizontalScroll);
 	}
 
 	public static function webClipHostCall(clip : WebClip, name : String, args : Array<String>) : String {

--- a/platforms/js/RenderSupportNodeJs.hx
+++ b/platforms/js/RenderSupportNodeJs.hx
@@ -159,7 +159,7 @@ class RenderSupport {
 		return null;
 	}
 
-	public static function makeWebClip(url : String, domain : String, useCache : Bool, reloadBlock : Bool, cb : Array<String> -> String, ondone : String -> Void, shrinkToFit : Bool) : Dynamic {
+	public static function makeWebClip(url : String, domain : String, useCache : Bool, reloadBlock : Bool, cb : Array<String> -> String, ondone : String -> Void, shrinkToFit : Bool, hideHorizontalScroll : Bool) : Dynamic {
 		return null;
 	}
 

--- a/platforms/js/WebClip.hx
+++ b/platforms/js/WebClip.hx
@@ -8,6 +8,7 @@ class WebClip extends NativeWidgetClip {
 	private var htmlPageWidth : Dynamic = null;
 	private var htmlPageHeight : Dynamic = null;
 	private var shrinkToFit : Dynamic = null;
+	private var hideHorizontalScroll : Dynamic = null;
 
 	private static function isUrl(str) : Bool {
 		return ~/^(\S+[.?][^\/\s]+(\/\S+|\/|))$/g.match(str);
@@ -46,7 +47,7 @@ class WebClip extends NativeWidgetClip {
 		nativeWidget.appendChild(div);
 	}
 
-	public function new(url : String, domain : String, useCache : Bool, reloadBlock : Bool, cb : Array<String> -> String, ondone : String -> Void, shrinkToFit : Bool) {
+	public function new(url : String, domain : String, useCache : Bool, reloadBlock : Bool, cb : Array<String> -> String, ondone : String -> Void, shrinkToFit : Bool, hideHorizontalScroll : Bool) {
 		super();
 
 		if (domain != "") {
@@ -63,6 +64,7 @@ class WebClip extends NativeWidgetClip {
 		}
 
 		this.shrinkToFit = shrinkToFit;
+		this.hideHorizontalScroll = hideHorizontalScroll;
 
 		iframe = Browser.document.createElement("iframe");
 		iframe.style.visibility = "hidden";
@@ -97,6 +99,10 @@ class WebClip extends NativeWidgetClip {
 					if (Native.isTouchScreen()) {
 						iframeDocument.addEventListener('touchstart', onContentMouseMove, false);
 					}
+				}
+
+				if (hideHorizontalScroll) {
+					untyped iframeDocument.body.style["overflow-x"] = "hidden";
 				}
 
 				if (shrinkToFit) {

--- a/tools/flowc/backends/cpp/flow_rendersupport.hpp
+++ b/tools/flowc/backends/cpp/flow_rendersupport.hpp
@@ -83,8 +83,8 @@ void setSelection(const native& , const int start, const int end) { FLOW_ABORT }
 void setTabIndex(const native& , const int ) { FLOW_ABORT }
 void setTextDirection(const native& clip, const flow::string& direction) { FLOW_ABORT }
 void setTextAndStyle(const native& textfield, const flow::string& text, const flow::string& fontfamily, const double fontsize,
-	const int fontweight, const flow::string& fontslope, 
-	const int fillcolour, const double fillopacity, const int letterspacing, 
+	const int fontweight, const flow::string& fontslope,
+	const int fillcolour, const double fillopacity, const int letterspacing,
 	const int backgroundcolour, const double backgroundopacity, const bool forTextinput) { FLOW_ABORT }
 void setTextFieldHeight(const native& clip, const double width) { FLOW_ABORT }
 void setTextFieldWidth(const native& clip, const double width) { FLOW_ABORT }
@@ -93,8 +93,8 @@ void setTextInput(const native& ) { FLOW_ABORT }
 struct PlayerControl;
 void setVideoControls(const native& clip, const flow::array<PlayerControl>& ctl) { FLOW_ABORT }
 void setVideoLooping(const native& clip, const bool looping) { FLOW_ABORT }
-void setVideoSubtitle(const native& clip, const flow::string& text, const flow::string& fontfamily, const double fontsize, 
-	const int fontweight, const flow::string& fontslope, 
+void setVideoSubtitle(const native& clip, const flow::string& text, const flow::string& fontfamily, const double fontsize,
+	const int fontweight, const flow::string& fontslope,
 	const int fillcolour, const double fillopacity, const int letterspacing, const int backgroundcolour, const double backgroundopacity) { FLOW_ABORT }
 void setVideoVolume(const native& clip, const double volume) { FLOW_ABORT }
 void setWebClipDisabled(const native& , const bool ) { FLOW_ABORT }
@@ -107,7 +107,7 @@ void timer(const int , const std::function<void()>& ) { FLOW_ABORT }
 void toggleFullWindow(const bool fs) { FLOW_ABORT }
 
 void impersonateCallstackItem(const native& item, const int flags) { /*FLOW_ABORT*/ }
-native makeWebClip(const flow::string&, const flow::string&, const bool, const bool, const std::function<flow_t(flow::array<flow_t>)>&, const std::function<void(flow::string)>&, const bool) { FLOW_ABORT }
+native makeWebClip(const flow::string&, const flow::string&, const bool, const bool, const std::function<flow_t(flow::array<flow_t>)>&, const std::function<void(flow::string)>&, const bool, const bool) { FLOW_ABORT }
 void setAccessAttributes(const native& clip, const flow::array<flow::array<flow_t>>& properties) { FLOW_ABORT }
 flow_t webClipEvalJS(const native& , const flow::string& ) { FLOW_ABORT }
 flow_t webClipHostCall(const native& , const flow::string& , const flow::array<flow_t>& ) { FLOW_ABORT }


### PR DESCRIPTION
IFrame shows horizontal scroll unpredictable depending on it's internal logic of re-flowing of words.
this PR allows to set special style to instruct MRealHTML to hide the horizontal scroll.

required for https://github.com/area9innovation/innovation/pull/1519

In master:
![image](https://user-images.githubusercontent.com/14361571/78356869-16320d80-75b9-11ea-8747-dbfa3360de1c.png)

in branch:
![image](https://user-images.githubusercontent.com/14361571/78357047-64471100-75b9-11ea-926e-3adf5fee933a.png)
