### PR TITLE
Fix double zoom button

### DIFF
--- a/lib/formats/html/html2form.flow
+++ b/lib/formats/html/html2form.flow
@@ -723,7 +723,7 @@ getHtmlPictureMagnifyCustom(
 		]);
 	};
 
-	resultForm = Disposer(postCropTransfrom(scaledForm), closeMagnify);
+	resultForm = Disposer(scaledForm, closeMagnify);
 	Pair(resultForm, postCropTransfrom)
 }
 


### PR DESCRIPTION
https://trello.com/c/LRlGziTB/13835-zoom-icon-appears-twice-in-the-basic-image-editor-for-some-cropped-images