### PR TITLE
DisplayObjectHelper: tune critical functions

### DIFF
--- a/platforms/js/DisplayObjectHelper.hx
+++ b/platforms/js/DisplayObjectHelper.hx
@@ -1757,25 +1757,6 @@ class DisplayObjectHelper {
 	}
 
 	public static function findNextNativeWidget(clip : DisplayObject, parent : DisplayObject) : Element {
-		// if (clip.parent != null) {
-		// 	var children = clip.parent.children;
-
-		// 	if (children.indexOf(clip) >= 0) {
-		// 		for (child in children.slice(children.indexOf(clip) + 1)) {
-		// 			if (untyped child.visible && (!isNativeWidget(child) || (child.onStage && child.parentClip == parent))) {
-		// 				var nativeWidget = findNativeWidgetChild(child, parent);
-
-		// 				if (nativeWidget != null) {
-		// 					return nativeWidget;
-		// 				}
-		// 			}
-		// 		}
-		// 	}
-
-		// 	return RenderSupport.RenderContainers || isNativeWidget(clip.parent) ? null : findNextNativeWidget(clip.parent, parent);
-		// }
-
-		// return null;
 		untyped __js__("
 		if(clip.parent != null) {
 			var children = clip.parent.children;
@@ -1802,21 +1783,6 @@ class DisplayObjectHelper {
 	}
 
 	public static function findNativeWidgetChild(clip : DisplayObject, parent : DisplayObject) : Element {
-		// if (untyped isNativeWidget(clip) && clip.parentClip == parent && getParentNode(clip) == parent.nativeWidget) {
-		// 	return untyped clip.nativeWidget;
-		// } else if (!RenderSupport.RenderContainers && RenderSupport.RendererType == "html") {
-		// 	for (child in getClipChildren(clip)) {
-		// 		if (untyped child.visible && (!isNativeWidget(child) || child.parentClip == parent)) {
-		// 			var nativeWidget = findNativeWidgetChild(child, parent);
-
-		// 			if (nativeWidget != null) {
-		// 				return nativeWidget;
-		// 			}
-		// 		}
-		// 	}
-		// }
-
-		// return null;
 		untyped __js__("
 		if(DisplayObjectHelper.isNativeWidget(clip) && clip.parentClip == parent && DisplayObjectHelper.getParentNode(clip) == parent.nativeWidget) {
 			return clip.nativeWidget;

--- a/platforms/js/DisplayObjectHelper.hx
+++ b/platforms/js/DisplayObjectHelper.hx
@@ -1706,7 +1706,7 @@ class DisplayObjectHelper {
 		}
 	}
 
-	public static function isNativeWidget(clip : DisplayObject) : Bool {
+	public static inline function isNativeWidget(clip : DisplayObject) : Bool {
 		return untyped clip.isNativeWidget;
 	}
 

--- a/platforms/js/DisplayObjectHelper.hx
+++ b/platforms/js/DisplayObjectHelper.hx
@@ -1757,41 +1757,81 @@ class DisplayObjectHelper {
 	}
 
 	public static function findNextNativeWidget(clip : DisplayObject, parent : DisplayObject) : Element {
-		if (clip.parent != null) {
+		// if (clip.parent != null) {
+		// 	var children = clip.parent.children;
+
+		// 	if (children.indexOf(clip) >= 0) {
+		// 		for (child in children.slice(children.indexOf(clip) + 1)) {
+		// 			if (untyped child.visible && (!isNativeWidget(child) || (child.onStage && child.parentClip == parent))) {
+		// 				var nativeWidget = findNativeWidgetChild(child, parent);
+
+		// 				if (nativeWidget != null) {
+		// 					return nativeWidget;
+		// 				}
+		// 			}
+		// 		}
+		// 	}
+
+		// 	return RenderSupport.RenderContainers || isNativeWidget(clip.parent) ? null : findNextNativeWidget(clip.parent, parent);
+		// }
+
+		// return null;
+		untyped __js__("
+		if(clip.parent != null) {
 			var children = clip.parent.children;
-
-			if (children.indexOf(clip) >= 0) {
-				for (child in children.slice(children.indexOf(clip) + 1)) {
-					if (untyped child.visible && (!isNativeWidget(child) || (child.onStage && child.parentClip == parent))) {
-						var nativeWidget = findNativeWidgetChild(child, parent);
-
-						if (nativeWidget != null) {
+			if(children.indexOf(clip) >= 0) {
+				for(var child in children.slice(children.indexOf(clip) + 1)) {
+					if(child.visible && (!DisplayObjectHelper.isNativeWidget(child) || child.onStage && child.parentClip == parent)) {
+						var nativeWidget = DisplayObjectHelper.findNativeWidgetChild(child,parent);
+						if(nativeWidget != null) {
 							return nativeWidget;
 						}
 					}
 				}
 			}
-
-			return RenderSupport.RenderContainers || isNativeWidget(clip.parent) ? null : findNextNativeWidget(clip.parent, parent);
+			if(RenderSupport.RenderContainers || DisplayObjectHelper.isNativeWidget(clip.parent)) {
+				return null;
+			} else {
+				return DisplayObjectHelper.findNextNativeWidget(clip.parent,parent);
+			}
 		}
+		return null;
+		");
 
 		return null;
 	}
 
 	public static function findNativeWidgetChild(clip : DisplayObject, parent : DisplayObject) : Element {
-		if (untyped isNativeWidget(clip) && clip.parentClip == parent && getParentNode(clip) == parent.nativeWidget) {
-			return untyped clip.nativeWidget;
-		} else if (!RenderSupport.RenderContainers && RenderSupport.RendererType == "html") {
-			for (child in getClipChildren(clip)) {
-				if (untyped child.visible && (!isNativeWidget(child) || child.parentClip == parent)) {
-					var nativeWidget = findNativeWidgetChild(child, parent);
+		// if (untyped isNativeWidget(clip) && clip.parentClip == parent && getParentNode(clip) == parent.nativeWidget) {
+		// 	return untyped clip.nativeWidget;
+		// } else if (!RenderSupport.RenderContainers && RenderSupport.RendererType == "html") {
+		// 	for (child in getClipChildren(clip)) {
+		// 		if (untyped child.visible && (!isNativeWidget(child) || child.parentClip == parent)) {
+		// 			var nativeWidget = findNativeWidgetChild(child, parent);
 
-					if (nativeWidget != null) {
+		// 			if (nativeWidget != null) {
+		// 				return nativeWidget;
+		// 			}
+		// 		}
+		// 	}
+		// }
+
+		// return null;
+		untyped __js__("
+		if(DisplayObjectHelper.isNativeWidget(clip) && clip.parentClip == parent && DisplayObjectHelper.getParentNode(clip) == parent.nativeWidget) {
+			return clip.nativeWidget;
+		} else if(!RenderSupport.RenderContainers && RenderSupport.RendererType == 'html') {
+			for (var child in clip.children || []) {
+				if(child.visible && (!DisplayObjectHelper.isNativeWidget(child) || child.parentClip == parent)) {
+					var nativeWidget = DisplayObjectHelper.findNativeWidgetChild(child,parent);
+					if(nativeWidget != null) {
 						return nativeWidget;
 					}
 				}
 			}
 		}
+		return null;
+		");
 
 		return null;
 	}


### PR DESCRIPTION
It reduce time to render from 9 seconds down to 6. profiler data looks better too

![image](https://user-images.githubusercontent.com/14361571/96598084-2f9d6b80-12f7-11eb-95f4-6ba62a563763.png)


with last commit:
![image](https://user-images.githubusercontent.com/14361571/96610186-03d4b280-1304-11eb-9d40-752d4f798a25.png)
