### PR TITLE
getJsonStringValue - bool2string added

### DIFF
--- a/lib/formats/json/json.flow
+++ b/lib/formats/json/json.flow
@@ -169,7 +169,7 @@ getJsonStringValue(json : Json, def : string) -> string {
 	switch (json : Json) {
 		JsonString(s): s;
 		JsonDouble(d): d2s(d);
-		JsonBool(b): if (b) "true" else "false";
+		JsonBool(b): b2s(b);
 		default: def;
 	}
 }

--- a/lib/formats/json/json.flow
+++ b/lib/formats/json/json.flow
@@ -169,6 +169,7 @@ getJsonStringValue(json : Json, def : string) -> string {
 	switch (json : Json) {
 		JsonString(s): s;
 		JsonDouble(d): d2s(d);
+		JsonBool(b): if (b) "true" else "false";
 		default: def;
 	}
 }


### PR DESCRIPTION
`getJsonBoolValue` is working with `JsonString` but `getJsonStringValue` cant get value from `JsonBool`.
Seems like it was never needed.
Added a convertation from bool to string.

Usages of this function seems not to work with bool, but I checked it briefly and only what I could find my projects.