### PR TITLE
Fixed Scheherazade standard font size is very small

### DIFF
--- a/lib/ui/fontmapping.flow
+++ b/lib/ui/fontmapping.flow
@@ -538,10 +538,16 @@ detectAlphabet(text : string) -> string {
 }
 
 getAlphabetScaling(alphabet : string, fontFamily : string) -> double {
+	isScheherazade = startsWith(fontFamily, "Scheherazade");
 	if (alphabet == "arb") {
-		// TODO per family scaling ratio.
-		1.4
-	} else 1.0
+		if (isScheherazade) {
+			2.5
+		} else 1.4
+	} else {
+		if (isScheherazade) {
+			1.5
+		} else 1.0
+	}
 }
 
 get2AlphabetsScaling(alphabet1 : string, alphabet2 : string, styles : [CharacterStyle]) -> double {


### PR DESCRIPTION
https://trello.com/c/Oaix9Pie/9259-scheherazade-standard-font-size-is-very-small-the-default-font-size-should-be-19-to-be-equivalent-to-tahoma-14

Before 
![image](https://user-images.githubusercontent.com/23188333/82692978-53398880-9c69-11ea-896a-b734c0826388.png)

After 
![image](https://user-images.githubusercontent.com/23188333/82692999-5d5b8700-9c69-11ea-96e4-8d8ad0f47670.png)
![image](https://user-images.githubusercontent.com/23188333/82693026-6a787600-9c69-11ea-8990-505048136068.png)

