### PR TITLE
Wigi: make text metrics dynamic for Safari

### DIFF
--- a/lib/fform/fform.flow
+++ b/lib/fform/fform.flow
@@ -10,7 +10,7 @@ export {
 		FBaseline, FSize2, FAvailable2, FAccess, FRealHTML, FSetPending, FVideo, FTextInput, FDynamicGroup2, FNativeForm, FCanvas, FAnimation;
 
 	FText(text : Transform<string>, style : [FTextStyle]);
-		FTextStyle ::= CharacterStyle, FDynamicColor, TagName, LangAttribute, FTextWidth;
+		FTextStyle ::= CharacterStyle, FDynamicColor, TagName, LangAttribute, TextWidthInspector;
 			FDynamicColor(color : Transform<int>);
 
 	FParagraph(text : Transform<string>, style : [FParagraphStyle]);

--- a/lib/fform/fform.flow
+++ b/lib/fform/fform.flow
@@ -12,7 +12,6 @@ export {
 	FText(text : Transform<string>, style : [FTextStyle]);
 		FTextStyle ::= CharacterStyle, FDynamicColor, TagName, LangAttribute, FTextWidth;
 			FDynamicColor(color : Transform<int>);
-			FTextWidth(width : DynamicBehaviour<double>); // Inspector
 
 	FParagraph(text : Transform<string>, style : [FParagraphStyle]);
 		FParagraphStyle ::= FTextStyle, ParagraphWidth, CommonAlignment, CropWords, InterlineSpacing, ParagraphMetrics, ParagraphEllipsis,

--- a/lib/fform/fformutils.flow
+++ b/lib/fform/fformutils.flow
@@ -1041,7 +1041,7 @@ renderFText(text : Transform<string>, style : [FTextStyle]) -> FRenderResult {
 		),
 
 		eitherMap(
-			tryExtractStruct(style, FTextWidth(make(0.))),
+			tryExtractStruct(style, TextWidthInspector(make(0.))),
 			\tw -> addEventListener(textfield, "textwidthchanged", \ -> nextDistinct(tw.width, getTextFieldWidth(textfield))),
 			nop
 		)

--- a/lib/fform/sfform.flow
+++ b/lib/fform/sfform.flow
@@ -207,7 +207,7 @@ FTextStyle2SFTextStyle(style : [FTextStyle]) -> [SFTextStyle] {
 			CharacterStyle() : Some(s);
 			TagName(__): Some(s);
 			LangAttribute(code): Some(LangAttribute(const(fgetValue(code))));
-			FTextWidth(__): None();
+			TextWidthInspector(__): None();
 		}
 	})
 }
@@ -228,7 +228,7 @@ FParagraphStyle2SFParagraphStyle(style : [FParagraphStyle]) -> [SFParagraphStyle
 			FDynamicColor(col) :   Some(FDynamicColor(const(fgetValue(col))));
 			TagName(__) :          Some(s);
 			LangAttribute(code) :  Some(LangAttribute(const(fgetValue(code))));
-			FTextWidth(__) : 	   Some(s);
+			TextWidthInspector(__) : 	   Some(s);
 		}
 	})
 }
@@ -409,7 +409,7 @@ SFParagraphStyle2FParagraphStyle(style : [SFParagraphStyle]) -> [FParagraphStyle
 			FDynamicColor(__) : s;
 			TagName(__) : s;
 			LangAttribute(__) : s;
-			FTextWidth(__) : s;
+			TextWidthInspector(__) : s;
 		}
 	)
 }

--- a/lib/form/paragraph3.flow
+++ b/lib/form/paragraph3.flow
@@ -75,7 +75,7 @@ Ghosted ::= Empty, Ghost, CoordinateInspectElement, InspectGhost;
 // Each word to be placed in the paragraph, including the metrics and as well as any ghost constructed
 ParaWord(
 	word : ParaAtomic,
-	metrics : Behaviour<FormMetrics>,
+	metrics : Transform<FormMetrics>,
 	ghosted : Ghosted,
 	form: GhostForm,
 	interactivityIdM : Maybe<int>
@@ -84,7 +84,7 @@ ParaWord(
 ParaLine(words : [ParaWord], indent : double);
 ParaLineAcc(lines : List<Form>, y : double, baseline : double);
 
-OptimizedLineElement(f : GhostForm, metrics : Behaviour<FormMetrics>, interactivityIdM : Maybe<int>);
+OptimizedLineElement(f : GhostForm, metrics : Transform<FormMetrics>, interactivityIdM : Maybe<int>);
 ParaLineInfo(optimizedLine : [OptimizedLineElement], lineAsc : double, lineHeight : double, lineWidth : double, lineIndent : double);
 ParaLinesInfos(lines : [ParaLineInfo], maxLineWidth : double);
 ParaLineResult(form : Form, width : double, height : double, baseline : double);
@@ -245,7 +245,7 @@ renderParagraph(
 	}
 
 	// If there is less or equal then upper limit of dynamic elements, we do not need to postpone updates
-	dynamicWords = filter(words, \w -> !isConst(w.metrics));
+	dynamicWords = filter(words, \w -> !isFConst(w.metrics));
 	ndynamic = length(dynamicWords);
 	ndymamicUpper = extractStruct(s, DynamicBlockDelay(getParagraphDynamicBlockDelay())).n;
 
@@ -314,7 +314,7 @@ renderParagraph(
 						})
 					})
 				],
