### PR TITLE
Changed the positioning of the text-superscript

### DIFF
--- a/lib/form/paragraph3.flow
+++ b/lib/form/paragraph3.flow
@@ -1065,7 +1065,9 @@ RenderLine(
 		isSuperscript = intStyleContains(ParaElementSuperscript());
 		isSubscript = intStyleContains(ParaElementSubscript());
 
-		dy = if (isSuperscript) -1.0 else info.lineAsc - m.baseline / (if (isSubscript) 2.0 else 1.0);
+		dy = if (isSuperscript) {
+			if (i == 0) -1.0 else info.lineAsc - m.baseline - fgetValue(info.optimizedLine[i - 1].metrics).height * 0.4
+		} else info.lineAsc - m.baseline / (if (isSubscript) 2.0 else 1.0);
 		applyStylesAndOffset = \fm : Form -> eitherMap(
 			elem.interactivityIdM,
 			\id -> applyIntStylesAndHighlighting(

--- a/lib/tropic/tropic_paragraph.flow
+++ b/lib/tropic/tropic_paragraph.flow
@@ -1179,11 +1179,12 @@ TRenderLine(
 	iteri(inspectors, \i : int, inspector -> {
 		elemWidth = getValue(inspector.size).width;
 		elemHeight = getValue(inspector.size).height;
+		elemBaseline = getValue(inspector.baseline);
 		dy = eitherMap(
 			words[i].scriptM,
 			\script -> switch(script) {
-				ParaElementSuperscript() : -1.0;
-				ParaElementSubscript() : lineAsc - getValue(inspector.baseline) / 2.0;
+				ParaElementSuperscript() : if (i==0) -1.0 else lineAsc - elemBaseline - getValue(inspectors[i-1].size).height * 0.4;
+				ParaElementSubscript() : lineAsc - elemBaseline / 2.0;
 			},
 			lineAsc - getValue(inspector.baseline)
 		);


### PR DESCRIPTION
Currently, the superscript position is based on the height of the character immediately before it.
![superscript](https://user-images.githubusercontent.com/19254090/119132313-3a61df80-ba43-11eb-9629-2ef2e0284d09.png)
