### PR TITLE
padArray() fix

### DIFF
--- a/lib/ds/arrayutils.flow
+++ b/lib/ds/arrayutils.flow
@@ -312,22 +312,14 @@ foldi2(a : [?], init1 : ??, init2 : ???, fn : (int, ??, ???, ?) -> Pair<??, ???>
 }
 
 replaceAtAndPad(pad : ?, xs : [?], i : int, x : ?) -> [?] {
-	l = length(xs);
-
-	if (i < l) {
-		replace(xs, i, x)
-	} else if (i == l) {
-		arrayPush(xs, x)
-	} else {
-		arrayPush(padArray(xs, pad, i - l), x)
-	}
+	replace(padArray(xs, pad, i), i, x);
 }
 
 padArray(xs : [?], pad : ?, i : int) -> [?] {
-	if (i <= 0) {
+	if (i <= length(xs)) {
 		xs
 	} else {
-		padArray(arrayPush(xs, pad), pad, i - 1);
+		padArray(arrayPush(xs, pad), pad, i);
 	}
 }
 

--- a/lib/ds/arrayutils.flow
+++ b/lib/ds/arrayutils.flow
@@ -319,7 +319,7 @@ padArray(xs : [?], pad : ?, i : int) -> [?] {
 	if (i <= length(xs)) {
 		xs
 	} else {
-		padArray(arrayPush(xs, pad), pad, i);
+		concat(xs, arrayRepeat(pad, i - length(xs)));
 	}
 }
 


### PR DESCRIPTION
padArray(), as stated in its description (https://github.com/area9innovation/flow9/blob/master/lib/ds/arrayutils.flow#L58), is supposed to fill the given array till the given length but instead it adds the given length to the initial length.