### PR TITLE
JS. FlowContainer. Added cropEnabled.

### DIFF
--- a/lib/fform/fform.flow
+++ b/lib/fform/fform.flow
@@ -95,9 +95,9 @@ export {
 		FDecorator2(form, decorators, above, captureCallstack());
 	}
 
-	FCrop2(left : Transform<double>, top : Transform<double>, width : Transform<double>, height : Transform<double>, form : FForm, stack : native);
+	FCrop2(left : Transform<double>, top : Transform<double>, width : Transform<double>, height : Transform<double>, enabled : Transform<bool>, form : FForm, stack : native);
 	FCrop(left : Transform<double>, top : Transform<double>, width : Transform<double>, height : Transform<double>, form : FForm) -> FCrop2 {
-		FCrop2(left, top, width, height, form, captureCallstack());
+		FCrop2(left, top, width, height, const(true), form, captureCallstack());
 	}
 
 	FControlFocus(focus : DynamicBehaviour<bool>, form : FForm);

--- a/lib/fform/fformmetrics.flow
+++ b/lib/fform/fformmetrics.flow
@@ -23,7 +23,7 @@ findTaggedFFormPositionScale(f : FForm, tag : int) -> Maybe<PositionScale> {
 		FTextInput(__, __, __) : None();
 
 		FTranslate(x, y, form) : cps(PositionScale(Point(fgetValue(x), fgetValue(y)), zeroScale), form);
-		FCrop2(left, top, width, height, form, stack) : cps(PositionScale(Point(-fgetValue(left), -fgetValue(top)), zeroScale), form);
+		FCrop2(left, top, width, height, enabled, form, stack) : cps(PositionScale(Point(-fgetValue(left), -fgetValue(top)), zeroScale), form);
 		FBorder(left, top, right, bottom, form) : cps(PositionScale(Point(left, top), zeroScale), form);
 		FScale(x, y, form) : cps(PositionScale(zeroPoint, zeroScale), form);
 

--- a/lib/fform/fformutils.flow
+++ b/lib/fform/fformutils.flow
@@ -186,7 +186,7 @@ fform2form(fform : FForm) -> Form {
 
 			Group(if (above) concat([f1], f2) else arrayPush(f2, f1));
 		}
-		FCrop2(left, top, width, height, form, stack) : switchTransform(left, \l -> switchTransform(top, \t -> switchTransform(width, \w ->
+		FCrop2(left, top, width, height, enabled, form, stack) : switchTransform(left, \l -> switchTransform(top, \t -> switchTransform(width, \w ->
 			switchTransform(height, \h -> Crop2(l, t, w, h, fform2form(form), stack)))));
 		FControlFocus(focus, form) : ControlFocus(focus, fform2form(form));
 		FPicture(url, size, s) : Inspect([ISize(size)], Picture(url, s));
@@ -228,7 +228,7 @@ form2fform(_form : Form) -> FForm {
 		Filter2(filt, form, stack) : FFilter2(filt, form2fform(form), stack);
 		Cursor(shape, form) : FCursor(shape, form2fform(form));
 		Mutable2(form, stack) : FMutable2(fselect(form, FLift(\f -> form2fform(f))), stack);
-		Crop2(left, top, width, height, form, stack) : FCrop2(left, top, width, height, form2fform(form), stack);
+		Crop2(left, top, width, height, form, stack) : FCrop2(left, top, width, height, const(true), form2fform(form), stack);
 		Picture(url, s) : FPicture(url, make(zeroWH), s);
 		Constructor(form, fn) : FConstructor(form2fform(form), fn);
 		FullWindow(fw, form) : FFullWindow(fw, make(zeroWH), form2fform(form));
@@ -1834,9 +1834,9 @@ fform2s(rform : FForm, level : int) -> string {
 			fform2s(form, level + 1) + "\n" +
 			generateSpaces + ")"
 		}
-		FCrop2(left, top, cwidth, cheight, form, stack): {
+		FCrop2(left, top, cwidth, cheight, enabled, form, stack): {
 			generateSpaces + structName + toString(fgetValue(left)) + ", " + toString(fgetValue(top)) + ", " +
-				toString(fgetValue(cwidth)) + ", " + toString(fgetValue(cheight)) + "," + "\n" +
+				toString(fgetValue(cwidth)) + ", " + toString(fgetValue(cheight)) + "," + "\n" + toString(fgetValue(enabled)) + "," + "\n" +
 			fform2s(form, level + 1) + "\n" +
 			generateSpaces + ")"
 		}

--- a/lib/fform/optimizefform.flow
+++ b/lib/fform/optimizefform.flow
@@ -247,7 +247,7 @@ optimizeFForm(form) {
 			else
 				FInteractive(listeners, of);
 		}
-		FCrop2(left, top, width, height, f, stack): {
+		FCrop2(left, top, width, height, enabled, f, stack): {
 			of = optimizeFForm(f);
 
 			switch (of) {
@@ -257,7 +257,7 @@ optimizeFForm(form) {
 					if (of == f)
 						form
 					else
-						FCrop2(left, top, width, height, of, stack);
+						FCrop2(left, top, width, height, enabled, of, stack);
 			}
 		}
 		FControlFocus(focus, f): {

--- a/lib/fform/renderfform.flow
+++ b/lib/fform/renderfform.flow
@@ -1034,14 +1034,18 @@ renderFForm(rform : FForm, zorder : Transform<[int]>) -> FRenderResult {
 			else
 				d
 		}
-		FCrop2(left, top, cwidth, cheight, form, stack): {
+		FCrop2(left, top, cwidth, cheight, enabled, form, stack): {
 			attachFChildAndCapability(
 				rform,
 				renderFForm(form, zorder),
 				[FClipMove(), FClipRotate(), FClipScale(), FClipMask()],
 				\clip -> {
 					setClipCallstack(clip, stack);
-					make4Subscribe(left, top, cwidth, cheight, \l, t, w, h -> setScrollRect(clip, l, t, w, h))()
+					uns = [
+						make4Subscribe(left, top, cwidth, cheight, \l, t, w, h -> setScrollRect(clip, l, t, w, h))(),
+						makeSubscribe(enabled, \en -> setCropEnabled(clip, en))()
+					];
+					\ -> applyall(uns)
 				}
 			);
 		}

--- a/lib/fform/sfform.flow
+++ b/lib/fform/sfform.flow
@@ -158,7 +158,7 @@ fform2sfform(fform : FForm, callConstructors : bool) -> SFForm {
 		FCursor(__, form) : fform2sfform(form, callConstructors);
 		FInspect(__, form) : fform2sfform(form, callConstructors);
 		FMutable2(form, __) : fform2sfform(fgetValue(form), callConstructors);
-		FCrop2(l, t, w, h, form, __) : SFCrop(fgetValue(l), fgetValue(t), fgetValue(w), fgetValue(h), fform2sfform(form, callConstructors));
+		FCrop2(l, t, w, h, __, form, __) : SFCrop(fgetValue(l), fgetValue(t), fgetValue(w), fgetValue(h), fform2sfform(form, callConstructors));
 		FControlFocus(__, form) : fform2sfform(form, callConstructors);
 		FPicture(url, size, s) : SFPicture(url, getValue(size), PictureStyle2SFPictureStyle(s));
 		FConstructor(form, fn) : {

--- a/lib/material/internal/debug_subscribers.flow
+++ b/lib/material/internal/debug_subscribers.flow
@@ -102,7 +102,7 @@ debugMaterialSubscribersTropic(manager : MaterialManager, newTr : Tropic, level 
 		TFilter(filters, form) : TFilter(filters, debugMaterialSubscribers(manager, \ -> form, form.structname, true, level));
 		TCursor(kind, form) : TCursor(kind, debugMaterialSubscribers(manager, \ -> form, form.structname, true, level));
 		TAccess(properties, form) : TAccess(properties, debugMaterialSubscribers(manager, \ -> form, form.structname, true, level));
-		TCrop(topleft, widthHeight, form) : TCrop(topleft, widthHeight, debugMaterialSubscribers(manager, \ -> form, form.structname, true, level));
+		TCrop2(topleft, widthHeight, enabled, form) : TCrop2(topleft, widthHeight, enabled, debugMaterialSubscribers(manager, \ -> form, form.structname, true, level));
 		TVisible(visible, form) : TVisible(visible, debugMaterialSubscribers(manager, \ -> form, form.structname, true, level));
 		TInteractive(interactivity, form) : TInteractive(interactivity, debugMaterialSubscribers(manager, \ -> form, form.structname, true, level));
 		TBaselineOffset(offset, form) : TBaselineOffset(offset, debugMaterialSubscribers(manager, \ -> form, form.structname, true, level));

--- a/lib/material/internal/material_focus.flow
+++ b/lib/material/internal/material_focus.flow
@@ -1026,7 +1026,7 @@ getFFormById(f : FForm, id : List<IScriptFormPosition>) -> Transform<Maybe<FForm
 		FCursor(kind, form): getFFormById(form, id);
 		FInspect(inspectors, form): getFFormById(form, id);
 		FMutable2(form, stack): fsubselect(form, FLift(\f2 -> getFFormById(f2, id)));
-		FCrop2(left, top, width, height, form, stack): getFFormById(form, id);
+		FCrop2(left, top, width, height, enabled, form, stack): getFFormById(form, id);
 		FAccess(props, form): getFFormById(form, id);
 		FControlFocus(focus, form): getFFormById(form, id);
 		FFullWindow(fullscreen, av, form): getFFormById(form, id);

--- a/lib/material/iscript/material_iscript_form.flow
+++ b/lib/material/iscript/material_iscript_form.flow
@@ -140,7 +140,7 @@ takeLogicalSnapshot(f : FForm) -> IScriptForm {
 		FCursor(kind, form): takeLogicalSnapshot(form);
 		FInspect(inspectors, form): takeLogicalSnapshot(form);
 		FMutable2(form, stack): takeLogicalSnapshot(fgetValue(form));
-		FCrop2(left, top, width, height, form, stack): ISCrop2(_ct(left), _ct(top), _ct(width), _ct(height), takeLogicalSnapshot(form));
+		FCrop2(left, top, width, height, enabled, form, stack): ISCrop2(_ct(left), _ct(top), _ct(width), _ct(height), takeLogicalSnapshot(form));
 		FAccess(props, form): {
 			iScriptId = filter(extractStructMany(props, FAccessAttribute("", const(""))), \aa -> aa.name == "id");
 
@@ -796,7 +796,7 @@ IScriptForm2FForm(manager : MaterialManager, f : IScriptForm, m2t : (Material, M
 		FCreate2(__, __): f;
 		FControlFocus(cf, form):
 			IScriptForm2FForm(manager, form, m2t, id, inputs);
-		FCrop2(l, t, w, h, form, callstack): FCrop2(l, t, w, h,
+		FCrop2(l, t, w, h, en, form, callstack): FCrop2(l, t, w, h, en,
 			IScriptForm2FForm(manager, form, m2t, id, inputs), callstack);
 		FTranslate(x, y, form): FTranslate(x, y,
 			IScriptForm2FForm(manager, form, m2t, id, inputs));

--- a/lib/rendersupport.flow
+++ b/lib/rendersupport.flow
@@ -220,6 +220,7 @@ export {
 	native makeGlow: io (radius : double, spread : double, color : int, alpha : double, inner : bool) -> native = RenderSupport.makeGlow;
 	native makeShader: io (vertex : [string], fragment : [string], uniform : [[string]]) -> native = RenderSupport.makeShader;
 	native setScrollRect : io (clip : native, left : double, top : double, width : double, height : double) -> void = RenderSupport.setScrollRect;
+	native setCropEnabled : io (clip : native, enabled : bool) -> void = RenderSupport.setCropEnabled;
 	native setContentRect : io (clip : native, width : double, height : double) -> void = RenderSupport.setContentRect;
 	native listenScrollRect : io (clip : native, cb : (dx : double, dy : double) -> void) -> () -> void = RenderSupport.listenScrollRect;
 	native setAccessAttributes : io (clip : native, properties : [[string]]) -> void = RenderSupport.setAccessAttributes;
@@ -453,6 +454,7 @@ setAccessibilityZoom(zoom) { }
 getAccessibilityZoom() { 1.0; }
 
 setPictureUseCrossOrigin(picture : native, useCrossOrigin : bool) -> void {}
+setCropEnabled(clip : native, enabled : bool) -> void {}
 
 addClipAnimation(clip, keyframes, options, onFinish, fallbackAnimation) { fallbackAnimation(); }
 getUserDefinedLetterSpacing() { 0.0; }

--- a/lib/tropic/tropic.flow
+++ b/lib/tropic/tropic.flow
@@ -19,7 +19,7 @@ Tropic ::=
 	TBorder, TTranslate, TScale, TRotate, TOrigin, TAlpha, TVisible,
 	TMask,
 	TFilter, TCursor,
-	TCrop, TAccess,
+	TCrop2, TAccess,
 	TInteractive,
 	TBaselineOffset,
 	TFullWindow,
@@ -128,7 +128,8 @@ TMask : (main : Tropic, mask : Tropic);
 TFilter(filters : [Filters], form : Tropic);
 TCursor(kind : CursorShape2, form : Tropic);
 TAccess : (properties : [FAccessProperty], form : Tropic);
-TCrop : (topleft : Transform<Point>, widthHeight : Transform<WidthHeight>, form : Tropic);
+TCrop(topleft : Transform<Point>, widthHeight : Transform<WidthHeight>, form : Tropic) -> Tropic {TCrop2(topleft, widthHeight, const(true), form)};
+TCrop2 : (topleft : Transform<Point>, widthHeight : Transform<WidthHeight>, enabled : Transform<bool>, form : Tropic);
 
 // The tropic is NOT destroyed/reconstructed when 'visible' becomes false/true for performance, only hidden.
 // See TShow in tropic_gui.flow if you want it to be destroyed and reconstructed.

--- a/lib/tropic/tropic2form.flow
+++ b/lib/tropic/tropic2form.flow
@@ -2643,7 +2643,7 @@ tropic2Acc(b : Tropic, parent : TParentInfo, sheet : Stylesheet, metricsOnly : b
 				[]
 			)
 		}
-		TCrop(pt, wh, bt): {
+		TCrop2(pt, wh, en, bt): {
 			x1 = fpointX(pt);
 			y1 = fpointY(pt);
 			wi = fwidth(wh);
@@ -2663,12 +2663,14 @@ tropic2Acc(b : Tropic, parent : TParentInfo, sheet : Stylesheet, metricsOnly : b
 				if (metricsOnly)
 					FEmpty()
 				else
-					FCrop(
+					FCrop2(
 						x1,
 						y1,
 						wi,
 						he,
-						bf.form
+						en,
+						bf.form,
+						captureCallstack()
 					),
 				TFormMetrics(
 					wi,

--- a/lib/tropic/tropic2string.flow
+++ b/lib/tropic/tropic2string.flow
@@ -44,8 +44,8 @@ doTropic2string(t : Tropic, indent : string) -> string {
 		TCursor(c, tr): {
 			"TCursor(" + rec(tr) + ")";
 		}
-		TCrop(tl, wh, tr): {
-			"TCrop(" + rec(tr) + ")";
+		TCrop2(tl, wh, en, tr): {
+			"TCrop2(" + rec(tr) + ")";
 		}
 		TCropSize(wh, tr): {
 			"TCropSize(" + rec(wh) + "," + rec(tr) + ")";

--- a/lib/tropic/tropic_metrics.flow
+++ b/lib/tropic/tropic_metrics.flow
@@ -102,7 +102,7 @@ getTWordMetrics(pt : TWord, env : Tree<string, Tropic>) -> FormMetrics {
 			getTropicMetrics(t);
 		}
 		TCreate2(current, fn): getTropicMetrics(if (^current != TEmpty()) ^current else fn());
-		TCrop(__, size, __): {
+		TCrop2(__, size, __, __): {
 			s = fgetValue(size);
 			makeMetrics(s.width, s.height);
 		}
@@ -329,7 +329,7 @@ isConstantSizeTropic(tr : Tropic) -> bool {
 		TMinimumGroup2(down, up): isConstantSizeTropic(up) && isConstantSizeTropic(down);
 		TScale(fac, t): isFConst(fac) && isConstantSizeTropic(t);
 		TConstruct(__, t): isConstantSizeTropic(t);
-		TCrop(__, size, __): isFConst(size);
+		TCrop2(__, size, __, __): isFConst(size);
 		TTag(__, t): isConstantSizeTropic(t);
 		TFormIn(__, b): isConstantSizeTropic(b);
 		TForm(f): false;

--- a/lib/tropic/tropic_optimize.flow
+++ b/lib/tropic/tropic_optimize.flow
@@ -61,13 +61,9 @@ optimizeTropic(t : Tropic) -> Tropic {
 			ot = optimizeTropic(tr);
 			if (isSameObj(ot, tr)) t else TCursor(c, ot);
 		}
-		TCrop(tl, wh, tr): {
-			if (tl == const(zeroPoint)) {
-				optimizeTropic(TCropSize(TMutable(fselect(wh, FLift(\v -> TBorder(v.width, v.height, 0.0, 0.0, TEmpty())))), tr))
-			} else {
-				ot = optimizeTropic(tr);
-				if (isSameObj(ot, tr)) t else TCrop(tl, wh, ot);
-			}
+		TCrop2(tl, wh, en, tr): {
+			ot = optimizeTropic(tr);
+			if (isSameObj(ot, tr)) t else TCrop2(tl, wh, en, ot);
 		}
 		TInteractive(ia, tr): {
 			ot = optimizeTropic(tr);

--- a/lib/tropic/tropic_paragraph.flow
+++ b/lib/tropic/tropic_paragraph.flow
@@ -934,7 +934,7 @@ keepWordsTogether(tr : Tropic) -> bool {
 		TMinimumGroup2(down, up): keepWordsTogether(up) && keepWordsTogether(down);
 		TScale(fac, t): keepWordsTogether(t);
 		TConstruct(__, t): keepWordsTogether(t);
-		TCrop(__, size, t): keepWordsTogether(t);
+		TCrop2(__, __, __, t): keepWordsTogether(t);
 		TTag(__, t): keepWordsTogether(t);
 		TFormIn(f, b): keepFormTogether(f);
 		TForm(f): keepFormTogether(f);

--- a/lib/tropic/tropic_paragraph_types.flow
+++ b/lib/tropic/tropic_paragraph_types.flow
@@ -52,7 +52,7 @@ getTropicTextAndStyle(tr : Tropic) -> Pair<string, [TCharacterStyle]> {
 		TFilter(__, t) : getTropicTextAndStyle(t);
 		TCursor(__, t) : getTropicTextAndStyle(t);
 		TAccess(__, t) : getTropicTextAndStyle(t);
-		TCrop(__, __, t) : getTropicTextAndStyle(t);
+		TCrop2(__, __, __, t) : getTropicTextAndStyle(t);
 		TVisible(__, t) : getTropicTextAndStyle(t);
 		TInteractive(__, t) : getTropicTextAndStyle(t);
 		TBaselineOffset(__, t) : getTropicTextAndStyle(t);

--- a/lib/tropic/tropic_profile.flow
+++ b/lib/tropic/tropic_profile.flow
@@ -96,7 +96,7 @@ sizeTropic(t : Tropic) -> int {
 		TMask(t1, t2): sizeTropic(t1) + sizeTropic(t2);
 		TFilter(f, tr): 1 + sizeTropic(tr);
 		TCursor(c, tr): 1 + sizeTropic(tr);
-		TCrop(tl, wh, tr): 1 + sizeTropic(tr);
+		TCrop2(tl, wh, en, tr): 1 + sizeTropic(tr);
 		TInteractive(ia, tr): 1 + sizeTropic(tr);
 		TAccess(p, tr): 1 + sizeTropic(tr);
 
@@ -186,7 +186,7 @@ commonTropic(t : Tropic, acc : Tree<Tropic, int>) -> Tree<Tropic, int> {
 		TVisible(v, tr): commonTropic(tr, acc2);
 		TFilter(f, tr): commonTropic(tr, acc2);
 		TCursor(c, tr): commonTropic(tr, acc2);
-		TCrop(tl, wh, tr): commonTropic(tr, acc2);
+		TCrop2(tl, wh, en, tr): commonTropic(tr, acc2);
 		TInteractive(ia, tr): commonTropic(tr, acc2);
 		TBaselineOffset(__, tr): commonTropic(tr, acc2);
 		TAccess(p, tr): commonTropic(tr, acc2);
@@ -290,7 +290,7 @@ containsTropic(small : Tropic, big : Tropic) -> bool {
 			TVisible(v, tr): containsTropic(small, tr);
 			TFilter(f, tr): containsTropic(small, tr);
 			TCursor(c, tr): containsTropic(small, tr);
-			TCrop(tl, wh, tr): containsTropic(small, tr);
+			TCrop2(tl, wh, en, tr): containsTropic(small, tr);
 			TInteractive(ia, tr): containsTropic(small, tr);
 			TBaselineOffset(__, tr):containsTropic(small, tr);
 			TAccess(p, tr): containsTropic(small, tr);

--- a/lib/tropic/tropic_resolve_css.flow
+++ b/lib/tropic/tropic_resolve_css.flow
@@ -150,9 +150,9 @@ resolveTropicCss(t : Tropic, sheet : Stylesheet) -> Tropic {
 			ot = resolveTropicCss(tr, sheet);
 			if (ot == tr) t else TCursor(c, ot);
 		}
-		TCrop(tl, wh, tr): {
+		TCrop2(tl, wh, en, tr): {
 			ot = resolveTropicCss(tr, sheet);
-			if (ot == tr) t else TCrop(tl, wh, ot);
+			if (ot == tr) t else TCrop2(tl, wh, en, ot);
 		}
 		TInteractive(ia, tr): {
 			ot = resolveTropicCss(tr, sheet);

--- a/lib/tropic/tscroll.flow
+++ b/lib/tropic/tscroll.flow
@@ -483,10 +483,8 @@ TScroll(manager : TManager, content : Tropic, box : Tropic, style : [TScrollStyl
 					|> (\t ->
 						if (nativeScroll())
 							TScrollRectT(scrollPosition, boxWH, t, enabled)
-						else if (isUrlParameterTrue("crop2"))
-							TCrop2(scrollPosition, boxWH, showScrolling, t)
 						else
-							TCrop(scrollPosition, boxWH, t)
+							TCrop2(scrollPosition, boxWH, showScrolling, t)
 					)
 				),
 				eitherMap(

--- a/lib/tropic/tscroll.flow
+++ b/lib/tropic/tscroll.flow
@@ -483,6 +483,8 @@ TScroll(manager : TManager, content : Tropic, box : Tropic, style : [TScrollStyl
 					|> (\t ->
 						if (nativeScroll())
 							TScrollRectT(scrollPosition, boxWH, t, enabled)
+						else if (isUrlParameterTrue("crop2"))
+							TCrop2(scrollPosition, boxWH, showScrolling, t)
 						else
 							TCrop(scrollPosition, boxWH, t)
 					)

--- a/platforms/js/DisplayObjectHelper.hx
+++ b/platforms/js/DisplayObjectHelper.hx
@@ -568,6 +568,12 @@ class DisplayObjectHelper {
 		scrollRect.drawRect(0.0, 0.0, width, height);
 	}
 
+	public static function setCropEnabled(clip : FlowContainer, enabled : Bool) : Void {
+		if (clip.cropEnabled != enabled) {
+			clip.cropEnabled = enabled;
+		}
+	}
+
 	public static inline function setContentRect(clip : FlowContainer, width : Float, height : Float) : Void {
 		if (untyped clip.contentBounds == null) {
 			untyped clip.contentBounds = new Bounds();
@@ -1549,9 +1555,9 @@ class DisplayObjectHelper {
 			nativeWidget.style.borderRadius = null;
 			if (untyped clip.scrollRectListener != null) {
 				nativeWidget.classList.add("nativeScroll");
-				nativeWidget.style.overflow = untyped clip.isInput ? "auto" : "scroll";
+				nativeWidget.style.overflow = untyped clip.cropEnabled ? (untyped clip.isInput ? "auto" : "scroll") : "visible";
 			} else {
-				nativeWidget.style.overflow = untyped clip.isInput ? "auto" : "hidden";
+				nativeWidget.style.overflow = untyped clip.cropEnabled ? (untyped clip.isInput ? "auto" : "hidden") : "visible";
 			}
 
 			scrollNativeWidget(clip, round(scrollRect.x), round(scrollRect.y));

--- a/platforms/js/DisplayObjectHelper.hx
+++ b/platforms/js/DisplayObjectHelper.hx
@@ -571,6 +571,7 @@ class DisplayObjectHelper {
 	public static function setCropEnabled(clip : FlowContainer, enabled : Bool) : Void {
 		if (clip.cropEnabled != enabled) {
 			clip.cropEnabled = enabled;
+			invalidateTransform(clip, "setCropEnabled");
 		}
 	}
 

--- a/platforms/js/FlowContainer.hx
+++ b/platforms/js/FlowContainer.hx
@@ -22,6 +22,7 @@ class FlowContainer extends Container {
 	public var stageChanged : Bool = false;
 	private var worldTransformChanged : Bool = false;
 	private var localTransformChanged : Bool = true;
+	public var cropEnabled : Bool = true;
 
 	private var localBounds = new Bounds();
 	private var _bounds = new Bounds();

--- a/platforms/js/RenderSupport.hx
+++ b/platforms/js/RenderSupport.hx
@@ -2941,6 +2941,10 @@ class RenderSupport {
 		clip.setScrollRect(left, top, width, height);
 	}
 
+	public static function setCropEnabled(clip : FlowContainer, enabled : Bool) : Void {
+		clip.setCropEnabled(enabled);
+	}
+
 	public static function setContentRect(clip : FlowContainer, width : Float, height : Float) : Void {
 		clip.setContentRect(width, height);
 	}


### PR DESCRIPTION
This fix is intended for cases when content into dialog with scroll has a stroke. At some positions, this stroke happens to be cut. For now, hotfix is to wrap content into 1 px border : https://github.com/area9innovation/innovation/blob/master/components/mwigi/mwigi/mw_dialog_utils.flow#L190, but it would be better to fix it on js level.

Is it appropriate? Should we additionally call invalidateTransform? 
![image](https://user-images.githubusercontent.com/27855185/103646034-aa267080-4f61-11eb-99e7-6cf9f3dab791.png)
