### PR TITLE
Fix https://trello.com/c/OM0aYCKj/9362-deploying-packages-in-safari-corrupts-the-content

### DIFF
--- a/platforms/js/FlowFileSystem.hx
+++ b/platforms/js/FlowFileSystem.hx
@@ -10,7 +10,13 @@ typedef FlowFile = Dynamic; // cannos use js.html.File, because can be sliced to
 
 class FlowFileSystem {
 
-	public static function createTempFile(name : String, content : String) : js.html.File {
+	public static function createTempFile(name : String, content0 : String) : js.html.File {
+		var content = content0;
+		if (Platform.isSafari && content0.indexOf("å") != -1) {
+			// https://trello.com/c/OM0aYCKj/9362-deploying-packages-in-safari-corrupts-the-content
+			content = StringTools.replace(content0, "å",  "å\u200b");
+		}
+
 		return new js.html.File([content], name);
 	}
 
@@ -331,7 +337,7 @@ class FlowFileSystem {
 				switch (readAs : String) {
 					case "data": onData(file.data.toString());
 					case "uri":  onData(file.data.toString()); // Data URI building is not supported in flash
-					
+
 					// TODO add support for other encodings for flash target if needed.
 					default: onData(file.data.readUTF());
 				}


### PR DESCRIPTION
https://trello.com/c/OM0aYCKj/9362-deploying-packages-in-safari-corrupts-the-content

Safari replaces two-chars symbol  å (a&#x30a;) to one char å (&aring;)
it breaks fjson because of the length changes
this PR replace such symbol with extra zero-width space symbol