### PR TITLE
https://trello.com/c/I6eDHyd5/10503-cursor-issue-arabic

### DIFF
--- a/lib/form/paragraph3.flow
+++ b/lib/form/paragraph3.flow
@@ -116,6 +116,8 @@ general2WrapElement(elem : GeneralWrapElement, style : [CharacterStyle]) -> Wrap
 makeAlphabetAwareTextField(txt : string, style : [CharacterStyle]) -> native {
 	overridden = applyAlphabetStyles(detectAlphabet(txt), style);
 	textfield = makeTextfield(getMappedFontFamily(overridden));
+	rtl = extractStruct(style, SetRTL(getDefaultRtl())).rtl;
+	setTextDirection(textfield, if (rtl) "rtl" else "ltr");
 	dstyle = getDefinedTextStyle(overridden);
 	setTextAndStyle(
 		textfield,

--- a/lib/ui/fontmapping.flow
+++ b/lib/ui/fontmapping.flow
@@ -32,6 +32,8 @@ export {
 	// Check if "lang" is one of RTL languages
 	isRTLLang(lang : string) -> bool;
 
+	isRtlAlphabet(alphabet : string) -> bool;
+
 	// Returns if BiDi support is enabled
 	isBiDiEnabled() -> bool;
 
@@ -350,6 +352,7 @@ setLangCore(lang0 : string) -> void{
 }
 
 rtlLanguages = ["ar", "he", "yi"];
+rtlAlphabets = ["arb", "heb"];
 
 getDefaultRtl() -> bool {
 	contains(rtlLanguages, getValue(currentLang));
@@ -361,6 +364,10 @@ getDefaultRtlB() -> Transform<bool> {
 
 isRTLLang(lang : string) -> bool {
 	contains(rtlLanguages, lang);
+}
+
+isRtlAlphabet(alphabet : string) -> bool {
+	contains(rtlAlphabets, alphabet);
 }
 
 isBiDiEnabled() -> bool {

--- a/platforms/js/TextClip.hx
+++ b/platforms/js/TextClip.hx
@@ -363,23 +363,6 @@ class TextClip extends NativeWidgetClip {
 		return [iso, iso, med, med];
 	}
 
-	// Given len is supposed to be measured from the beginning.
-	private static function getAdvancedWidthsCorrection(tm: TextMappedModification, style: TextStyle, textLen: Int, glyphsLen: Int, inGlyphBack: Int) : Int {
-		if (textLen < 1 || glyphsLen < 1) return 0;
-		var variant : Int = tm.variants[glyphsLen-1];
-		if (variant <= 1 && inGlyphBack == 0) return 0;
-		// Last char is initial or medial — will be mistakenly measured as
-		// isolated or final — correction needed.
-		var key : String = tm.text.substr(textLen-1, 1 + tm.difPositionMapping[glyphsLen-1]);
-		var nMetrics : Array<Array<Int>> = getAdvancedWidths(key, style);
-		if (key != tm.text.substr(textLen-1, 1)) {
-			key = tm.text.substr(textLen-1, 1 + tm.difPositionMapping[glyphsLen-1] - inGlyphBack);
-			var oMetrics : Array<Array<Int>> = getAdvancedWidths(key, style);
-			return nMetrics[variant][0]-oMetrics[variant&1][0];
-		}
-		return nMetrics[variant][0]-nMetrics[variant&1][0];
-	}
-
 	public static function measureTextModFrag(tm: TextMappedModification, style: TextStyle, b: Int, e: Int) : Float {
 		var bochi = -1;
 		var bgchi = -1;
@@ -399,16 +382,13 @@ class TextClip extends NativeWidgetClip {
 		if (bochi>b) { --bochi; ++bgb; }
 		if (eochi>e) { --eochi; ++egb; }
 		if (bochi > eochi || bochi < 0) return -1.0;
-		var advanceCorrection : Float = 0.0;
-
-		advanceCorrection = untyped (getAdvancedWidthsCorrection(tm, style, eochi, egchi, egb)-getAdvancedWidthsCorrection(tm, style, bochi, bgchi, bgb)) / UPM * style.fontSize;
 
 		var scriptingFixSuffix = "";  // Helps to keep substring ending letter form when measuring with Pixi.
 		if (isRtlChar(tm.text.substr(eochi, 1))) scriptingFixSuffix = "ث";  // Any letter with 4 variants.
 		var mtxb : Dynamic = pixi.core.text.TextMetrics.measureText(tm.text.substr(0, bochi)+scriptingFixSuffix, style);
 		var mtxe : Dynamic = pixi.core.text.TextMetrics.measureText(tm.text.substr(0, eochi)+scriptingFixSuffix, style);
 
-		return mtxe.width - mtxb.width + advanceCorrection;
+		return mtxe.width - mtxb.width;
 	}
 
 	public function getCharXPosition(charIdx: Int) : Float {

--- a/platforms/js/TextClip.hx
+++ b/platforms/js/TextClip.hx
@@ -193,7 +193,7 @@ class TextClip extends NativeWidgetClip {
 		return (code >= 0x30 && code < 0x3A)      // Decimals.
 			|| (code >= 0x41 && code < 0x5B)      // Capital basic latin.
 			|| (code >= 0x61 && code < 0x7B)      // Small basic latin.
-			|| (code >= 0xA0 && code < 0x590)     // Extended latin, diacritics, greeks, cyrillics, and other LTR alphabet letters, also symbols.
+			|| (code >= 0xA1 && code < 0x590)     // Extended latin, diacritics, greeks, cyrillics, and other LTR alphabet letters, also symbols.
 			|| (code >= 0x700 && code < 0x2000)   // Extended latin and greek, other LTR alphabet letters, also symbols.
 			|| (code >= 0x2100 && code < 0x2190)  // Punctuation, subscripts and superscripts, letterlikes, numerics, diacritics.
 			|| (code >= 0x2460 && code < 0x2500)  // Enclosed alphanums.
@@ -403,8 +403,10 @@ class TextClip extends NativeWidgetClip {
 
 		advanceCorrection = untyped (getAdvancedWidthsCorrection(tm, style, eochi, egchi, egb)-getAdvancedWidthsCorrection(tm, style, bochi, bgchi, bgb)) / UPM * style.fontSize;
 
-		var mtxb : Dynamic = pixi.core.text.TextMetrics.measureText(tm.text.substr(0, bochi), style);
-		var mtxe : Dynamic = pixi.core.text.TextMetrics.measureText(tm.text.substr(0, eochi), style);
+		var scriptingFixSuffix = "";  // Helps to keep substring ending letter form when measuring with Pixi.
+		if (isRtlChar(tm.text.substr(eochi, 1))) scriptingFixSuffix = "ث";  // Any letter with 4 variants.
+		var mtxb : Dynamic = pixi.core.text.TextMetrics.measureText(tm.text.substr(0, bochi)+scriptingFixSuffix, style);
+		var mtxe : Dynamic = pixi.core.text.TextMetrics.measureText(tm.text.substr(0, eochi)+scriptingFixSuffix, style);
 
 		return mtxe.width - mtxb.width + advanceCorrection;
 	}


### PR DESCRIPTION
JS target solution only. Non-breaking space no more LTR character in Haxe TextClip natives, alphabet direction function added, improved metrics for Arabic word parts via fooling pixijs.

Linked PR: https://github.com/area9innovation/innovation/pull/1808.