### PR TITLE
Added highlight for annotated images

### DIFF
--- a/lib/form/paragraph3.flow
+++ b/lib/form/paragraph3.flow
@@ -316,7 +316,10 @@ renderParagraphEx(
 		filtermap(words, \word -> {
 			applyStyles = \form -> eitherMap(
 				lookupTree(interactiveStyles, either(word.interactivityIdM, -1)),
-				\wordStyles -> applyListenersAndModifiers(wordStyles, form),
+				\wordStyles -> {
+					applyListenersAndModifiers(wordStyles, form)
+					|>(\f -> applyBlockHighlighting(wordStyles, f))
+				},
 				form
 			);
 			switch (word.ghosted : Ghosted) {
@@ -1210,6 +1213,40 @@ applyListenersAndModifiers(styles : [ParaElementInteractiveStyle], form : Form) 
 	}
 }
 
+applyBlockHighlighting(styles : [ParaElementInteractiveStyle], form : Form) -> Form {
+	eitherMap(tryExtractStruct(styles, Stroked()),
+	\__ -> {
+		getStyleForRectFromCharStyle = \s -> eitherMap(
+			tryExtractStruct(s, BackgroundFill(white)),
+			\backFill -> [
+				Stroke(backFill.color),
+				StrokeOpacity(extractStruct(s, BackgroundFillOpacity(1.0)).opacity),
+				StrokeWidth(3.0),
+			],
+			[]
+		);
+
+		makeRect = \dynStyle, wh : WidthHeight -> Rectangle(
+			wh.width,
+			wh.height,
+			getStyleForRectFromCharStyle(dynStyle)
+		);
+		
+		eitherMap(
+			tryExtractStruct(styles, DynamicCharStyle(make([]))),
+			\dynCharStyle -> {
+				whB = makeWH();
+				Group([
+					Inspect([ISize(whB)], form),
+					Select2(dynCharStyle.styleB, whB, makeRect),
+				])
+			},
+			form
+		)
+	},
+	form
+	)
+}
 
 // Joins texts together to a single text element, along with the new metrics
 optimizeLine(words : [ParaWord]) -> [OptimizedLineElement] {

--- a/lib/form/paragraph3.flow
+++ b/lib/form/paragraph3.flow
@@ -1153,7 +1153,7 @@ applyIntStylesAndHighlighting(
 		)
 	);
 
-	dynamicCharStyleBM = tryExtractStruct(styles, DynamicCharStyle(make([])));
+	dynamicHighlightStyleBM = tryExtractStruct(styles, DynamicHighlightStyle(make([]), false));
 
 	textAndBackPair = switch(form) {
 		Text(txt, txtStyle) : {
@@ -1169,10 +1169,10 @@ applyIntStylesAndHighlighting(
 			// We draw custom highlighting to fix gaps for cases of justifying alignment
 			// And to have more straight and pretty highlighting.
 			eitherMap(
-				dynamicCharStyleBM,
-				\dynCharStyle -> Pair(
-					Select(dynCharStyle.styleB, \chStyle -> makeTxt(chStyle)),
-					Select(dynCharStyle.styleB, \chStyle -> makeBackRect(txtStyle, chStyle))
+				dynamicHighlightStyleBM,
+				\dynHlStyle -> Pair(
+					Select(dynHlStyle.styleB, \chStyle -> makeTxt(chStyle)),
+					Select(dynHlStyle.styleB, \chStyle -> makeBackRect(txtStyle, chStyle))
 				),
 				Pair(makeTxt([]), makeBackRect(txtStyle, []))
 			)
@@ -1180,8 +1180,8 @@ applyIntStylesAndHighlighting(
 		default : Pair(
 			form,
 			eitherMap(
-				dynamicCharStyleBM,
-				\dynCharStyle -> Select(dynCharStyle.styleB, \chStyle -> makeBackRect([], chStyle)),
+				dynamicHighlightStyleBM,
+				\dynHlStyle -> Select(dynHlStyle.styleB, \chStyle -> makeBackRect([], chStyle)),
 				Empty()
 			)
 		);
@@ -1214,35 +1214,31 @@ applyListenersAndModifiers(styles : [ParaElementInteractiveStyle], form : Form) 
 }
 
 applyBlockHighlighting(styles : [ParaElementInteractiveStyle], form : Form) -> Form {
-	eitherMap(tryExtractStruct(styles, Stroked()),
-	\__ -> {
-		getStyleForRectFromCharStyle = \s -> eitherMap(
-			tryExtractStruct(s, BackgroundFill(white)),
-			\backFill -> [
-				Stroke(backFill.color),
-				StrokeOpacity(extractStruct(s, BackgroundFillOpacity(1.0)).opacity),
-				StrokeWidth(3.0),
-			],
-			[]
-		);
+	eitherMap(tryExtractStruct(styles, DynamicHighlightStyle(make([]), false)),
+	\dynamicHlStyle -> {
+		if (dynamicHlStyle.extraHighlight) {
+			getStyleForRectFromCharStyle = \s -> eitherMap(
+				tryExtractStruct(s, BackgroundFill(white)),
+				\backFill -> [
+					Stroke(backFill.color),
+					StrokeOpacity(extractStruct(s, BackgroundFillOpacity(1.0)).opacity),
+					StrokeWidth(3.0),
+				],
+				[]
+			);
 
-		makeRect = \dynStyle, wh : WidthHeight -> Rectangle(
-			wh.width,
-			wh.height,
-			getStyleForRectFromCharStyle(dynStyle)
-		);
-		
-		eitherMap(
-			tryExtractStruct(styles, DynamicCharStyle(make([]))),
-			\dynCharStyle -> {
-				whB = makeWH();
-				Group([
-					Inspect([ISize(whB)], form),
-					Select2(dynCharStyle.styleB, whB, makeRect),
-				])
-			},
-			form
-		)
+			makeRect = \dynStyle, wh : WidthHeight -> Rectangle(
+				wh.width,
+				wh.height,
+				getStyleForRectFromCharStyle(dynStyle)
+			);
+
+			whB = makeWH();
+			Group([
+				Inspect([ISize(whB)], form),
+				Select2(dynamicHlStyle.styleB, whB, makeRect),
+			])
+		} else form
 	},
 	form
 	)

--- a/lib/form/paragraphtypes.flow
+++ b/lib/form/paragraphtypes.flow
@@ -39,11 +39,12 @@ export {
 		// Needed because paragraph elements get expanded to words before rendering of paragraph lines.
 		ParagraphInteractiveStyleTree(styleTree : Tree<int, [ParaElementInteractiveStyle]>);
 
-		ParaElementInteractiveStyle ::= DynamicCharStyle, EventListeners, FormModifiers, IgnoreMetrics, ParaElementScriptType;
+		ParaElementInteractiveStyle ::= DynamicCharStyle, EventListeners, FormModifiers, IgnoreMetrics, ParaElementScriptType, Stroked;
 				DynamicCharStyle(styleB : Behaviour<[CharacterStyle]>);
 				EventListeners(listeners : [EventHandler]);
 				FormModifiers(fns : [(Form) -> Form]);
 				IgnoreMetrics();
+				Stroked();
 
 			ParaElementScriptType ::= ParaElementSubscript, ParaElementSuperscript;
 				ParaElementSubscript();

--- a/lib/form/paragraphtypes.flow
+++ b/lib/form/paragraphtypes.flow
@@ -39,12 +39,11 @@ export {
 		// Needed because paragraph elements get expanded to words before rendering of paragraph lines.
 		ParagraphInteractiveStyleTree(styleTree : Tree<int, [ParaElementInteractiveStyle]>);
 
-		ParaElementInteractiveStyle ::= DynamicCharStyle, EventListeners, FormModifiers, IgnoreMetrics, ParaElementScriptType, Stroked;
-				DynamicCharStyle(styleB : Behaviour<[CharacterStyle]>);
+		ParaElementInteractiveStyle ::= DynamicHighlightStyle, EventListeners, FormModifiers, IgnoreMetrics, ParaElementScriptType;
+				DynamicHighlightStyle(styleB : Behaviour<[CharacterStyle]>, extraHighlight : bool);
 				EventListeners(listeners : [EventHandler]);
 				FormModifiers(fns : [(Form) -> Form]);
 				IgnoreMetrics();
-				Stroked();
 
 			ParaElementScriptType ::= ParaElementSubscript, ParaElementSuperscript;
 				ParaElementSubscript();


### PR DESCRIPTION
Added borders highlight for annotated images:
![annotation](https://user-images.githubusercontent.com/19254090/117160762-10b18300-adca-11eb-8edf-0d37e2dc95cd.png)

**Related PR:** https://github.com/area9innovation/innovation/pull/2256