### PR TITLE
fixed processing of MDialog's `closeWhen` parameter

### DIFF
--- a/lib/material/internal/material_dialog_internal.flow
+++ b/lib/material/internal/material_dialog_internal.flow
@@ -87,6 +87,17 @@ renderMDialog2(
 	m2t : (Material, MFocusGroup) -> Tropic,
 	renderFn : (Tropic) -> () -> void) -> void {
 
+	if (!fgetValue(closeWhen)) renderMDialog3(manager, closeWhen, style, content, m2t, renderFn)
+}
+
+renderMDialog3(
+	manager : MaterialManager,
+	closeWhen : Transform<bool>,
+	style : [MDialogStyle],
+	content : Material,
+	m2t : (Material, MFocusGroup) -> Tropic,
+	renderFn : (Tropic) -> () -> void) -> void {
+
 	us = ref [];
 	disp = \ -> dispUnsA(us);
 
@@ -103,10 +114,10 @@ renderMDialog2(
 
 	u1 =
 		switch (closeWhen : Transform<bool>) {
-			DynamicBehaviour(__, __): {
-				subscribe2(closeWhen, \__ -> disp());
+			DynamicBehaviour(val, __): {
+				subscribe2(closeWhen, \__ -> if (^val) disp());
 			}
-			default: makeSubscribe2(closeWhen, \__ -> disp())();
+			default: makeSubscribe2(closeWhen, \val -> if (val) disp())();
 		};
 
 	title = tryExtractStruct(style, MDialogTitle(""));


### PR DESCRIPTION
- close MDialog when `closeWhen` is really changed to true (previously it was closed whenever `closeWhen` was changed to any value)
- do not open MDialog if `closeWhen` is false