### PR TITLE
JS. getClipAt. Check pixel alpha.

### DIFF
--- a/lib/fform/renderfform.flow
+++ b/lib/fform/renderfform.flow
@@ -201,7 +201,6 @@ renderFForm(rform : FForm, zorder : Transform<[int]>) -> FRenderResult {
 						}
 						InspectRealSize(fn): realSizeFn := fn;
 						AltText(text): picAltText := text;
-						default : {};
 					}
 				);
 
@@ -275,8 +274,6 @@ renderFForm(rform : FForm, zorder : Transform<[int]>) -> FRenderResult {
 							^picAltText
 						);
 					}
-
-				if (contains(style, TransparentForInput())) setPictureTransparentForInput(picture);
 
 				FRenderResult(
 					[picture],

--- a/lib/form/form.flow
+++ b/lib/form/form.flow
@@ -46,15 +46,13 @@ Graphics : (path : [StaticGraphicOp], style : [GraphicsStyle]);
 
 /// A static picture
 Picture : (url : string, style : [PictureStyle]);
-	PictureStyle ::= DontCache, OnlyDownloadToCache, OnLoadingError, OnLoaded, InspectRealSize, AltText, TransparentForInput;
+	PictureStyle ::= DontCache, OnlyDownloadToCache, OnLoadingError, OnLoaded, InspectRealSize, AltText;
 	DontCache : ();
 	OnlyDownloadToCache : ();
 	OnLoadingError : (fn : (string) -> void);
 	OnLoaded : (fn : ()->void);
 	InspectRealSize : (fn : (WidthHeight) -> void);
 	AltText : (text : string);
-	// JS only. Do not prevent default for input click event.
-	TransparentForInput();
 
 Camera : (filename : string, parameters : [RecordParameter], listeners: [RecordStreamEvent], controls: [RecordControl]);
 // Tested with Wowza Media Server 3.6

--- a/lib/form/formtransforms.flow
+++ b/lib/form/formtransforms.flow
@@ -147,7 +147,6 @@ takeFormSnapshot(f) {
 				DontCache() : true;
 				OnlyDownloadToCache() : true;
 				AltText(__): true;
-				TransparentForInput() : true;
 			}
 		});
 		Picture(url, filteredStyle)

--- a/lib/form/renderform.flow
+++ b/lib/form/renderform.flow
@@ -291,7 +291,6 @@ renderForm(rform : Form, available : Behaviour<WidthHeight>, zorder : [int], tab
 				};
 				InspectRealSize(fn): realSizeFn := fn;
 				AltText(text): picAltText := text;
-				default : {};
 			});
 			widthHeight = make(zeroWH);
 			baseline = make(0.0);
@@ -316,7 +315,6 @@ renderForm(rform : Form, available : Behaviour<WidthHeight>, zorder : [int], tab
 					println(e);
 				}
 			}, ^onlydl, ^picAltText);
-			if (contains(style, TransparentForInput())) setPictureTransparentForInput(picture);
 
 			RenderResult(
 				[picture], widthHeight, baseline, pending,

--- a/lib/material/iscript/material_iscript_form.flow
+++ b/lib/material/iscript/material_iscript_form.flow
@@ -112,7 +112,6 @@ takeLogicalSnapshot(f : FForm) -> IScriptForm {
 					DontCache() : true;
 					OnlyDownloadToCache() : true;
 					AltText(__) : true;
-					TransparentForInput() : true;
 				}
 			});
 			FPicture(url, make(getValue(sz)), filteredStyle)

--- a/lib/rendersupport.flow
+++ b/lib/rendersupport.flow
@@ -426,7 +426,7 @@ setContentRect(clip, width, height) {}
 listenScrollRect(clip, cb) { nop; }
 setApplicationLanguage(lang) { }
 
-setPictureTransparentForInput(picture : native) -> void {}
+setPictureTransparentForInput(picture) -> void {}
 
 getSafeArea() { [0.0, 0.0, 0.0, 0.0]; }
 

--- a/lib/rendersupport.flow
+++ b/lib/rendersupport.flow
@@ -102,7 +102,6 @@ export {
 		url : string, cache : bool, metricsFn : (width : double, height : double) -> void,
 		errorFn : (string) -> void, onlyDownload : bool, altText : string
 	) -> native = RenderSupport.makePicture;
