### PR TITLE
[NOT FOR MERGING] findObjectByName

### DIFF
--- a/lib/formats/json/json.flow
+++ b/lib/formats/json/json.flow
@@ -125,10 +125,10 @@ getJsonFieldValueCustom(json : Json, field : string, def : Json, options : [Json
 
 findObjectByName(objects : [Pair<string, Json>], key : string, ignoreCase : bool, defaultValue : Json) -> Json {
 	key2 = if (ignoreCase) toLowerCase(key) else key;
-	findDef(objects, \o -> {
+	either(findmap(objects, \o -> {
 		k = if (ignoreCase) toLowerCase(o.first) else o.first;
-		k == key2
-	}, Pair(key2, defaultValue)).second
+		if (k == key2) Some(o.second) else None()
+	}), defaultValue)
 }
 
 getJsonArrayValue(json, def) {


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/19932962/80360055-713ce480-8887-11ea-8069-7d1587715dd2.png)

After:
![image](https://user-images.githubusercontent.com/19932962/80362018-941cc800-888a-11ea-9c7c-9fef0d25b265.png)


@andrejefimov  @yegordovganich  @alstrup 
What do you think about this? Total request time : before ~3.5 , after ~ 1.2-2.2
