### PR TITLE
If java is not in the path, then give a warning

### DIFF
--- a/bin/flowc1.bat
+++ b/bin/flowc1.bat
@@ -1,6 +1,13 @@
 @echo off
 
 PATH %PATH%;%JAVA_HOME%\bin\
+
+where java
+if ERRORLEVEL 1 (
+	echo Java not found, please install OpenJDK 14 or newer, and set JAVA_HOME to the install location or add java to the path.
+	goto :eof
+)
+
 for /f tokens^=2-5^ delims^=.-_^" %%j in ('java -fullversion 2^>^&1') do set "jver=%%j"
 set argsFor8=
 if %jver% == 8 (set argsFor8=-XX:+UseConcMarkSweepGC -XX:ParallelCMSThreads=2)


### PR DESCRIPTION
This should make much easier to debug issues where Java is not in the path or if JAVA HOME is not defined. Before this the "flowcpp" and "update.bat" tools will give strange errors. Some thing like "(set not expected". 