-	native setPictureTransparentForInput : io (picture : native) -> void = RenderSupport.setPictureTransparentForInput;
 	native makeVideo : io (
 		metricsFn : (width : double, height : double) -> void, playFn : (playing : bool) -> void,
 		durationFn : (length : double) -> void, positionFn : (position : double) -> void
@@ -425,8 +424,6 @@ setEscapeHTML(textfield, escape) {}
 setContentRect(clip, width, height) {}
 listenScrollRect(clip, cb) { nop; }
 setApplicationLanguage(lang) { }
-
-setPictureTransparentForInput(picture) -> void {}
 
 getSafeArea() { [0.0, 0.0, 0.0, 0.0]; }
 

--- a/platforms/js/FlowSprite.hx
+++ b/platforms/js/FlowSprite.hx
@@ -382,6 +382,7 @@ class FlowSprite extends Sprite {
 			nativeWidget = Browser.document.createElement(tagName);
 			this.updateClipID();
 
+			nativeWidget.crossOrigin = Util.determineCrossOrigin(url);
 			nativeWidget.onload = onLoaded;
 			nativeWidget.onerror = onError;
 			nativeWidget.src = url;

--- a/platforms/js/FlowSprite.hx
+++ b/platforms/js/FlowSprite.hx
@@ -41,7 +41,6 @@ class FlowSprite extends Sprite {
 	public var isNativeWidget : Bool = false;
 	public var keepNativeWidget : Bool = false;
 	public var keepNativeWidgetChildren : Bool = false;
-	public var transparentForInput : Bool = false;
 	private var disposed : Bool = false;
 
 	private static inline var MAX_CHACHED_IMAGES : Int = 50;

--- a/platforms/js/RenderSupport.hx
+++ b/platforms/js/RenderSupport.hx
@@ -2464,13 +2464,15 @@ class RenderSupport {
 			var clipWidth = untyped clip.getWidth();
 			var clipHeight = untyped clip.getHeight();
 			if (checkAlpha != null && untyped HaxeRuntime.instanceof(clip, FlowSprite)) {
-				var tempCanvas = Browser.document.createElement('canvas');
-				untyped tempCanvas.width = clipWidth;
-				untyped tempCanvas.height = clipHeight;
-				var ctx = untyped tempCanvas.getContext('2d');
-				untyped ctx.drawImage(clip.nativeWidget, 0, 0, clipWidth, clipHeight);
-				var pixel = ctx.getImageData(point.x, point.y, 1, 1);
-				if (pixel.data[3] / 255 < checkAlpha) return null;
+				try {
+					var tempCanvas = Browser.document.createElement('canvas');
+					untyped tempCanvas.width = clipWidth;
+					untyped tempCanvas.height = clipHeight;
+					var ctx = untyped tempCanvas.getContext('2d');
+					untyped ctx.drawImage(clip.nativeWidget, 0, 0, clipWidth, clipHeight);
+					var pixel = ctx.getImageData(local.x, local.y, 1, 1);
+					if (pixel.data[3] * clip.worldAlpha / 255 < checkAlpha) return null;
+				} catch (e : Dynamic) {}
 			}
 
 			if (local.x >= 0.0 && local.y >= 0.0 && local.x <= clipWidth && local.y <= clipHeight) {

--- a/platforms/js/RenderSupport.hx
+++ b/platforms/js/RenderSupport.hx
@@ -2456,7 +2456,6 @@ class RenderSupport {
 		}
 
 		if (untyped HaxeRuntime.instanceof(clip, NativeWidgetClip) || untyped HaxeRuntime.instanceof(clip, FlowSprite)) {
-			if (untyped HaxeRuntime.instanceof(clip, FlowSprite) && clip.transparentForInput) return null;
 			if (untyped clip.worldTransformChanged) {
 				untyped clip.transform.updateTransform(clip.parent.transform);
 			}
@@ -2576,10 +2575,6 @@ class RenderSupport {
 
 	public static function makePicture(url : String, cache : Bool, metricsFn : Float -> Float -> Void, errorFn : String -> Void, onlyDownload : Bool, altText : String) : Dynamic {
 		return new FlowSprite(url, cache, metricsFn, errorFn, onlyDownload, altText);
-	}
-
-	public static function setPictureTransparentForInput(picture : FlowSprite) {
-		picture.transparentForInput = true;
 	}
 
 	public static function cursor2css(cursor : String) : String {

--- a/platforms/js/RenderSupport.hx
+++ b/platforms/js/RenderSupport.hx
@@ -2463,6 +2463,15 @@ class RenderSupport {
 			var local : Point = untyped __js__('clip.toLocal(point, null, null, true)');
 			var clipWidth = untyped clip.getWidth();
 			var clipHeight = untyped clip.getHeight();
+			if (checkAlpha != null && untyped HaxeRuntime.instanceof(clip, FlowSprite)) {
+				var tempCanvas = Browser.document.createElement('canvas');
+				untyped tempCanvas.width = clipWidth;
+				untyped tempCanvas.height = clipHeight;
+				var ctx = untyped tempCanvas.getContext('2d');
+				untyped ctx.drawImage(clip.nativeWidget, 0, 0, clipWidth, clipHeight);
+				var pixel = ctx.getImageData(point.x, point.y, 1, 1);
+				if (pixel.data[3] / 255 < checkAlpha) return null;
+			}
 
 			if (local.x >= 0.0 && local.y >= 0.0 && local.x <= clipWidth && local.y <= clipHeight) {
 				return clip;


### PR DESCRIPTION
We need it for https://trello.com/c/enLKYnGG/11767-mobile-device-frames-looks-bad.
Is there a better way to detect pixel data from img?
Or maybe even get rid of the check? https://github.com/area9innovation/flow9/blob/master/platforms/js/TextClip.hx#L1072