### PR TITLE
Increased ephemeral memory values

### DIFF
--- a/platforms/common/cpp/core/ByteCodeRunner.h
+++ b/platforms/common/cpp/core/ByteCodeRunner.h
@@ -359,8 +359,8 @@ private:
 
     /* End of high-throughput vars */
 
-    static const unsigned int EPHEMERAL_HEAP_SIZE = 2*1024*1024;
-    static const unsigned int MAX_EPHEMERAL_ALLOC = 32*1024;
+    static const unsigned int EPHEMERAL_HEAP_SIZE = 128*1024*1024;
+    static const unsigned int MAX_EPHEMERAL_ALLOC = 1*1024*1024;
 
     /* Heap structure
 

--- a/platforms/qt/bin/windows/QtByteRunner.exe
+++ b/platforms/qt/bin/windows/QtByteRunner.exe
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3e9cee2193d46264489f875c56d2a9c0fe9a64f4300fc93242b64a5be5b4e190
-size 1994752
+oid sha256:544cc5712a2930b889452e0ac659b43428c4595ab2eeb844dfe1f2ba47a78e39
+size 1592320


### PR DESCRIPTION
It increases chance to run fast garbage collection instead of full garbage collection, so it speeds up QtByteRunner.

Command `update --only-master-key --profile` now takes 25 sec. instead of 3.5 min for rhapsode.