### PR TITLE
Make foldiAsync2 tail recursive

### DIFF
--- a/lib/ds/arrayutils.flow
+++ b/lib/ds/arrayutils.flow
@@ -29,6 +29,7 @@ export {
 	foldi2(a : [?], init1 : ??, init2 : ???, fn : (int, ??, ???, ?) -> Pair<??, ???>) -> Pair<??, ???>;
 
 	// Functions for performing synchronous array operations with an asynchronous function.
+	// They use tail recursive and apply fn on items in natural order.
 	foldAsync(xs : [?], init : ??, fn : (??, ?, (??) -> void, (???) -> void) -> void, onOK : (??) -> void, onError : (???) -> void) -> void;
 	foldiAsync(xs : [?], init : ??, fn : (int, ??, ?, (??) -> void, (???) -> void) -> void, onOK : (??) -> void, onError : (???) -> void) -> void;
 	// Same as doneP(allP(map(xs, \x -> Promise(\f, r -> f(x, f, r)))), fulfill, reject)
@@ -233,6 +234,10 @@ foldiAsync(xs : [?], init : ??, fn : (int, ??, ?, (??) -> void, (???) -> void) -
 	foldiAsync2(xs, length(xs) - 1, init, fn, onOK, onError)
 }
 
+// It starts to iterate from the last element of array (xs[n-1]),
+// because it calls itself recursively and the first real call of fn happens 
+// for the last iterated element (x[0]), then it goes back over the rest elements 
+// via callbacks. This way it performs array elements in natural order.
 foldiAsync2(xs : [?], i : int, acc : ??, fn : (int, ??, ?, (??) -> void, (???) -> void) -> void, onOK : (??) -> void, onError : (???) -> void) -> void {
 	if (i < 0) {
 		onOK(acc)

--- a/lib/ds/arrayutils.flow
+++ b/lib/ds/arrayutils.flow
@@ -226,20 +226,20 @@ binaryFold(
 }
 
 foldAsync(xs : [?], init : ??, fn : (??, ?, (??) -> void, (???) -> void) -> void, onOK : (??) -> void, onError : (???) -> void) -> void {
-	foldiAsync2(xs, 0, init, \__, acc, x, onOKFn, onErrorFn -> fn(acc, x, onOKFn, onErrorFn), onOK, onError)
+	foldiAsync2(xs, length(xs) - 1, init, \__, acc, x, onOKFn, onErrorFn -> fn(acc, x, onOKFn, onErrorFn), onOK, onError)
 }
 
 foldiAsync(xs : [?], init : ??, fn : (int, ??, ?, (??) -> void, (???) -> void) -> void, onOK : (??) -> void, onError : (???) -> void) -> void {
-	foldiAsync2(xs, 0, init, fn, onOK, onError)
+	foldiAsync2(xs, length(xs) - 1, init, fn, onOK, onError)
 }
 
 foldiAsync2(xs : [?], i : int, acc : ??, fn : (int, ??, ?, (??) -> void, (???) -> void) -> void, onOK : (??) -> void, onError : (???) -> void) -> void {
-	if (i == length(xs)) {
+	if (i < 0) {
 		onOK(acc)
+	} else if (i == 0) {
+		fn(i, acc, xs[i], onOK, onError)
 	} else {
-		fn(i, acc, xs[i], \acc2 -> {
-			foldiAsync2(xs, i + 1, acc2, fn, onOK, onError)
-		}, onError)
+		foldiAsync2(xs, i - 1, acc, fn, \acc2 -> fn(i, acc2, xs[i], onOK, onError), onError)
 	}
 }
 


### PR DESCRIPTION
It addresses "Maybe iterASync could be implemented simpler than using foldiAsync2" not to get stack overflow.