### PR TITLE
Fix PIXI.TextMetrics.measureFont on MacOS

### DIFF
--- a/platforms/js/PixiWorkarounds.hx
+++ b/platforms/js/PixiWorkarounds.hx
@@ -753,7 +753,7 @@ class PixiWorkarounds {
 				{
 					for (var j = 0; j < line; j += 4)
 					{
-						if (imagedata[idx + j] !== 255)
+						if (imagedata[idx + j] <= 150)
 						{
 							stop = true;
 							break;
@@ -779,7 +779,7 @@ class PixiWorkarounds {
 				{
 					for (var j = 0; j < line; j += 4)
 					{
-						if (imagedata[idx + j] !== 255)
+						if (imagedata[idx + j] <= 150)
 						{
 							stop = true;
 							break;
@@ -798,48 +798,6 @@ class PixiWorkarounds {
 
 				properties.descent = i - baseline;
 				properties.fontSize = properties.ascent + properties.descent;
-
-				context.fillStyle = '#f00';
-				context.fillRect(0, 0, width, height);
-
-				context.textBaseline = 'alphabetic';
-				context.fillStyle = '#000';
-				context.fillText('B', 0, baseline);
-
-				imagedata = context.getImageData(0, 0, width, height).data;
-				pixels = imagedata.length;
-				line = width * 4;
-
-				i = 0;
-				idx = 0;
-				stop = false;
-
-				// ascent. scan from top to bottom until we find a non red pixel
-				for (i = 0; i < baseline; ++i)
-				{
-					for (var j = 0; j < line; j += 4)
-					{
-						if (imagedata[idx + j] !== 255)
-						{
-							stop = true;
-							break;
-						}
-					}
-					if (!stop)
-					{
-						idx += line;
-					}
-					else
-					{
-						break;
-					}
-				}
-
-				if (Platform.isMacintosh) {
-					properties.baselineCorrection = (properties.descent - (properties.ascent - (baseline - i - 1.0))) / 2.0;
-					properties.descent -= properties.baselineCorrection;
-					properties.ascent += properties.baselineCorrection;
-				}
 
 				PIXI.TextMetrics._fonts[font] = properties;
 

--- a/platforms/js/RenderSupport.hx
+++ b/platforms/js/RenderSupport.hx
@@ -90,7 +90,7 @@ class RenderSupport {
 			Antialias = Util.getParameter("antialias") != null ? Util.getParameter("antialias") == "1" :
 				!Native.isTouchScreen() && (RendererType != "webgl" || Native.detectDedicatedGPU());
 
-			untyped __js__("PIXI.TextMetrics.METRICS_STRING = (Platform.isMacintosh || (Platform.isIOS && RenderSupport.RendererType != 'html')) ? '|Éq█Å' : '|Éq'");
+			// untyped __js__("PIXI.TextMetrics.METRICS_STRING = (Platform.isMacintosh || (Platform.isIOS && RenderSupport.RendererType != 'html')) ? '|Éq█Å' : '|Éq'");
 
 			PixiWorkarounds.workaroundGetContext();
 
@@ -571,7 +571,7 @@ class RenderSupport {
 			untyped __js__("document.location.reload(true)");
 		}
 
-		untyped __js__("PIXI.TextMetrics.METRICS_STRING = (Platform.isMacintosh || (Platform.isIOS && RenderSupport.RendererType != 'html')) ? '|Éq█Å' : '|Éq'");
+		// untyped __js__("PIXI.TextMetrics.METRICS_STRING = (Platform.isMacintosh || (Platform.isIOS && RenderSupport.RendererType != 'html')) ? '|Éq█Å' : '|Éq'");
 
 		PixiWorkarounds.workaroundGetContext();
 		PixiWorkarounds.workaroundTextMetrics();

--- a/platforms/js/RenderSupport.hx
+++ b/platforms/js/RenderSupport.hx
@@ -90,7 +90,7 @@ class RenderSupport {
 			Antialias = Util.getParameter("antialias") != null ? Util.getParameter("antialias") == "1" :
 				!Native.isTouchScreen() && (RendererType != "webgl" || Native.detectDedicatedGPU());
 
-			// untyped __js__("PIXI.TextMetrics.METRICS_STRING = (Platform.isMacintosh || (Platform.isIOS && RenderSupport.RendererType != 'html')) ? '|Éq█Å' : '|Éq'");
+			untyped __js__("PIXI.TextMetrics.METRICS_STRING = ((Platform.isMacintosh || Platform.isIOS) && RenderSupport.RendererType != 'html') ? '|Éq█Å' : '|Éq'");
 
 			PixiWorkarounds.workaroundGetContext();
 
@@ -571,7 +571,7 @@ class RenderSupport {
 			untyped __js__("document.location.reload(true)");
 		}
 
-		// untyped __js__("PIXI.TextMetrics.METRICS_STRING = (Platform.isMacintosh || (Platform.isIOS && RenderSupport.RendererType != 'html')) ? '|Éq█Å' : '|Éq'");
+		untyped __js__("PIXI.TextMetrics.METRICS_STRING = ((Platform.isMacintosh || Platform.isIOS) && RenderSupport.RendererType != 'html') ? '|Éq█Å' : '|Éq'");
 
 		PixiWorkarounds.workaroundGetContext();
 		PixiWorkarounds.workaroundTextMetrics();


### PR DESCRIPTION

In the branch:
![image](https://user-images.githubusercontent.com/14361571/111954094-a03ff280-8af8-11eb-8672-887f8bcc2800.png)

In the master:
![image](https://user-images.githubusercontent.com/14361571/111954128-afbf3b80-8af8-11eb-8891-5abeea815bfa.png)
