### PR TITLE
json double with E parsing fixed

### DIFF
--- a/lib/formats/json/json.flow
+++ b/lib/formats/json/json.flow
@@ -276,7 +276,8 @@ parseJsonDouble(s : string, start : int) -> Pair<Json, int> {
 parseJsonDouble2(s : string, stringLength: int, start : int) -> Pair<Json, int> {
 	end = countUntil(start, stringLength, \i -> {
 		c = getCharCodeAt(s, i);
-		! ((48 <= c && c <= 57) || c == 46 || c == 45 || c == 101 || c == 43); // "0" <= c && c <= "9") || c == "." || c == "-" || c == "e" || c == "+"
+		// "0" <= c && c <= "9") || c == "." || c == "-" || c == "e" || c == "E" || c == "+"
+		! ((48 <= c && c <= 57) || c == 46 || c == 45 || c == 101 || c == 69 || c == 43);
 	});
 	Pair(JsonDouble(s2d(substring(s, start, end - start))), end);
 }


### PR DESCRIPTION
There is a strict check for `e` but sometimes it is `E` and it works the same way.

Without this change 0E-8 will cause an error.