### PR TITLE
Added a style to control the positioning of superscript text

### DIFF
--- a/lib/form/paragraph3.flow
+++ b/lib/form/paragraph3.flow
@@ -272,6 +272,8 @@ renderParagraphEx(
 	isParagraphMarked = containsStruct(s, ParagraphMarked());
 	paragraphBorder = extractStruct(s, ParagraphBorder(0.0, 0.0));
 
+	superscriptOnTop = containsStruct(s, SuperscriptOnTopLine());
+
 	// Expand elements into word-units
 	glued : List<ParaAtomic> = expandGlueFragments(p, false, makeList(), makeList(), 0);
 	// Construct our ParaWords
@@ -304,7 +306,7 @@ renderParagraphEx(
 			storyWidth, lines, tightWidth, alignment, interlineSpacing,
 			topLineBaseline, interactiveStyles, rtl, isParagraphMarked,
 			interLineHighlighting,
-			renderedLinesInfoM
+			renderedLinesInfoM, superscriptOnTop
 		);
 	}
 	paragraphAccessibilityParent = ^accessibilityParent;
@@ -954,7 +956,8 @@ renderParaLines(
 	rtl : bool,
 	isMarked : bool,
 	interLineHighlighting : bool,
-	renderedLinesInfoM : Maybe<DynamicBehaviour<[WigiRenderedLinesInfo]>>
+	renderedLinesInfoM : Maybe<DynamicBehaviour<[WigiRenderedLinesInfo]>>,
+	superscriptOnTop : bool
 ) -> Form {
 	lasti = length(lines.lines) - 1;
 	a : ParaLineAcc = foldi(lines.lines, ParaLineAcc(EmptyList(), 0.0, 0.0), \i : int, acc : ParaLineAcc, lineInfo : ParaLineInfo -> {
@@ -977,7 +980,8 @@ renderParaLines(
 			} else 0.0,
 			if (interLineHighlighting){
 				if (lastLine || i == 0) interlineSpacing / 2.0 else interlineSpacing
-			} else 0.0
+			} else 0.0,
+			superscriptOnTop
 		);
 		ParaLineAcc(
 			Cons(Size2(const(zeroWH), f.form), acc.lines),
@@ -1032,6 +1036,7 @@ RenderLine(
 	isMarked : bool,
 	highLightOffset : double,
 	interlineSpacing : double,
+	superscriptOnTop : bool
 ) -> ParaLineResult {
 	remaining = width - info.lineWidth;
 	alignmentOffset = ref calcParaLineAlignmentOffset(remaining, info.lineIndent, rtl, alignment);
@@ -1059,7 +1064,7 @@ RenderLine(
 		isSubscript = intStyleContains(ParaElementSubscript());
 
 		dy = if (isSuperscript) {
-			if (i == 0) -1.0 else info.lineAsc - m.baseline - fgetValue(info.optimizedLine[i - 1].metrics).height * 0.4
+			if (i == 0 || superscriptOnTop) -1.0 else info.lineAsc - m.baseline - fgetValue(info.optimizedLine[i - 1].metrics).height * 0.4
 		} else info.lineAsc - m.baseline / (if (isSubscript) 2.0 else 1.0);
 		applyStylesAndOffset = \fm : Form -> eitherMap(
 			elem.interactivityIdM,

--- a/lib/form/paragraphtypes.flow
+++ b/lib/form/paragraphtypes.flow
@@ -15,7 +15,7 @@ export {
 		FirstLineIndent, DynamicBlockDelay, ParagraphBorder, ParagraphColoredBorder,
 		ParagraphInteractiveStyleTree, ParagraphSingleLine, ParagraphMarked, GeneralIndent,
 		ParagraphLinesCount, ParagraphRtl, InterlineHighlighting, ParagraphFitLongWords,
-		IgnoreLetterspacingOnReflow;
+		IgnoreLetterspacingOnReflow, SuperscriptOnTopLine;
 
 		// Spacing between lines. Can be used to implement leading. If the font size is
 		// 14 px, then set InterlineSpacing to 2 px to get 16 px leading.
@@ -65,6 +65,10 @@ export {
 		// Ignores letterspacing when doing relfow. Can lead to unexpected behaviour,
 		// needed only for backward compatibility with some content
 		IgnoreLetterspacingOnReflow();
+		
+		// With this style the superscript's position will be based on the height of the tallest character/element in the expression. 
+		// Default -  on the height of the character immediately before it.
+		SuperscriptOnTopLine();
 
 
 	TextElement ::= InspectElement, LinePart, NewLine, Space;

--- a/lib/tropic/tropic_paragraph.flow
+++ b/lib/tropic/tropic_paragraph.flow
@@ -59,6 +59,8 @@ TRenderDynamicParagraph(
 	isSingleLine = containsStruct(s, ParagraphSingleLine());
 	linesCountB = extractStruct(s, ParagraphLinesCount(make(0))).count;
 
+	superscriptOnTop = containsStruct(s, SuperscriptOnTopLine());
+
 	awB = make(0.0);
 	update = make(0);
 	paragraphBorder = extractStruct(s, ParagraphBorder(0.0, 0.0));
@@ -89,7 +91,7 @@ TRenderDynamicParagraph(
 		paragraphSizeBaselineAndChanges = reflowTParaWords(
 			^words, w, indent, tightWidth, alignment, interlineSpacing,
 			topLineBaseline, rtl, containsStruct(s, ParagraphMarked()),
-			genIndent, linesCountB, alignWidthM, false, false
+			genIndent, linesCountB, alignWidthM, false, false, superscriptOnTop
 		);
 		paragraphSizeAndBaseline = paragraphSizeBaselineAndChanges.metrics;
 		// We have to rerender even when lines are identical, at minimum to move things because of potential size changes
@@ -231,6 +233,8 @@ TRenderParagraph(
 	isSingleLine = containsStruct(s, ParagraphSingleLine());
 	linesCountB = extractStruct(s, ParagraphLinesCount(make(0))).count;
 
+	superscriptOnTop = containsStruct(s, SuperscriptOnTopLine());
+
 	awB = make(0.0);
 	update = make(0);
 	paragraphBorder = extractStruct(s, ParagraphBorder(0.0, 0.0));
@@ -270,7 +274,7 @@ TRenderParagraph(
 			words, w, indent, tightWidth, alignment, interlineSpacing,
 			topLineBaseline, rtl, containsStruct(s, ParagraphMarked()),
 			genIndent, linesCountB, alignWidthM, fitLongWords,
-			ignoreLetterSpacing
+			ignoreLetterSpacing, superscriptOnTop
 		);
 		paragraphSizeAndBaseline = paragraphSizeBaselineAndChanges.metrics;
 		// We have to rerender even when lines are identical, at minimum to move things because of potential size changes
@@ -705,7 +709,8 @@ reflowTParaWords(
 	linesCountB : DynamicBehaviour<int>,
 	alignWidthM : Maybe<double>,
 	fitLongWords : bool,
-	ignoreLetterSpacing : bool 
+	ignoreLetterSpacing : bool,
+	superscriptOnTop : bool 
 ) -> TReflowResult {
 	setTParaWordText = tParaWordsTextSetter(ignoreLetterSpacing);
 
@@ -746,7 +751,8 @@ reflowTParaWords(
 		rtl,
 		isMarked,
 		generalIndent,
-		alignWidthM
+		alignWidthM,
+		superscriptOnTop
 	);
 
 	TReflowResult(
@@ -1094,7 +1100,8 @@ TAlignParaLines(
 	rtl : bool,
 	isMarked : bool,
 	generalIndent : double,
-	alignWidthM : Maybe<double>
+	alignWidthM : Maybe<double>,
+	superscriptOnTop : bool
 ) -> Pair<WidthHeight, double> {
 	lasti = length(lines) - 1;
 
@@ -1112,7 +1119,7 @@ TAlignParaLines(
 		f = TRenderLine(
 			acc.y, line.words, availableWidth,
 			lineAlignment, line.indent, generalIndent,
-			i, rtl, isMarked, alignWidthM
+			i, rtl, isMarked, alignWidthM, superscriptOnTop
 		);
 		nwidth = max(acc.width, f.width);
 		// For interline spacing, it turns out that the old paragraph had crazy behaviour, so we have to double it
@@ -1142,7 +1149,8 @@ TRenderLine(
 	lineNumber : int,
 	rtl : bool,
 	isMarked : bool,
-	alignWidthM : Maybe<double>
+	alignWidthM : Maybe<double>,
+	superscriptOnTop : bool
 ) -> TParaLineResult {
 	// styles = map(optimizedLine, \p -> lookupTreeDef(interactiveStyles, getValue(p.id), []));
 	inspectors = map(words, \p -> p.inspector);
@@ -1183,7 +1191,7 @@ TRenderLine(
 		dy = eitherMap(
 			words[i].scriptM,
 			\script -> switch(script) {
-				ParaElementSuperscript() : if (i==0) -1.0 else lineAsc - elemBaseline - getValue(inspectors[i-1].size).height * 0.4;
+				ParaElementSuperscript() : if (i==0 || superscriptOnTop) -1.0 else lineAsc - elemBaseline - getValue(inspectors[i-1].size).height * 0.4;
 				ParaElementSubscript() : lineAsc - elemBaseline / 2.0;
 			},
 			lineAsc - getValue(inspector.baseline)


### PR DESCRIPTION
Added a new style to control the positioning of superscript text SuperscriptOnTopLine().
With this style the superscript's position will be based on the height of the tallest character/element in the expression. 
Default -  on the height of the character immediately before it.
		