### PR TITLE
Extended CharacterStyle to contain FSetDirection

### DIFF
--- a/lib/fform/fform.flow
+++ b/lib/fform/fform.flow
@@ -9,7 +9,7 @@ export {
 		FBaseline, FSize2, FAvailable2, FAccess, FRealHTML, FSetPending, FVideo, FTextInput, FDynamicGroup2, FNativeForm, FCanvas;
 
 	FText(text : Transform<string>, style : [FTextStyle]);
-		FTextStyle ::= CharacterStyle, FSetDirection, FDynamicColor;
+		FTextStyle ::= CharacterStyle, FDynamicColor;
 			FDynamicColor(color : Transform<int>);
 
 	FParagraph(text : Transform<string>, style : [FParagraphStyle]);
@@ -215,7 +215,6 @@ export {
 			FCursorWidth(width : Transform<double>);
 
 			FCharacterStyle(style : Transform<[CharacterStyle]>);
-			FSetDirection(rtl : bool);
 
 	// Draws content with 'canvas' renderer
 	// Works only in js with 'html' renderer, for other targets identical to regular clip

--- a/lib/form/optimizeform.flow
+++ b/lib/form/optimizeform.flow
@@ -322,6 +322,7 @@ joinText(t1 : string, s1 : [CharacterStyle], t2: string, s2 : [CharacterStyle]) 
 				Fill(c): fillcolour1 := c;
 				FillOpacity(o): fillopacity1 := o;
 				EscapeHTML(__): {}
+				FSetDirection(__): {}
 			}
 		});
 		mappedFont1 = getMappedFont(^fontfamily1, ^fontsize1);
@@ -358,6 +359,7 @@ joinText(t1 : string, s1 : [CharacterStyle], t2: string, s2 : [CharacterStyle]) 
 			}
 			Underlined(style) : underlined2 := Some(style);
 			EscapeHTML(__) : {}
+			FSetDirection(__) : {}
 			}
 		});
 		mappedFont2 = getMappedFont(^fontfamily2, ^fontsize2);

--- a/lib/formats/html/form2html.flow
+++ b/lib/formats/html/form2html.flow
@@ -166,6 +166,7 @@ text2htmlEx(textForm : Text, safe : bool) -> string {
 			BackgroundFillOpacity(opacity):	backgroundopacity := opacity;
 			Underlined(st): {}
 			EscapeHTML(__): {}
+			FSetDirection(__): {}
 		}
 	});
 

--- a/lib/stylestructs.flow
+++ b/lib/stylestructs.flow
@@ -1,5 +1,5 @@
 export {
-	CharacterStyle ::= BasicCharacterStyle, Underlined, Sharpness, EscapeHTML;
+	CharacterStyle ::= BasicCharacterStyle, Underlined, Sharpness, EscapeHTML, FSetDirection;
 	BasicCharacterStyle ::= FontFamily, FontSize, Fill, FillOpacity, LetterSpacing, BackgroundFill, BackgroundFillOpacity;
 		FontFamily : (name : string);
 		FontSize : (size : double);
@@ -23,6 +23,7 @@ export {
 		BackgroundFillOpacity : (opacity : double);
 		Underlined(style : [GraphicsStyle]);
 		EscapeHTML(escape : bool);
+		FSetDirection(rtl : bool);
 
 	GraphicsStyle ::= Fill, FillOpacity, GradientFill, RadialGradient, Stroke, StrokeOpacity, StrokeWidth, StrokeLineGradient;
 		// This is 0x00RRGGBB, and can not have alpha channel. Use StrokeOpacity for that.

--- a/lib/tropic/tropic_ui.flow
+++ b/lib/tropic/tropic_ui.flow
@@ -223,6 +223,7 @@ TTextButton(text : string, shortcut : string, style : [TTextButtonStyle], state 
 			StrokeWidth(__): acc;
 			TTextOnly(): acc;
 			EscapeHTML(__): acc;
+			FSetDirection(__): acc;
 
 			TWhite(): s;
 			TBlack(): s;
@@ -250,6 +251,7 @@ TTextButton(text : string, shortcut : string, style : [TTextButtonStyle], state 
 			FontFamily(__): arrayPush(acc, s);
 			Underlined(__): arrayPush(acc, s);
 			EscapeHTML(__): arrayPush(acc, s);
+			FSetDirection(__): arrayPush(acc, s);
 
 			StrokeWidth(__): acc;
 			TWhite(): acc;


### PR DESCRIPTION
It was found out that the following code is incorrect 
https://github.com/area9innovation/innovation/blame/master/lib/wigi/wigify.flow#L1227, because CharacterStyle doesn't contain FSetDirection. This causes crashes in https://github.com/area9innovation/flow9/blob/master/lib/form/optimizeform.flow#L309

This change fixes this. Maybe it's worth to rename FSetDirection to SetDirection.