### PR TITLE
Flowc fontconfig relative path

### DIFF
--- a/tools/flowc/flowc_lsp.flow
+++ b/tools/flowc/flowc_lsp.flow
@@ -150,14 +150,14 @@ fcLspProcessRequest(conf : CompilerConfig, globEnv : FcTypeEnvGlobal, json : Jso
 					// TODO: handle properly
 					switch (lookupTree(fcLspServerState.requests, response.id)) {
 						Some(request): {
-							fcDebugLog("response to the request: " + 
+							fcServerLog("response to the request: " + 
 								json2string(lspRequestMessage2Json(request)) + ":\n" + 
 								json2string(lspResponseMessage2Json(response))
 								, conf
 							);
 						}
 						None(): {
-							fcDebugLog("unknown request: " + json2string(response.id), conf);
+							fcServerLog("unknown request: " + json2string(response.id), conf);
 						}
 					}
 					loop_cb();
@@ -326,7 +326,7 @@ fcLspTextDocumentDidChange(call: FcLspMethodCall) -> void {
 			);
 		}
 		None(): {
-			fcDebugLog("Failed to load a file " + json2string(call.params) + " ", call.conf);
+			fcServerLog("Failed to load a file " + json2string(call.params) + " ", call.conf);
 			call.out_cb(fcLspErrorResponse(call.id, 1, "text document item is invalid: " + json2string(call.params)));
 			call.loop_cb();
 		}

--- a/tools/flowc/flowc_remote.flow
+++ b/tools/flowc/flowc_remote.flow
@@ -41,21 +41,7 @@ runConfigRemote(conf : CompilerConfig, onData: (flow) -> void, onError : (string
 	serverUrl = 
 		"http://localhost:" +
 		getConfigParameterDef(conf.config, "server-port", "10001");
-	cwd = strReplace(resolveRelativePath("."), "\\", "/");
-	patchedConfig = CompilerConfig(conf with config =
-		setTree(
-			setTree(
-				switch (lookupTree(conf.config, "output-dir")) {
-					Some(__): conf.config;
-					None():   setTree(conf.config, "output-dir", cwd);
-				},
-				"file",
-				conf.flowfile
-			),
-			"working-dir",
-			lookupTreeDef(conf.config, "working-dir", cwd)
-		)
-	);
+	patchedConfig = patchRemoteConfig(conf);
 	serialized_server_job = 
 		isConfigParameterSet(conf.config, "compile-expression") || 
 		isConfigParameterTrue(conf.config, "dump-program");
@@ -85,4 +71,26 @@ runConfigRemote(conf : CompilerConfig, onData: (flow) -> void, onError : (string
 		},
 		false
 	)
+}
+
+patchRemoteConfig(conf : CompilerConfig) -> CompilerConfig {
+	cwd = strReplace(resolveRelativePath("."), "\\", "/");
+
+	// Setup the 'output-dir' in case it is not set explicitly.
+	conf1 = switch (lookupTree(conf.config, "output-dir")) {
+		Some(__): conf.config;
+		None():   setTree(conf.config, "output-dir", cwd);
+	}
+	// Add a flowfile as a config tree option.
+	conf2 = setTree(conf1, "file", conf.flowfile);
+
+	// Setup the 'working-dir' option
+	conf3 = setTree(conf2, "working-dir", lookupTreeDef(conf2, "working-dir", cwd));
+
+	// Resolve relative path for 'fontconfig-file', because server may run in a different place.
+	conf4 = switch (lookupTree(conf3, "fontconfig-file")) {
+		Some(file): setTree(conf3, "fontconfig-file", resolveRelativePath(file));
+		None():     conf3;
+	}
+	CompilerConfig(conf with config = conf4);
 }

--- a/tools/flowc/flowc_remote.flow
+++ b/tools/flowc/flowc_remote.flow
@@ -92,5 +92,11 @@ patchRemoteConfig(conf : CompilerConfig) -> CompilerConfig {
 		Some(file): setTree(conf3, "fontconfig-file", resolveRelativePath(file));
 		None():     conf3;
 	}
-	CompilerConfig(conf with config = conf4);
+
+	// Update 'fontconfig' field in JSCliParams
+	fontconfig = lookupTreeDef(conf4, "fontconfig-file", conf.jsParams.fontconfig);
+	jsParams = JSCliParams(conf.jsParams with fontconfig = fontconfig);
+
+	// Output the result
+	CompilerConfig(conf with config = conf4, jsParams = jsParams);
 }

--- a/tools/flowc/flowc_server.flow
+++ b/tools/flowc/flowc_server.flow
@@ -69,7 +69,7 @@ fcProcessRequest(serverConf : CompilerConfig, globEnv : FcTypeEnvGlobal, req : s
 }
 
 fcConsoleServer(config : CompilerConfig) -> void { 
-	fcServerLog("Console server started.", config);
+	fcServerLog("Console server started in: " + resolveRelativePath(".") + " directory", config);
 	fcSetSkipPrinting(config.threadId, true);
 	fcRunConsoleServer(initFcTypeEnvGlobal(), config);
 }
@@ -104,7 +104,7 @@ fcHttpServer(config : CompilerConfig) -> void {
 	server = ref nop;
 	server := createHttpServer(port,
 		\-> {
-			fcServerLog("Http server started.", config);
+			fcServerLog("Http server started in: " + resolveRelativePath(".") + " directory", config);
 			fcPrintln("Http server started.", config.threadId)
 		},
 		\request, response -> {

--- a/tools/flowc/flowc_version.flow
+++ b/tools/flowc/flowc_version.flow
@@ -2,5 +2,5 @@
 // Edit 'build-flowc' instead.
 export {
 	flowc_version = "3.0";
-	flowc_git_revision = "29e0604e8";
+	flowc_git_revision = "d079062bc";
 }

--- a/tools/flowc/flowc_version.flow
+++ b/tools/flowc/flowc_version.flow
@@ -2,5 +2,5 @@
 // Edit 'build-flowc' instead.
 export {
 	flowc_version = "3.0";
-	flowc_git_revision = "2f7ca4396";
+	flowc_git_revision = "29e0604e8";
 }

--- a/tools/flowc/flowc_version.flow
+++ b/tools/flowc/flowc_version.flow
@@ -2,5 +2,5 @@
 // Edit 'build-flowc' instead.
 export {
 	flowc_version = "3.0";
-	flowc_git_revision = "c1b28b34f";
+	flowc_git_revision = "f567f33af";
 }


### PR DESCRIPTION
Solution to: https://trello.com/c/CscV560c/735-flowc1-wrong-fontconfig-file-is-taken-in-in-server-mode