### PR TITLE
Flowc specialization: fix bug with generic lambda

### DIFF
--- a/tools/flowc/flowc_version.flow
+++ b/tools/flowc/flowc_version.flow
@@ -2,5 +2,5 @@
 // Edit 'build-flowc' instead.
 export {
 	flowc_version = "3.0";
-	flowc_git_revision = "34fb520";
+	flowc_git_revision = "9370e14";
 }

--- a/tools/flowc/flowc_version.flow
+++ b/tools/flowc/flowc_version.flow
@@ -2,5 +2,5 @@
 // Edit 'build-flowc' instead.
 export {
 	flowc_version = "3.0";
-	flowc_git_revision = "099d41b";
+	flowc_git_revision = "34fb520";
 }

--- a/tools/flowc/manipulation/mangle.flow
+++ b/tools/flowc/manipulation/mangle.flow
@@ -21,7 +21,7 @@ export {
 		n : FiNativeDec,
 		polymorphics : Tree<string, FiType>,
 		specializations : Tree<string, Set<FiType>>,
-		mangle : bool		
+		mangle : bool
 	) -> [FiNativeDec];
 
 	specializationFiTypeStruct(
@@ -38,6 +38,13 @@ export {
 		mangle : bool
 	) -> [FiTypeUnion];
 
+	specializeFiglobalVar(
+		v : FiGlobalVar,
+		polymorphics : Tree<string, FiType>,
+		specializations : Tree<string, Set<FiType>>,
+		mangle : bool
+	) -> [FiGlobalVar];
+
 	// only mangles type in initializer - there should not be any unbound parameters
 	specializeGlobalVar(
 		v : FiGlobalVar,
@@ -52,7 +59,7 @@ mangleSuffix(f : FiType) -> string {
 	jsmangling = true;
 	suffix = switch (f) {
 		FiTypeArray(t): (if (jsmangling) "" else "a" + mangleSuffix(t));
-		FiTypeFunction(args, returnType): "c" + i2s(length(args)) + superglue(args, \a -> mangleSuffix(a.type), "") 
+		FiTypeFunction(args, returnType): "c" + i2s(length(args)) + superglue(args, \a -> mangleSuffix(a.type), "")
 			+ if (jsmangling) "" else mangleSuffix(returnType);
 		FiTypeRef(t): if (jsmangling) "" else "r" + mangleSuffix(t);
 		FiTypeParameter(n): {
@@ -130,10 +137,10 @@ mangleName(name : string, t : FiType) -> string {
 		//printCallstack();
 	}*/
 	switch (t) {
-		FiTypeName(n, tps): 
-			if (n == name && length(tps) == 0) 
+		FiTypeName(n, tps):
+			if (n == name && length(tps) == 0)
 				name
-			else	
+			else
 				doMangleName(name, t);
 		default:
 			doMangleName(name, t);
@@ -173,21 +180,25 @@ specializeEntity(
 	switch (mpoly) {
 		None(): [constructSpecialized(entityName, makeTree())]; // no specialization occurs - but maybe it is needed further down
 		Some(poly): {
-			specs = lookupTreeDef(specializations, entityName, makeSet());
-			// map of mangled name -> specialization - used to remove specializations resulting in the same mangled name
-			// allows mangling to work as a merging transformation too
-			uniqueSpecs = foldSet(specs, makeTree(), \tree, s -> setTree(tree, mangleName(entityName, s), s));
-			convertTreeToArray(uniqueSpecs, \mangled, s : FiType -> {
-				typars = fiMatchTypars(poly, s, makeTree());
-				constructSpecialized(mangled, typars);
-			});
+			specs : Set<FiType> = lookupTreeDef(specializations, entityName, makeSet());
+			if (isEmptySet(specs)) {
+				[constructSpecialized(entityName, makeTree())]
+			 } else {
+				// map of mangled name -> specialization - used to remove specializations resulting in the same mangled name
+				// allows mangling to work as a merging transformation too
+				uniqueSpecs = foldSet(specs, makeTree(), \tree, s -> setTree(tree, mangleName(entityName, s), s));
+				convertTreeToArray(uniqueSpecs, \mangled, s : FiType -> {
+					typars = fiMatchTypars(poly, s, makeTree());
+					constructSpecialized(mangled, typars);
+				});
+			 }
 		}
 	}
 }
 
 // specializes function body and creates new FiFunctionDec
-specializeFunctionBody(f : FiFunctionDec, mangledName : string, typars : Tree<string, FiType>, 
-	polymorphics : Tree<string, FiType>, mangle : bool) 
+specializeFunctionBody(f : FiFunctionDec, mangledName : string, typars : Tree<string, FiType>,
+	polymorphics : Tree<string, FiType>, mangle : bool)
 {
 	functionType = instantiateFiTypeFunctionTypars(polymorphics, f.type, typars, mangle);
 	body = instantiateFiLambdaTypars(f.lambda, typars, polymorphics, makeSet(), mangle);
@@ -195,7 +206,7 @@ specializeFunctionBody(f : FiFunctionDec, mangledName : string, typars : Tree<st
 }
 
 // specializes function and deals with unbound type parameters inside
-specializeFunction(f : FiFunctionDec, mangledName : string, typars : Tree<string, FiType>, 
+specializeFunction(f : FiFunctionDec, mangledName : string, typars : Tree<string, FiType>,
 	polymorphics : Tree<string, FiType>, mangle : bool) {
 
 	// always instantiating without mangle first time to detect unbound parameters correctly
@@ -250,10 +261,10 @@ specializeFiNativeDec(
 		polymorphics,
 		specializations,
 		\mangledName, typars -> {
-			FiNativeDec(mangledName, n.io, 
+			FiNativeDec(mangledName, n.io,
 				instantiateFiTypeTypars(polymorphics, n.type, typars, mangle),
 				n.nativeName,
-				instantiateFiExpTypars(n.fallbackLambda, typars, polymorphics, makeSet(), mangle), 
+				instantiateFiExpTypars(n.fallbackLambda, typars, polymorphics, makeSet(), mangle),
 				n.declStart, n.defiStart
 			)
 		});
@@ -271,7 +282,7 @@ specializationFiTypeStruct(
 		specializations,
 		\mangledName, typars -> {
 			FiTypeStruct(
-				if (mangleFields) mangledName else struct_.name, 
+				if (mangleFields) mangledName else struct_.name,
 				[], // empty as all parameters are specialized
 				map(struct_.args, \sa -> {
 					FiStructArg(
@@ -286,7 +297,6 @@ specializationFiTypeStruct(
 	);
 }
 
-
 specializationFiTypeUnion(
 	union : FiTypeUnion,
 	polymorphics : Tree<string, FiType>,
@@ -299,7 +309,7 @@ specializationFiTypeUnion(
 		specializations,
 		\mangledName, typars -> {
 			FiTypeUnion(
-				mangledName, 
+				mangledName,
 				[], // empty as all type parameters are specialized
 				map(union.typenames, \tn -> {
 					// instantiating using union type parameters - i.e. List<T>(EmptyList, Cons<T>)
@@ -310,6 +320,27 @@ specializationFiTypeUnion(
 			)
 		},
 	);
+}
+
+specializeFiglobalVar(
+	v : FiGlobalVar,
+	polymorphics : Tree<string, FiType>,
+	specializations : Tree<string, Set<FiType>>,
+	mangle : bool
+) -> [FiGlobalVar] {
+	specializeEntity(
+		v.name,
+		polymorphics,
+		specializations,
+		\mangledName, typars -> {
+			FiGlobalVar(
+				v.name,
+				instantiateFiExpTypars(v.value, typars, polymorphics, makeSet(), true),
+				instantiateFiTypeTypars(polymorphics, v.type, typars, true),
+				v.declStart,
+				v.defiStart
+			);
+		});
 }
 
 specializeGlobalVar(v : FiGlobalVar, polymorphics : Tree<string, FiType>) -> FiGlobalVar {
@@ -330,30 +361,30 @@ instantiateFiExpTypars(f : FiExp, typars : Tree<string, FiType>, polymorphic : T
 			instantiateFiLambdaTypars(f, typars, polymorphic, bound, mangle);
 		FiCall(fn, args, type, start): {
 			FiCall(
-				instantiateFiExpTypars(fn, typars, polymorphic, bound, mangle), 
-				map(args, \a -> instantiateFiExpTypars(a, typars, polymorphic, bound, mangle)), 
-				instantiateFiTypeTypars(polymorphic, type, typars, mangle), 
+				instantiateFiExpTypars(fn, typars, polymorphic, bound, mangle),
+				map(args, \a -> instantiateFiExpTypars(a, typars, polymorphic, bound, mangle)),
+				instantiateFiTypeTypars(polymorphic, type, typars, mangle),
 				start
 			);
 		}
-		FiVar(name, type, start): 
+		FiVar(name, type, start):
 			instantiateFiVarTypars(f, typars, polymorphic, bound, mangle);
 		FiLet(name, type, e1, e2, type2, start): {
 			FiLet(
 				name,
-				instantiateFiTypeTypars(polymorphic, type, typars, mangle), 
-				instantiateFiExpTypars(e1, typars, polymorphic, bound, mangle), 
-				instantiateFiExpTypars(e2, typars, polymorphic, insertSet(bound, name), mangle), 
-				instantiateFiTypeTypars(polymorphic, type2, typars, mangle), 
+				instantiateFiTypeTypars(polymorphic, type, typars, mangle),
+				instantiateFiExpTypars(e1, typars, polymorphic, bound, mangle),
+				instantiateFiExpTypars(e2, typars, polymorphic, insertSet(bound, name), mangle),
+				instantiateFiTypeTypars(polymorphic, type2, typars, mangle),
 				start
 			);
 		}
 		FiIf(e1, e2, e3, type, start):  {
 			FiIf(
-				instantiateFiExpTypars(e1, typars, polymorphic, bound, mangle), 
-				instantiateFiExpTypars(e2, typars, polymorphic, bound, mangle), 
-				instantiateFiExpTypars(e3, typars, polymorphic, bound, mangle), 
-				instantiateFiTypeTypars(polymorphic, type, typars, mangle), 
+				instantiateFiExpTypars(e1, typars, polymorphic, bound, mangle),
+				instantiateFiExpTypars(e2, typars, polymorphic, bound, mangle),
+				instantiateFiExpTypars(e3, typars, polymorphic, bound, mangle),
+				instantiateFiTypeTypars(polymorphic, type, typars, mangle),
 				start
 			);
 		}
@@ -363,36 +394,36 @@ instantiateFiExpTypars(f : FiExp, typars : Tree<string, FiType>, polymorphic : T
 				instantiateFiTypeTypars(polymorphic, switchType, typars, mangle),
 				map(cases, \c -> {
 					structType = instantiateFiTypeTypars(polymorphic, FiTypeName(c.struct, getTypars(switchType)), typars, mangle);
-					FiCase(getTypeName(structType), c.argNames, 
-						instantiateFiExpTypars(c.body, typars, polymorphic, 
+					FiCase(getTypeName(structType), c.argNames,
+						instantiateFiExpTypars(c.body, typars, polymorphic,
 							fold(c.argNames, bound, \acc, a -> insertSet(acc, a)), mangle),
 						c.start
 					);
-				}), 
-				instantiateFiTypeTypars(polymorphic, type, typars, mangle), 
+				}),
+				instantiateFiTypeTypars(polymorphic, type, typars, mangle),
 				start
 			);
 		}
 		FiCast(e, tFrom, tTo, type, start):  {
 			FiCast(
-				instantiateFiExpTypars(e, typars, polymorphic, bound, mangle), 
-				instantiateFiTypeTypars(polymorphic, tFrom, typars, mangle), 
-				instantiateFiTypeTypars(polymorphic, tTo, typars, mangle), 
-				instantiateFiTypeTypars(polymorphic, type, typars, mangle), 
+				instantiateFiExpTypars(e, typars, polymorphic, bound, mangle),
+				instantiateFiTypeTypars(polymorphic, tFrom, typars, mangle),
+				instantiateFiTypeTypars(polymorphic, tTo, typars, mangle),
+				instantiateFiTypeTypars(polymorphic, type, typars, mangle),
 				start
 			);
 		}
 		FiSeq(es, type, start):  {
 			FiSeq(
-				map(es, \a -> instantiateFiExpTypars(a, typars, polymorphic, bound, mangle)), 
-				instantiateFiTypeTypars(polymorphic, type, typars, mangle), 
+				map(es, \a -> instantiateFiExpTypars(a, typars, polymorphic, bound, mangle)),
+				instantiateFiTypeTypars(polymorphic, type, typars, mangle),
 				start
 			);
 		}
 		FiCallPrim(op, es, type, start): {
 			instantiatedType = instantiateFiTypeTypars(polymorphic, type, typars, mangle);
 			instantiatedOp = switch (op) {
-				FcStructPrim(name): 
+				FcStructPrim(name):
 					FcStructPrim(
 						if (mangle && containsKeyTree(polymorphic, name)) {
 							cast(instantiatedType : FiType -> FiTypeName).name;
@@ -416,7 +447,7 @@ instantiateFiExpTypars(f : FiExp, typars : Tree<string, FiType>, polymorphic : T
 			}
 			FiCallPrim(
 				instantiatedOp,
-				map(es, \a -> instantiateFiExpTypars(a, typars, polymorphic, bound, mangle)), 
+				map(es, \a -> instantiateFiExpTypars(a, typars, polymorphic, bound, mangle)),
 				instantiatedType,
 				start
 			);
@@ -424,14 +455,14 @@ instantiateFiExpTypars(f : FiExp, typars : Tree<string, FiType>, polymorphic : T
 		FiVoid(start): f;
 		FiDouble(d, start): f;
 		FiInt(i, start): f;
-		FiString(s, start): f; 
+		FiString(s, start): f;
 		FiBool(b, start): f;
 		FiRequire(flowfile, e, type, start): {
-			FiRequire(flowfile, instantiateFiExpTypars(e, typars, polymorphic, bound, mangle), 
+			FiRequire(flowfile, instantiateFiExpTypars(e, typars, polymorphic, bound, mangle),
 				instantiateFiTypeTypars(polymorphic, type, typars, mangle), start);
 		}
 		FiUnsafe(name, fallback, type, start): {
-			FiUnsafe(name, instantiateFiExpTypars(fallback, typars, polymorphic, bound, mangle), 
+			FiUnsafe(name, instantiateFiExpTypars(fallback, typars, polymorphic, bound, mangle),
 				instantiateFiTypeTypars(polymorphic, type, typars, mangle), start);
 		}
 	}
@@ -442,20 +473,20 @@ instantiateFiVarTypars(v : FiVar, typars : Tree<string, FiType>, polymorphic : T
 
 	mangled = if (mangle && !containsSet(bound, v.name) && containsKeyTree(polymorphic, v.name)) {
 		mangleName(v.name, instantiateFiTypeTypars(polymorphic, v.type, typars, false))
-	} else 
+	} else
 		v.name;
-	
+
 	FiVar(mangled, instantiateFiTypeTypars(polymorphic, v.type, typars, mangle), v.start);
 }
 
 instantiateFiLambdaTypars(f : FiLambda, typars : Tree<string, FiType>, polymorphic : Tree<string, FiType>,
 	bound : Set<string>, mangle : bool) -> FiLambda {
 	FiLambda(
-		map(f.args, \a -> FiFunArg(a.name, instantiateFiTypeTypars(polymorphic, a.type, typars, mangle))), 
-		instantiateFiExpTypars(f.body, typars, polymorphic, 
+		map(f.args, \a -> FiFunArg(a.name, instantiateFiTypeTypars(polymorphic, a.type, typars, mangle))),
+		instantiateFiExpTypars(f.body, typars, polymorphic,
 			fold(f.args, bound, \acc, a -> insertSet(acc, a.name)),
-			mangle), 
-		instantiateFiTypeFunctionTypars(polymorphic, f.type, typars, mangle), 
+			mangle),
+		instantiateFiTypeFunctionTypars(polymorphic, f.type, typars, mangle),
 		f.start
 	);
 }
@@ -491,7 +522,7 @@ instantiateFiTypeTypars(polymorphic : Tree<string, FiType>, type : FiType, typar
 		FiTypeRef(t):  FiTypeRef(instantiateFiTypeTypars(polymorphic, t, typars, mangle));
 		FiTypeParameter(n): {
 			resolved = lookupTreeDef(typars, n, type);
-			if (mangle && resolved != type) 
+			if (mangle && resolved != type)
 				mangleType(polymorphic, resolved)
 			else
 				resolved;

--- a/tools/flowc/manipulation/mangle.flow
+++ b/tools/flowc/manipulation/mangle.flow
@@ -334,7 +334,7 @@ specializeFiglobalVar(
 		specializations,
 		\mangledName, typars -> {
 			FiGlobalVar(
-				v.name,
+				mangledName,
 				instantiateFiExpTypars(v.value, typars, polymorphics, makeSet(), true),
 				instantiateFiTypeTypars(polymorphics, v.type, typars, true),
 				v.declStart,

--- a/tools/flowc/manipulation/specialization_js.flow
+++ b/tools/flowc/manipulation/specialization_js.flow
@@ -186,8 +186,15 @@ do_find_specialization_modules_js(m : FiModule, polymorphics : Tree<string, FiTy
 	step1 = fold(concat(m.functions, expandedFunctions), found, \acc0, f ->
 		find_free_vars_with_types_multiple_js(f.lambda, makeSet(), acc0, polymorphics));
 
-	step2 = fold(m.globalVars, step1, \acc0, g ->
+	expandedGlobalVars = concatA(map(m.globalVars,
+		\v -> {
+			specializeFiglobalVar(v, polymorphics, step1, false)
+		})
+	);
+
+	step2 = fold(concat(m.globalVars, expandedGlobalVars), step1, \acc0, g ->
 		find_free_vars_with_types_multiple_js(g.value, makeSet(), acc0, polymorphics));
+
 	step3 = fold(m.natives, step2, \acc0, n ->
 		find_type_specializations_js(n.type, polymorphics, acc0));
 
@@ -222,27 +229,16 @@ specializeProgramJS(cfg : FcCommonConfig, program : FiProgram, onlyBasicSpeciali
 
 	fcVerbose(cfg, 0, "Specializing - collecting specializations");
 	t0 = timestamp();
-	specializations0 = find_specializations_js(program, polymorphics, makeTree());
-
-	specializations = if (false && onlyBasicSpecializations) {
-		// Second, get rid of specializations that are not basic
-		// Unfortunately, this does not work in the specialization
-		// code such that we can keep the original one. Right now,
-		// it is all or nothing
-		mapTree2(specializations0, \fn, types -> {
-			pt = lookupTreeDef(polymorphics, fn, FiTypeVoid());
-			filterSet(types, \t -> {
-				shouldThisSpecializationBeKeptJS(pt, t)
-			})
-		})
-	} else specializations0;
+	specializations = find_specializations_js(program, polymorphics, makeTree());
 	printStat("specializations", sizeTree(specializations), round(timestamp() - t0));
 
-	if (false) {
+	if (true) {
+		println("Found specializations:");
 		traverseInOrder(specializations, \n, types -> {
 			pt = lookupTreeDef(polymorphics, n, FiTypeVoid());
 			println(n + " : " + prettyFiType(dummyPretty, pt, makeSet()) + " as " + superglue(set2array(types), \t -> prettyFiType(dummyPretty, t, makeSet()), ", "));
 		});
+		println("");
 	}
 
 	fcVerbose(cfg, 0, "Specializing - generating specialized entity declarations");
@@ -345,6 +341,11 @@ specializeProgramModuleJS(program : FiProgram, moduleName : string, polymorphics
 				setTree(acc, n.name, r);
 			});
 
+			expandedGlobalVars : Tree<string, [FiGlobalVar]> = fold(m.globalVars, makeTree(), \acc, v -> {
+					r = specializeFiglobalVar(v, polymorphics, specializations, false);
+					setTree(acc, v.name, r);
+			});
+
 			// Our globals are specialized here
 			convertedVars : [FiGlobalVar] = map(m.globalVars, \v -> specializeGlobalVar(v, polymorphics));
 
@@ -360,7 +361,15 @@ specializeProgramModuleJS(program : FiProgram, moduleName : string, polymorphics
 							eitherFn(
 								lookupTree(expandedNatives, k),
 								\natives -> Cons(map(natives, \n -> n.name), l),
-								\-> Cons([k], l)
+								\-> {
+									eitherFn(
+										lookupTree(expandedGlobalVars, k),
+										\globals -> {
+											Cons(map(globals, \g -> g.name), l)
+										},
+										\ -> Cons([k], l)
+									)
+								}
 							)
 						}
 					)
@@ -381,7 +390,7 @@ specializeProgramModuleJS(program : FiProgram, moduleName : string, polymorphics
 				m.structs,
 				m.unions,
 				overrideWithSpecializationJS(m.functions, \f -> f.name, expandedFunctions),
-				convertedVars,
+				overrideWithSpecializationJS(m.globalVars, \f -> f.name, expandedGlobalVars),
 				overrideWithSpecializationJS(m.natives, \n -> n.name, expandedNatives),
 				foldList(expandedInitOrderList, [], \ll, l -> concat(l, ll)),
 				m.stringIncludes,
@@ -413,9 +422,9 @@ specializeProgramModuleJS(program : FiProgram, moduleName : string, polymorphics
 					program.names.unions,
 					foldArrayTree(expandedNatives,
 						foldArrayTree(expandedFunctions,
-							fold(convertedVars,
+							foldArrayTree(expandedGlobalVars,
 								program.names.toplevel,
-								\acc : Tree<string, FiDeclaration>, v -> setTree(acc, v.name, v)
+								\__, v, acc : Tree<string, FiDeclaration> -> setTree(acc, v.name, v)
 							),
 							\__, f, acc -> setTree(acc, f.name, f)
 						),

--- a/tools/flowc/manipulation/specialization_js.flow
+++ b/tools/flowc/manipulation/specialization_js.flow
@@ -412,7 +412,11 @@ specializeProgramModuleJS(program : FiProgram, moduleName : string, polymorphics
 						program.names.function2module,
 						\__, f, acc -> setTree(acc, f.name, moduleName)
 					),
-					program.names.globalVar2module,
+					foldArrayTree(
+						expandedGlobalVars,
+						program.names.globalVar2module,
+						\__, g, acc -> setTree(acc, g.name, moduleName)
+					),
 					foldArrayTree(
 						expandedNatives,
 						program.names.native2module,
@@ -424,7 +428,7 @@ specializeProgramModuleJS(program : FiProgram, moduleName : string, polymorphics
 						foldArrayTree(expandedFunctions,
 							foldArrayTree(expandedGlobalVars,
 								program.names.toplevel,
-								\__, v, acc : Tree<string, FiDeclaration> -> setTree(acc, v.name, v)
+								\__, g, acc : Tree<string, FiDeclaration> -> setTree(acc, g.name, g)
 							),
 							\__, f, acc -> setTree(acc, f.name, f)
 						),

--- a/tools/flowc/manipulation/specialization_js.flow
+++ b/tools/flowc/manipulation/specialization_js.flow
@@ -232,7 +232,7 @@ specializeProgramJS(cfg : FcCommonConfig, program : FiProgram, onlyBasicSpeciali
 	specializations = find_specializations_js(program, polymorphics, makeTree());
 	printStat("specializations", sizeTree(specializations), round(timestamp() - t0));
 
-	if (true) {
+	if (false) {
 		println("Found specializations:");
 		traverseInOrder(specializations, \n, types -> {
 			pt = lookupTreeDef(polymorphics, n, FiTypeVoid());

--- a/tools/flowc/manipulation/specialization_js.flow
+++ b/tools/flowc/manipulation/specialization_js.flow
@@ -216,12 +216,8 @@ do_find_specialization_modules_js(m : FiModule, polymorphics : Tree<string, FiTy
 specializeProgramJS(cfg : FcCommonConfig, program : FiProgram, onlyBasicSpecializations : bool) -> FiProgram {
 	fcVerbose(cfg, 0, "Specializing - looking for polymorphic entities");
 	t00 = timestamp();
-	polymorphics0 = collect_polymorphic_entities_js(program, onlyBasicSpecializations);
+	polymorphics = collect_polymorphic_entities_js(program, onlyBasicSpecializations);
 
-	// For JS, we only specialize some polymorphism
-	polymorphics = if (onlyBasicSpecializations) filterTree(polymorphics0, \fn, type -> {
-		shouldThisTypeBeSpecializedJS(type);
-	}) else polymorphics0;
 	printStat = \prefix : string, size : int, ms : int -> {
 		fcVerbose(cfg, 0, prefix + ". size: " + i2s(size) + ", " + i2s(ms) + " ms");
 	}
@@ -251,61 +247,6 @@ specializeProgramJS(cfg : FcCommonConfig, program : FiProgram, onlyBasicSpeciali
 	fcVerbose(cfg, 0, "Specialization finished.");
 
 	result;
-}
-
-shouldThisTypeBeSpecializedJS(t : FiType) -> bool {
-	switch (t) {
-		FiTypeFunction(args, rt): {
-			// TODO: If there is exactly one polymorphic arg type
-			// that does not exist in the output, we are good
-			true;
-		}
-		default: false;
-	}
-}
-
-shouldThisSpecializationBeKeptJS(pt : FiType, ct : FiType) -> bool {
-	switch (pt) {
-		FiTypeFunction(pargs, prt): {
-			switch (ct) {
-				FiTypeFunction(cargs, crt): {
-					foldi(pargs, true, \i, acc, parg -> {
-						acc && shouldThisSpecializationBeKeptJS(parg.type, cargs[i].type)
-					}) && shouldThisSpecializationBeKeptJS(crt, crt)
-				}
-				default: false;
-			}
-		}
-		FiTypeParameter(tp): {
-			// We only keep basic type specializations
-			fiTypeIsBasic(ct);
-		}
-		FiTypeArray(pat): {
-			switch (ct) {
-				FiTypeArray(cat): shouldThisSpecializationBeKeptJS(pat, cat);
-				default: false;
-			}
-		}
-		FiTypeRef(prt): {
-			switch (ct) {
-				FiTypeRef(crt): shouldThisSpecializationBeKeptJS(prt, crt);
-				default: false;
-			}
-		}
-		FiTypeBool(): true;
-		FiTypeInt(): true;
-		FiTypeDouble(): true;
-		FiTypeString(): true;
-		FiTypeFlow(): true;
-		FiTypeVoid(): true;
-		FiTypeNative(): true;
-		FiTypeName(pn, ptypar): {
-			switch (ct) {
-				FiTypeName(cn, ctypar): forall(ctypar, fiTypeIsBasic);
-				default: false;
-			}
-		}
-	}
 }
 
 overrideWithSpecializationJS(original : [?], getKey : (?) -> ??, overrides : Tree<??, [?]>) -> [?] {


### PR DESCRIPTION
Current specialization code can't handle lambda with non-defined argument's type because it treats as generic but there is no code to handle generics in global lambdas

for example, simple test:
```
genericFn(arg : ?) -> string { "arg" }
lambda = \key -> { genericFn(key) }

main() {
    lambda("key");
    {}
}
```

compiles into

```
var A9__lambda=(function(key){
    return genericFn___c1(key);});
function main(){
  lambda___c1s("key");
    return null;
}
main();
```


in the branch it will compile into:
```
function A9__genericFn(arg){
  return "arg";
}
var A9__lambda___c1s=(function(key){
    return genericFn___c1s(key);});
function main(){
  A9__lambda___c1s("key");
    return null;
}
main();
```

it is not perfect fix because if some generic are used only inside lambda then the code will crash, but curator in the branch compiles and run seems correct because all generic functions mentioned inside lambdas are mentioned somewhere else in "normal" functions.
