### PR TITLE
don't add empty style

### DIFF
--- a/lib/formats/html/form2html.flow
+++ b/lib/formats/html/form2html.flow
@@ -37,10 +37,18 @@ export {
 fontName2css(name : string) -> string {
 	// Converts font to a proper html CSS "style" string.
 	// https://fonts.googleapis.com/css?family=Roboto:regular,bold,italic,thin,light,bolditalic,black,medium&lang=en
-	fontFace2css = \font : FontFace -> formatString(
-		"font-family:%1;font-style:%2;font-weight:%3;",
-		[fontFace2familiesString(font), font.slope, i2s(font.weight)]
-	);
+	fontFace2css = \font : FontFace -> {
+		fontStyle = if (font.slope == FONT_SLOPE_NORMAL) {
+			// ignore empty style
+			""
+		} else {
+			formatString("font-style:%2;", [font.slope]);
+		}
+		formatString(
+			"font-family:%1;%2font-weight:%3;",
+			[fontFace2familiesString(font), fontStyle, i2s(font.weight)]
+		);
+	}
 
 	fontFace2css(fontName2fontFace(name));
 }

--- a/lib/formats/html/form2html.flow
+++ b/lib/formats/html/form2html.flow
@@ -38,13 +38,10 @@ fontName2css(name : string) -> string {
 	// Converts font to a proper html CSS "style" string.
 	// https://fonts.googleapis.com/css?family=Roboto:regular,bold,italic,thin,light,bolditalic,black,medium&lang=en
 	fontFace2css = \font : FontFace -> {
-		fontStyle = if (font.slope == FONT_SLOPE_NORMAL) {
-			"font-style:normal;"  //FONT_SLOPE_NORMAL was "normal" before, now it is empty string, so this code branch solves it.
-		} else {
-			formatString("font-style:%2;", [font.slope]);
-		}
+		// font-style can't be empty string
+		fontStyle = if (font.slope == FONT_SLOPE_NORMAL) "normal" else font.slope;
 		formatString(
-			"font-family:%1;%2font-weight:%3;",
+			"font-family:%1;font-style:%2;font-weight:%3;",
 			[fontFace2familiesString(font), fontStyle, i2s(font.weight)]
 		);
 	}

--- a/lib/formats/html/form2html.flow
+++ b/lib/formats/html/form2html.flow
@@ -39,8 +39,7 @@ fontName2css(name : string) -> string {
 	// https://fonts.googleapis.com/css?family=Roboto:regular,bold,italic,thin,light,bolditalic,black,medium&lang=en
 	fontFace2css = \font : FontFace -> {
 		fontStyle = if (font.slope == FONT_SLOPE_NORMAL) {
-			// ignore empty style
-			""
+			"font-style:normal;"  //FONT_SLOPE_NORMAL was "normal" before, now it is empty string, so this code branch solves it.
 		} else {
 			formatString("font-style:%2;", [font.slope]);
 		}


### PR DESCRIPTION
gmail removes styles completely if something is incorrect inside.

before
![image](https://user-images.githubusercontent.com/19932962/95455877-29ae9e80-0977-11eb-90aa-7400d221103b.png)

after
![image](https://user-images.githubusercontent.com/19932962/95455931-3c28d800-0977-11eb-82bf-633bd94afe03.png)

![image](https://user-images.githubusercontent.com/19932962/95456546-2962d300-0978-11eb-8632-1dc39dff7d86.png)

