### PR TITLE
Fix return SQL Ints

### DIFF
--- a/platforms/java/com/area9innovation/flow/Database.java
+++ b/platforms/java/com/area9innovation/flow/Database.java
@@ -277,6 +277,7 @@ public class Database extends NativeHost {
                 case (Types.NULL):
                     value = anull;
                     break;
+                case (Types.BIGINT): // Session variables in MySql are either bigint or longtext. Without this they are both converted to SString
                 case (Types.INTEGER):
                 case (Types.TINYINT):
                 case (Types.SMALLINT):


### PR DESCRIPTION
A session variable is a variable that begins with "@". For example:

CALL my_stored_procedure(1, @v);
SELECT @v;

If the stored procedure have an out variable that is of type int, then the type of @v will be bigint(20).

With out this fix the session variable is returned as SString. With this fix some of them are returned as SInt. 

I think there are a risk that this will break some code that depends on bigint being an SString. 