-				mapi(dynamicWords, \i, w -> subscribe2(w.metrics, \m -> if (i < ndymamicUpper) updateFn(getValue(aw)) else nextDistinct(update, 1)))
+				mapi(dynamicWords, \i, w -> makeSubscribe2(w.metrics, \m -> if (i < ndymamicUpper) updateFn(getValue(aw)) else nextDistinct(update, 1))())
 			]);
 			\ -> applyall(uns)
 		}
@@ -343,7 +343,7 @@ getParaLineInfosAndScale(
 		ReflowedLines(newLines) : {
 			infos = map(newLines, \line -> {
 				optimizedLine = getOptimizedLine(line.words, alignment);
-				metrics = map(optimizedLine, \ole -> getValue(ole.metrics));
+				metrics = map(optimizedLine, \ole -> fgetValue(ole.metrics));
 				lineAsc = fold(metrics, 0.0, \ac, m -> max(ac, m.baseline));
 				ParaLineInfo(
 					optimizedLine,
@@ -449,7 +449,7 @@ makeInteractiveParaWord(
 	interactivityIdM : Maybe<int>,
 	ignoreLetterSpacing : bool
 ) -> ParaWord {
-	s2w = \s : Pair<Form, Behaviour<FormMetrics>> -> {
+	s2w = \s : Pair<Form, Transform<FormMetrics>> -> {
 		if (!isGhostable(s.first)) {
 			ParaWord(s.first, s.second, Empty(), Empty(), interactivityIdM);
 		} else {
@@ -534,18 +534,21 @@ getJoinableTextMetrics(
 	form: Form,
 	getExactTopPoint : bool,
 	ignoreLetterSpacing : bool
-) -> Pair<Form, Behaviour<FormMetrics>> {
+) -> Pair<Form, Transform<FormMetrics>> {
 	if (ignoreLetterSpacing) {
 		getDynamicFormSize2(form, getExactTopPoint)
 	} else switch (form) {
-		Text(__, st) : {
+		Text(text, st) : {
 			letterSpacing = extractStruct(st, LetterSpacing(0.0)).spacing;
-			metrics = getStaticFormSizeCached2(form, getExactTopPoint);
+			staticMetrics = getStaticFormSizeCached2(form, getExactTopPoint);
+			pprint("Static metrics for text (" + text + ") : ")(staticMetrics);
+			textWidth = make(staticMetrics.width);
+			fpprint("Text width for text (" + text + ") : ")(textWidth);
 			Pair(
-				form,
-				const(FormMetrics(metrics with
-					width = metrics.width + letterSpacing
-				))
+				Text(text, arrayPush(st, FTextWidth(textWidth))),
+				fselect(textWidth, FLift(\tw -> FormMetrics(staticMetrics with
+					width = tw + letterSpacing
+				)))
 			);
 		}
 		default : getDynamicFormSize2(form, getExactTopPoint)
@@ -624,7 +627,7 @@ reflowParaWords(
 }
 
 getParaWordWidth(word : ParaWord) -> double {
-	getValue(word.metrics).width;
+	fgetValue(word.metrics).width;
 };
 
 // here availableWidth is an amount of width for current line
@@ -1028,7 +1031,7 @@ RenderLine(
 	// The width and the individual forms
 	lo : [Form] = filtermapi(info.optimizedLine, \i : int, elem : OptimizedLineElement -> {
 		f = elem.f;
-		m = getValue(elem.metrics);
+		m = fgetValue(elem.metrics);
 		intStyleContains = \st : ParaElementInteractiveStyle -> eitherMap(
 			elem.interactivityIdM,
 			\id -> containsStruct(

--- a/lib/form/paragraph3.flow
+++ b/lib/form/paragraph3.flow
@@ -541,15 +541,22 @@ getJoinableTextMetrics(
 		Text(text, st) : {
 			letterSpacing = extractStruct(st, LetterSpacing(0.0)).spacing;
 			staticMetrics = getStaticFormSizeCached2(form, getExactTopPoint);
-			pprint("Static metrics for text (" + text + ") : ")(staticMetrics);
-			textWidth = make(staticMetrics.width);
-			fpprint("Text width for text (" + text + ") : ")(textWidth);
-			Pair(
-				Text(text, arrayPush(st, FTextWidth(textWidth))),
-				fselect(textWidth, FLift(\tw -> FormMetrics(staticMetrics with
-					width = tw + letterSpacing
-				)))
-			);
+			if (isSafariBrowser() && !isUrlParameterTrue("static_text_metrics")) {
+				textWidth = make(staticMetrics.width);
+				Pair(
+					Text(text, arrayPush(st, TextWidthInspector(textWidth))),
+					fselect(textWidth, FLift(\tw -> FormMetrics(staticMetrics with
+						width = tw + letterSpacing
+					)))
+				);
+			} else {
+				Pair(
+					form,
+					const(FormMetrics(staticMetrics with
+						width = staticMetrics.width + letterSpacing
+					))
+				);
+			}
 		}
 		default : getDynamicFormSize2(form, getExactTopPoint)
 	}

--- a/lib/formats/html/form2html.flow
+++ b/lib/formats/html/form2html.flow
@@ -184,6 +184,7 @@ text2htmlEx(textForm : Text, safe : bool) -> string {
 			Underlined(st): {}
 			EscapeHTML(__): {}
 			SetRTL(__): {}
+			FTextWidth(__): {}
 		}
 	});
 

--- a/lib/formats/html/form2html.flow
+++ b/lib/formats/html/form2html.flow
@@ -184,7 +184,7 @@ text2htmlEx(textForm : Text, safe : bool) -> string {
 			Underlined(st): {}
 			EscapeHTML(__): {}
 			SetRTL(__): {}
-			FTextWidth(__): {}
+			TextWidthInspector(__): {}
 		}
 	});
 

--- a/lib/stylestructs.flow
+++ b/lib/stylestructs.flow
@@ -1,5 +1,6 @@
+import behaviour;
 export {
-	CharacterStyle ::= BasicCharacterStyle, Underlined, Sharpness, EscapeHTML, SetRTL;
+	CharacterStyle ::= BasicCharacterStyle, Underlined, Sharpness, EscapeHTML, SetRTL, FTextWidth;
 	BasicCharacterStyle ::= FontFamily, FontSize, Fill, FillOpacity, LetterSpacing, BackgroundFill, BackgroundFillOpacity;
 		FontFamily : (name : string);
 		FontSize : (size : double);
@@ -24,6 +25,7 @@ export {
 		Underlined(style : [GraphicsStyle]);
 		EscapeHTML(escape : bool);
 		SetRTL(rtl : bool);
+		FTextWidth(width : DynamicBehaviour<double>); // Inspector
 
 	GraphicsStyle ::= Fill, FillOpacity, GradientFill, RadialGradient, Stroke, StrokeOpacity, StrokeWidth, StrokeLineGradient;
 		// This is 0x00RRGGBB, and can not have alpha channel. Use StrokeOpacity for that.

--- a/lib/stylestructs.flow
+++ b/lib/stylestructs.flow
@@ -1,6 +1,6 @@
 import behaviour;
 export {
-	CharacterStyle ::= BasicCharacterStyle, Underlined, Sharpness, EscapeHTML, SetRTL, FTextWidth;
+	CharacterStyle ::= BasicCharacterStyle, Underlined, Sharpness, EscapeHTML, SetRTL, TextWidthInspector;
 	BasicCharacterStyle ::= FontFamily, FontSize, Fill, FillOpacity, LetterSpacing, BackgroundFill, BackgroundFillOpacity;
 		FontFamily : (name : string);
 		FontSize : (size : double);
@@ -25,7 +25,7 @@ export {
 		Underlined(style : [GraphicsStyle]);
 		EscapeHTML(escape : bool);
 		SetRTL(rtl : bool);
-		FTextWidth(width : DynamicBehaviour<double>); // Inspector
+		TextWidthInspector(width : DynamicBehaviour<double>); // Inspector
 
 	GraphicsStyle ::= Fill, FillOpacity, GradientFill, RadialGradient, Stroke, StrokeOpacity, StrokeWidth, StrokeLineGradient;
 		// This is 0x00RRGGBB, and can not have alpha channel. Use StrokeOpacity for that.

--- a/lib/sys/target.flow
+++ b/lib/sys/target.flow
@@ -342,11 +342,12 @@ isMobileBrowser() -> bool {
 	js && mobile;
 }
 
+safariBrowser = js && strContains(toLowerCase(getBrowser()), "safari");
 isSafariBrowser() -> bool {
 	// https://github.com/faisalman/ua-parser-js#methods
 	// Safari
 	// Mobile Safari
-	js && strContains(toLowerCase(getBrowser()), "safari")
+	safariBrowser
 }
 
 isIE() -> bool {

--- a/lib/tropic/tropic2form.flow
+++ b/lib/tropic/tropic2form.flow
@@ -2158,13 +2158,13 @@ tropic2Acc(b : Tropic, parent : TParentInfo, sheet : Stylesheet, metricsOnly : b
 			charStyle = tcharacterStyle2charStyle(s);
 			fTextStyle = tcharacterStyle2FTextStyle(s);
 			wh = getStaticFormSize2(Text(t, charStyle), false);
-			textWidth = extractStruct(s, FTextWidth(make(wh.width))).width;
+			textWidth = extractStruct(s, TextWidthInspector(make(wh.width))).width;
 
 			TAcc(
 				if (metricsOnly)
 					FEmpty()
 				else
-					FText(const(t), replaceStruct(fTextStyle, FTextWidth(textWidth))),
+					FText(const(t), replaceStruct(fTextStyle, TextWidthInspector(textWidth))),
 				TFormMetrics(
 					textWidth,
 					const(wh.height),

--- a/lib/tropic/tropic2form.flow
+++ b/lib/tropic/tropic2form.flow
@@ -2158,13 +2158,13 @@ tropic2Acc(b : Tropic, parent : TParentInfo, sheet : Stylesheet, metricsOnly : b
 			charStyle = tcharacterStyle2charStyle(s);
 			fTextStyle = tcharacterStyle2FTextStyle(s);
 			wh = getStaticFormSize2(Text(t, charStyle), false);
-			textWidth = make(wh.width);
+			textWidth = extractStruct(s, FTextWidth(make(wh.width))).width;
 
 			TAcc(
 				if (metricsOnly)
 					FEmpty()
 				else
-					FText(const(t), arrayPush(fTextStyle, FTextWidth(textWidth))),
+					FText(const(t), replaceStruct(fTextStyle, FTextWidth(textWidth))),
 				TFormMetrics(
 					textWidth,
 					const(wh.height),

--- a/lib/tropic/tropic_ui.flow
+++ b/lib/tropic/tropic_ui.flow
@@ -224,7 +224,7 @@ TTextButton(text : string, shortcut : string, style : [TTextButtonStyle], state 
 			TTextOnly(): acc;
 			EscapeHTML(__): acc;
 			SetRTL(__): acc;
-			FTextWidth(__): acc;
+			TextWidthInspector(__): acc;
 
 			TWhite(): s;
 			TBlack(): s;
@@ -253,7 +253,7 @@ TTextButton(text : string, shortcut : string, style : [TTextButtonStyle], state 
 			Underlined(__): arrayPush(acc, s);
 			EscapeHTML(__): arrayPush(acc, s);
 			SetRTL(__): arrayPush(acc, s);
-			FTextWidth(__): arrayPush(acc, s);
+			TextWidthInspector(__): arrayPush(acc, s);
 
 			StrokeWidth(__): acc;
 			TWhite(): acc;

--- a/lib/tropic/tropic_ui.flow
+++ b/lib/tropic/tropic_ui.flow
@@ -224,6 +224,7 @@ TTextButton(text : string, shortcut : string, style : [TTextButtonStyle], state 
 			TTextOnly(): acc;
 			EscapeHTML(__): acc;
 			SetRTL(__): acc;
+			FTextWidth(__): acc;
 
 			TWhite(): s;
 			TBlack(): s;
@@ -252,6 +253,7 @@ TTextButton(text : string, shortcut : string, style : [TTextButtonStyle], state 
 			Underlined(__): arrayPush(acc, s);
 			EscapeHTML(__): arrayPush(acc, s);
 			SetRTL(__): arrayPush(acc, s);
+			FTextWidth(__): arrayPush(acc, s);
 
 			StrokeWidth(__): acc;
 			TWhite(): acc;


### PR DESCRIPTION
In Safari, the text behaves like dynamic element regarding its metrics so we can't measure it in advance.
for example, the real metrics of the text is changes in case the scale is changed. but from pixi (canvas) point of view nothing changed.