### PR TITLE
parseJson: improve memory footprint using string table in object2JsonStructs native

### DIFF
--- a/platforms/js/Native.hx
+++ b/platforms/js/Native.hx
@@ -1803,7 +1803,7 @@ class Native {
 	static var sidJsonObjectFields : String;
 
 	// Chrome and maybe other browsers faster with for(var f in o) that with Object.getOwnPropertyNames
-	private static function object2JsonStructs(o : Dynamic) : Dynamic {
+	private static function object2JsonStructs(o : Dynamic, strDict : Dynamic) : Dynamic {
 		untyped __js__("
 		if (Array.isArray(o)) {
 			var a1 = Native.map(o,Native.object2JsonStructs);
@@ -1828,9 +1828,14 @@ class Native {
 					} else {
 						var mappedFields = [];
 						for(var f in o) {
-							var a2 = Native.object2JsonStructs(o[f]);
+							var a2 = Native.object2JsonStructs(o[f], strDict);
 							var obj = { _id : Native.sidPair };
-							obj[Native.sidPairFirst] = f;
+							var cf = strDict[f];
+							if (cf === undefined) {
+								cf = f;
+								strDict[f] = cf;
+							}
+							obj[Native.sidPairFirst] = cf;
 							obj[Native.sidPairSecond] = a2;
 							mappedFields.push(obj);
 						}
@@ -1845,7 +1850,7 @@ class Native {
 	}
 
 	// Firefox and maybe other browsers faster with Object.getOwnPropertyNames that with for(var f in o)
-	private static function object2JsonStructs_FF(o : Dynamic) : Dynamic {
+	private static function object2JsonStructs_FF(o : Dynamic, strDict : Dynamic) : Dynamic {
 		untyped __js__("
 		if (Array.isArray(o)) {
 			var a1 = Native.map(o,Native.object2JsonStructs_FF);
@@ -1871,9 +1876,15 @@ class Native {
 						var mappedFields = Object.getOwnPropertyNames(o);
 						for(var i=0; i< mappedFields.length; i++) {
 							var f = mappedFields[i];
-							var a2 = Native.object2JsonStructs_FF(o[f]);
+							var cf = strDict[f];
+							if (cf === undefined) {
+								cf = f;
+								strDict[f] = cf;
+							}
+
+							var a2 = Native.object2JsonStructs_FF(o[f], strDict);
 							var obj = { _id : Native.sidPair };
-							obj[Native.sidPairFirst] = f;
+							obj[Native.sidPairFirst] = cf;
 							obj[Native.sidPairSecond] = a2;
 							mappedFields[i] = obj;
 						}
@@ -1914,7 +1925,7 @@ class Native {
 				parseJsonFirstCall = false;
 			}
 
-			return Platform.isFirefox ? object2JsonStructs_FF(haxe.Json.parse(json)) : object2JsonStructs(haxe.Json.parse(json));
+			return Platform.isFirefox ? object2JsonStructs_FF(haxe.Json.parse(json), untyped __js__("{}")) : object2JsonStructs(haxe.Json.parse(json), untyped __js__("{}"));
 		} catch (e : Dynamic) {
 			return makeStructValue("JsonDouble", [0.0], null);
 		}


### PR DESCRIPTION
measured using http://localhost/rhapsode/flowjs.html?name=learner&new=1&compacting=0&i=yegor.dovganich@area9.dk#home
final point is Dashboard screen after all activities are completed and GC collects garbage

compactJson does not give any measurable improvments.
string table cache on object2JsonStructs level does improve (Safari, MacOS):
final memory usage in the same test reduced from 361-371 down to 293-295 Mb
Peak memory uage reduced too from 842-847 down to 721-755 Mb

https://trello-attachments.s3.amazonaws.com/5a4a73d7f5ecb00ce1364e40/5f0f28a54b14f43d974a5260/635c19ff518e29384eebd6ba2a64c1ce/image.png

Chrome:
87 -> 69 Mb

FireFox (can't measure because it does not show memory usage, just allows to take stapshot):
263 -> 261 Mb

screenshot for Safari@MacOS:
![image](https://user-images.githubusercontent.com/14361571/95837688-8cbe7d80-0d49-11eb-8482-4d31fbd67a7a.png)
