### PR TITLE
JS: introduce FInputEventFilter

### DIFF
--- a/lib/fform/fform.flow
+++ b/lib/fform/fform.flow
@@ -205,7 +205,7 @@ export {
 	FTextInput(content : DynamicBehaviour<string>, wh : DynamicBehaviour<WidthHeight>, style : [FTextInputStyle]);
 		FTextInputStyle ::= CharacterStyle, FWordWrap, FMultiline, FInputType, FAutoCompleteType, FReadOnly, FInputFilter, FInputKeyFilter, FMaxChars,
 			FAutoAlign, FFocus, FPosition, FSelection, FScrollInfo, FCursorColor, FCursorOpacity, FCursorWidth, FNumericStep, ViewBounds, FAccessProperty,
-			FCharacterStyle, InterlineSpacing, SetRTL;
+			FCharacterStyle, InterlineSpacing, SetRTL, FInputEventFilter;
 
 			FWordWrap(wrap : Transform<bool>);
 			FMultiline(multiline : Transform<bool>);
@@ -213,6 +213,7 @@ export {
 			FAutoCompleteType(type : Transform<ACType>);
 			FReadOnly(readOnly : Transform<bool>);
 			FInputFilter(fn : (string) -> string);
+			FInputEventFilter(fn : (string, string) -> string); // in JS, accepts text and type of inputEvent (insertText, insertFromPaste and maybe other)
 			FInputKeyFilter(fn : (name : string, event : KeyEvent) -> bool);
 			FMaxChars(maxChars : Transform<int>);
 			FAutoAlign(align : Transform<AutoAlignType>);
@@ -228,6 +229,8 @@ export {
 			FCursorWidth(width : Transform<double>);
 
 			FCharacterStyle(style : Transform<[CharacterStyle]>);
+
+			dummyFInputEventFilter = FInputEventFilter(\s, __ -> s);
 
 	// Draws content with 'canvas' renderer
 	// Works only in js with 'html' renderer, for other targets identical to regular clip

--- a/lib/fform/renderfform.flow
+++ b/lib/fform/renderfform.flow
@@ -1488,6 +1488,8 @@ renderFForm(rform : FForm, zorder : Transform<[int]>) -> FRenderResult {
 			maxChars = extractStruct(style, FMaxChars(const(-1))).maxChars;
 			numericStep = tryExtractStruct(style, FNumericStep(const(1.)));
 			filterFn = tryExtractStruct(style, FInputFilter(idfn));
+			eventFilterFn = tryExtractStruct(style, dummyFInputEventFilter);
+
 			keyFilterFn = tryExtractStruct(style, FInputKeyFilter(\__, __ -> true));
 			cursorColor = extractStruct(style, FCursorColor(fselect(characterStyle, FLift(\cs -> extractStruct(cs, Fill(0)).color)))).color;
 			cursorOpacity = extractStruct(style, FCursorOpacity(fselect(characterStyle, FLift(\cs -> extractStruct(cs, FillOpacity(1.)).opacity)))).opacity;
@@ -1600,6 +1602,12 @@ renderFForm(rform : FForm, zorder : Transform<[int]>) -> FRenderResult {
 						filterFn,
 						\fn ->
 							[addTextInputFilter(textfield, fn.fn)],
+						[]
+					),
+					eitherMap(
+						eventFilterFn,
+						\fn ->
+							[addTextInputEventFilter(textfield, fn.fn)],
 						[]
 					),
 					eitherMap(

--- a/lib/fform/sfform.flow
+++ b/lib/fform/sfform.flow
@@ -320,6 +320,7 @@ FTextInputStyle2SFTextInputStyle(style : [FTextInputStyle]) -> [SFTextInputStyle
 				FInputType(type) : Some(SInputType(fgetValue(type)));
 				FReadOnly(readOnly) : Some(SReadOnly(fgetValue(readOnly)));
 				FInputFilter(__): None();
+				FInputEventFilter(__): None();
 				FInputKeyFilter(__): None();
 				FMaxChars(maxChars) : Some(SMaxChars(fgetValue(maxChars)));
 				FAutoAlign(align) : Some(SAutoAlign(fgetValue(align)));

--- a/lib/rendersupport.flow
+++ b/lib/rendersupport.flow
@@ -155,6 +155,7 @@ export {
 	native setTextInputAutoCompleteType : io (native, string) -> void = RenderSupport.setTextInputAutoCompleteType;
 	native setTextInputStep : io (native, double) -> void = RenderSupport.setTextInputStep;
 	native addTextInputFilter : io (textfiled : native, f : (string) -> string) -> () -> void = RenderSupport.addTextInputFilter;
+	native addTextInputEventFilter : io (textfiled : native, f : (string, string) -> string) -> () -> void = RenderSupport.addTextInputEventFilter;
 	native addTextInputKeyEventFilter : io (
 		clip : native, event : string, cb : (key : string, ctrl : bool, shift : bool,
 		alt : bool, meta : bool, keyCode : int) -> bool
@@ -352,6 +353,7 @@ getPixelsPerCm() { 37.795; }
 getBrowserZoom() { 1.0; }
 isDarkMode() { false; }
 addTextInputFilter(textfiled, f) { nop }
+addTextInputEventFilter(textfiled, f) { nop }
 setTabEnabled(c, e) { }
 addExtendedEventListener(c, e, cb) { nop }
 setAccessibilityEnabled(e) { }

--- a/platforms/js/RenderSupport.hx
+++ b/platforms/js/RenderSupport.hx
@@ -1836,6 +1836,10 @@ class RenderSupport {
 		return clip.addTextInputFilter(filter);
 	}
 
+	public static function addTextInputEventFilter(clip : TextClip, filter : String -> String -> String) : Void -> Void {
+		return clip.addTextInputEventFilter(filter);
+	}
+
 	public static function addTextInputKeyEventFilter(clip : TextClip, event : String, filter : String -> Bool -> Bool -> Bool -> Bool -> Int -> Bool) : Void -> Void {
 		if (event == "keydown")
 			return clip.addTextInputKeyDownEventFilter(filter);

--- a/platforms/js/TextClip.hx
+++ b/platforms/js/TextClip.hx
@@ -153,6 +153,7 @@ class TextClip extends NativeWidgetClip {
 	private var multiline : Bool = false;
 
 	private var TextInputFilters : Array<String -> String> = new Array();
+	private var TextInputEventFilters : Array<String -> String -> String> = new Array();
 	private var TextInputKeyDownFilters : Array<String -> Bool -> Bool -> Bool -> Bool -> Int -> Bool> = new Array();
 	private var TextInputKeyUpFilters : Array<String -> Bool -> Bool -> Bool -> Bool -> Int -> Bool> = new Array();
 
@@ -1214,6 +1215,12 @@ class TextClip extends NativeWidgetClip {
 			newValue = f(newValue);
 		}
 
+		if (e != null && e.inputType != null) {
+			for (f in TextInputEventFilters) {
+				newValue = f(newValue, e.inputType);
+			}
+		}
+
 		if (nativeWidget == null) {
 			return;
 		}
@@ -1407,6 +1414,11 @@ class TextClip extends NativeWidgetClip {
 	public function addTextInputFilter(filter : String -> String) : Void -> Void {
 		TextInputFilters.push(filter);
 		return function() { TextInputFilters.remove(filter); }
+	}
+
+	public function addTextInputEventFilter(filter : String -> String -> String) : Void -> Void {
+		TextInputEventFilters.push(filter);
+		return function() { TextInputEventFilters.remove(filter); }
 	}
 
 	public function addTextInputKeyDownEventFilter(filter : String -> Bool -> Bool -> Bool -> Bool -> Int -> Bool) : Void -> Void {


### PR DESCRIPTION
linked with https://github.com/area9innovation/innovation/pull/2112

in JS when pasting into FTextInput, we receive input both from paste and typing
but in WIGI we process pasting from global paste listener (special event Paste) so it leads to double processing of the pasting text.
this new filter allow to get type of event