### PR TITLE
MouseDownInfo: introduce insideY fn

### DIFF
--- a/lib/form/form.flow
+++ b/lib/form/form.flow
@@ -279,7 +279,7 @@ Interactive : (listeners: [EventHandler], form : Form);
 	MouseWheelInfo(dx : double, dy : double, inside : bool);
 	TouchInfo(points : [Point], inside : [() -> bool]);
 
-	MouseDownInfo(x : double, y : double, inside : () -> bool);
+	MouseDownInfo(x : double, y : double, inside : () -> bool, insideY : () -> bool);
 
 	// Shares the list of event handlers with MouseMove2 handlers.
 	// Thus, Form with MouseMove handler prevents underlying one's scrolling,

--- a/lib/sys/interactive.flow
+++ b/lib/sys/interactive.flow
@@ -21,6 +21,7 @@ getTouchPoints(clip : native) -> [[double]] {
 }
 
 native hittest : io (clip : native, x : double, y : double) -> bool = RenderSupport.hittest;
+native insideY : io (clip : native, x : double, y : double) -> bool = RenderSupport.insideY;
 native addMouseWheelEventListener : io (clip : native, cb : (delta : double) -> void) -> (() -> void) = RenderSupport.addMouseWheelEventListener;
 
 handleRealEvents(l : EventHandler, clip : native, clipalive : ref bool, stage : native, zorder : [int], doHittest : bool, doRespectHandled : bool) -> () -> void {
@@ -87,9 +88,15 @@ handleRealEvents(l : EventHandler, clip : native, clipalive : ref bool, stage : 
 	miDownHandler = \fn : (handled : bool, mi : MouseDownInfo) -> bool -> {
 		\handled : bool, mi : GetMouseInfo -> {
 			if (^clipalive && !(handled && doRespectHandled) && getClipRenderable(clip)) {
-				mdi = MouseDownInfo(getMouseX(clip), getMouseY(clip), \ -> {
-					^clipalive && doHittest && getClipRenderable(clip) && hittest(clip, getMouseX(stage), getMouseY(stage))
-				});
+				mdi = MouseDownInfo(
+					getMouseX(clip),
+					getMouseY(clip),
+					\ -> {
+						^clipalive && doHittest && getClipRenderable(clip) && hittest(clip, getMouseX(stage), getMouseY(stage))
+					},
+					\ -> {
+						^clipalive && getClipRenderable(clip) && insideY(clip, getMouseX(stage), getMouseY(stage))
+					});
 				fn(handled, mdi)
 			} else handled
 		}
@@ -199,4 +206,3 @@ handleRealEvents(l : EventHandler, clip : native, clipalive : ref bool, stage : 
 		RespectHandled(e): handleRealEvents(e, clip, clipalive, stage, zorder, doHittest, true);
 	}
 }
-

--- a/lib/tropic/tropic_gui.flow
+++ b/lib/tropic/tropic_gui.flow
@@ -1713,7 +1713,7 @@ longTouchCounter = ref 0;
 
 TLongTouch(duration : int, fn : () -> void, handle : bool, tropic : Tropic) -> Tropic {
 	pressed = ref false;
-	mdowni = ref MouseDownInfo(0.0, 0.0, \ -> false);
+	mdowni = ref MouseDownInfo(0.0, 0.0, \ -> false, \ -> false);
 
 	TInteractive(
 		[

--- a/lib/ui/gestures.flow
+++ b/lib/ui/gestures.flow
@@ -9,11 +9,11 @@ import form/gui;
 // Mostly for handhelds
 
 /*
-You can emulate events in the c++ runner by adding 
+You can emulate events in the c++ runner by adding
 	--touch
-	  Emulate touch device events. 
+	  Emulate touch device events.
 	  Press F12 to turn device orientation
-	  Press Ctrl-Shift-F11 to toggle Pan Gesture on/off. 
+	  Press Ctrl-Shift-F11 to toggle Pan Gesture on/off.
 	    Use Mouse to click and drag to emulate Pan Gesture when On.
 	  Press Ctrl-Shift-Arrow Key-Left Mouse to simulate Swipe gestures
 	  This also sets: target::mobile = true
@@ -66,7 +66,7 @@ pinchZoomDebugUI() {
 				Offset(cx, cy, Align(0.5, 0.5, Text(pzt, [])))
 			])
 		})
-		
+
 	)
 }
 
@@ -91,8 +91,8 @@ LongTouchTap(durationMsec, fn, returnOverride) {
 	pressed = ref false;
 	tapped = ref false;
 	steady = ref true;
-	mdowni = ref MouseDownInfo(0.0, 0.0, \ -> false);
-	
+	mdowni = ref MouseDownInfo(0.0, 0.0, \ -> false, \ -> false);
+
 	downhandler = MouseDown2(\handled, mdi -> {
 		tapped := false;
 		pressed := true;
@@ -115,7 +115,7 @@ LongTouchTap(durationMsec, fn, returnOverride) {
 		sqdelta = mmovedx * mmovedx + mmovedy * mmovedy;
 		if(^pressed && (!mi.inside || sqdelta > 200.0)){
 			steady := false
-		}			
+		}
 		handled // let it fall through
 	});
 
@@ -140,11 +140,11 @@ SwipeMonitor(form : Form, xSwipe : DynamicBehaviour<int>, ySwipe : DynamicBehavi
 	sumX = ref 0.0;
 	maxYV = ref 0.0;
 	sumY = ref 0.0;
-	
+
 	// Arbitrary values set by testing on random iPad
 	dpi = i2d(screenDPI);
-	buffer = 5.0 / 264.0 * dpi; 
-	velocityThreshold = 22.0 / 264.0 * dpi; 
+	buffer = 5.0 / 264.0 * dpi;
+	velocityThreshold = 22.0 / 264.0 * dpi;
 	distanceThreshold = 200.0 / 264.0 * dpi;
 
 	Interactive([
@@ -163,8 +163,8 @@ SwipeMonitor(form : Form, xSwipe : DynamicBehaviour<int>, ySwipe : DynamicBehavi
 					// Wriggling is not a swipe (x or y will cancel swipe)
 					if (dx * ^maxXV < 0.0 ) {
 						panStartX := false;
-					} 
-					
+					}
+
 					// Record top speed
 					if (abs(dx) > abs(^maxXV)) {
 						maxXV := dx;
@@ -175,7 +175,7 @@ SwipeMonitor(form : Form, xSwipe : DynamicBehaviour<int>, ySwipe : DynamicBehavi
 					// Wriggling is not a swipe (x or y will cancel swipe)
 					if (dy * ^maxYV < 0.0 ) {
 						panStartY := false;
-					} 
+					}
 
 					// Record top speed
 					if (abs(dy) > abs(^maxYV)) {
@@ -188,7 +188,7 @@ SwipeMonitor(form : Form, xSwipe : DynamicBehaviour<int>, ySwipe : DynamicBehavi
 					if (^panStartX ) {
 						if (abs(^maxXV) > velocityThreshold && abs(^sumX) > distanceThreshold) {
 							if (^maxXV > 0.0) next(xSwipe, 1) else next(xSwipe, -1);
-						} 
+						}
 						true;
 					} else {
 						false;
@@ -196,14 +196,14 @@ SwipeMonitor(form : Form, xSwipe : DynamicBehaviour<int>, ySwipe : DynamicBehavi
 				} else {
 					if(^panStartY) {
 					 	if( abs(^maxYV) > velocityThreshold && abs(^sumY) > distanceThreshold) {
-							if (^maxYV > 0.0) next(ySwipe, 1) else next(ySwipe, -1);	
+							if (^maxYV > 0.0) next(ySwipe, 1) else next(ySwipe, -1);
 						}
 						true;
 					} else {
 						false;
 					}
-				} 
-			
+				}
+
 				panStartX := false;
 				panStartY := false;
 				sumX := 0.0;
@@ -242,7 +242,7 @@ DoubleTapTimed(maxtime: double, fn : () -> void) {
 		ts = timestamp();
 		mi = mifn();
 		if (mi.inside && ^last_was_down) {
-			if (abs(^down_first[0] - mi.x) < 100.0 && 
+			if (abs(^down_first[0] - mi.x) < 100.0 &&
 				abs(^down_first[1] - mi.y) < 100.0 )
 			{
 				if (ts - ^down_first[2] < maxtime) {

--- a/platforms/js/RenderSupport.hx
+++ b/platforms/js/RenderSupport.hx
@@ -2409,6 +2409,36 @@ class RenderSupport {
 		MousePos.y = y;
 	}
 
+	public static function insideY(clip : DisplayObject, x : Float, y : Float) : Bool {
+		if (!clip.getClipRenderable() || clip.parent == null) {
+			return false;
+		}
+
+		clip.invalidateLocalBounds();
+
+		var point = new Point(x, y);
+		return hittestMaskY(clip.parent, point);
+	}
+
+	private static function hittestMaskY(clip : DisplayObject, point : Point) : Bool {
+		if (untyped clip.viewBounds != null) {
+			if (untyped clip.worldTransformChanged) {
+				untyped clip.transform.updateTransform(clip.parent.transform);
+			}
+
+			var local : Point = untyped __js__('clip.toLocal(point, null, null, true)');
+			var viewBounds = untyped clip.viewBounds;
+
+			return viewBounds.minY <= local.y && viewBounds.maxY >= local.y;
+		} else if (untyped clip.scrollRect != null && !hittestGraphics(untyped clip.scrollRect, point)) {
+			return false;
+		} else if (clip.mask != null && !hittestGraphics(clip.mask, point)) {
+			return false;
+		} else {
+			return clip.parent == null || hittestMaskY(clip.parent, point);
+		}
+	}
+
 	public static function hittest(clip : DisplayObject, x : Float, y : Float) : Bool {
 		if (!clip.getClipRenderable() || clip.parent == null) {
 			return false;


### PR DESCRIPTION
https://trello.com/c/jT5a3uGa/11763-danfoss-cell-border-stroke-setting-in-the-table-properties-is-not-working-properly

In the WigiEditor we need an ability to check if the MouseDown happens inside Y coordinates but the default test for X is not suited because we need extended range on the left of the editor. so we need new insideY function to test

NOTE: it works in JS but crashes in CPP
![image](https://user-images.githubusercontent.com/14361571/99800797-fcdcd200-2b45-11eb-8c2a-15c6797586c1.png)

crash in CPP:
![image](https://user-images.githubusercontent.com/14361571/99800858-14b45600-2b46-11eb-9e57-ca548835a445.png)
