### PR TITLE
fontmapping: add setFontFamilyOverride

### DIFF
--- a/lib/ui/fontmapping.flow
+++ b/lib/ui/fontmapping.flow
@@ -61,6 +61,9 @@ export {
 	// Note that function may be called by renderForm very often, so it must be fast.
 	setDefaultFontMappingFn2(mappingFn : (string, double) -> Pair<string, double>) -> void;
 
+	// override font family for default font (works as defaultFont http-parameter but lower priority)
+	setFontFamilyOverride(familyM : Maybe<string>) -> void;
+
 	getNativeLangFromBCP(bcpLang : string) -> string;
 
 	getMappedFontFamily(style : [CharacterStyle]) -> string;
@@ -261,7 +264,17 @@ getChineseFontMinimal() -> FontFamily {
 //In case of change update getCharacterStyleFromWigiTextStyle
 defaultFontFamily_ = "Roboto";
 defaultFontSize_ = 11.0;
-defaultFontOverride_ = eitherGetUrlValidParameter("defaultFont", isValidIdentifier, idfn, defaultFontFamily_);
+defaultFontOverride_ = eitherGetUrlValidParameter("defaultFont", isValidIdentifier, idfn, "");
+fontFamilyOverride_ : ref Maybe<string> = ref None();
+
+setFontFamilyOverride(familyM : Maybe<string>) -> void {
+	fontFamilyOverride_ := familyM;
+}
+
+defaultFontFamilyOverride() -> string {
+	if (defaultFontOverride_ != "") defaultFontOverride_
+	else either(^fontFamilyOverride_,  defaultFontFamily_);
+}
 
 fontOverrides = eitherGetUrlValidParameterM("fontOverrides", \s -> {
 	fold(strSplit(s, ","), Some([]), \acc, raw -> {
@@ -294,7 +307,7 @@ getMappedFont_cache_key = ref Pair("", -1.0);
 getMappedFont_cache_value = ref Pair("", -1.0);
 
 getMappedFont(family : string, size : double) {
-	ffamily = if (family != "" && family != defaultFontFamily_) family else defaultFontOverride_;
+	ffamily = if (family != "" && family != defaultFontFamily_) family else defaultFontFamilyOverride();
 	if (ffamily != ^getMappedFont_cache_key.first || size != ^getMappedFont_cache_key.second) {
 		mappedFont =
 			if (ffamily == "MaterialIcons" || (ffamily == "'Material Icons'")) {


### PR DESCRIPTION
We need to set default font family from the app.
We will use it to set the font from a rhapsode skin property.