### PR TITLE
'UploadSelect' for uploadFile function

### DIFF
--- a/lib/net/http.flow
+++ b/lib/net/http.flow
@@ -349,18 +349,22 @@ uploadFile(url, params, headers, fileTypes, listeners) {
 	onOpen = extractStruct(listeners, UploadOpen(nop));
 	onProgress = extractStruct(listeners, UploadProgress(nop2));
 	onSelect = extractStruct(listeners, UploadSelect(\name, size -> {true}));
+	onSelectUnfit = extractStruct(listeners, UploadSelectUnfit(nop));
 	onCancel = extractStruct(listeners, UploadCancel(nop));
 
 	openFileDialog(1, fileTypes, \files -> {
 		if (length(files) > 0) {
-			onSelect.onSelect(fileNameClient(files[0]), trunc(fileSizeClient(files[0])));
-			uploadClientFile(
-				files[0], 
-				url, 
-				params,
-				headers,
-				[onData, onError, onOpen, onProgress]
-			) |> ignore;
+			if (onSelect.onSelect(fileNameClient(files[0]), trunc(fileSizeClient(files[0])))) {
+				uploadClientFile(
+					files[0], 
+					url, 
+					params,
+					headers,
+					[onData, onError, onOpen, onProgress]
+				) |> ignore;
+			} else {
+				onSelectUnfit.onSelectUnfit();
+			}
 		} else {
 			onCancel.onCancel();
 		}

--- a/lib/net/http_types.flow
+++ b/lib/net/http_types.flow
@@ -22,6 +22,8 @@ export {
 	UploadEventListener ::= UploadSelect, UploadCancel, UploadOnlyEventListener;
 		// Here we get the filename and the size.
 		UploadSelect(onSelect: (name: string, size: int) -> bool);
+		// What to do if the selected file doesn't fit
+		UploadSelectUnfit(onSelectUnfit : () -> void);
 		// If the user cancels openFileDialog
 		UploadCancel(onCancel: () -> void);
 


### PR DESCRIPTION
UploadSelect's result uses as a condition for calling the uploadClientFile().
- true: call uploadClientFile();
- false: use the callback of UploadSelectUnfit for tell the user why that file doesn't fit.

I'm not sure about the naming of UploadSelectUnfit structure.