### PR TITLE
Remove extra space around WigiDottedElement

### DIFF
--- a/lib/form/mathdrawing.flow
+++ b/lib/form/mathdrawing.flow
@@ -534,11 +534,11 @@ dotted2formWithColor(body, left, top, right, bottom, leftSign, rightSign, color)
 
 
 		//calc topSpace and width of the top block
-		leftSpace = if (left > 2) radius else 2.0 * radius;
+		leftSpace = if (left > 0) {if (left > 2) radius else 2.0 * radius} else 0.0;
 		leftHeight = calcBlockSize(left, leftSpace);
 
 		//calc bottomSpace and width of the bottom block
-		rightSpace = if (right > 2) radius else 2.0 * radius;
+		rightSpace = if (right > 0) {if (right > 2) radius else 2.0 * radius} else 0.0;
 		rightHeight = calcBlockSize(right, rightSpace);
 
 		centerHeight = max3(storyHeight, leftHeight, rightHeight);
@@ -625,22 +625,20 @@ dotted2formWithColor(body, left, top, right, bottom, leftSign, rightSign, color)
 					bm = getValue(bmB);
 					bm.baseline + dm.topHeight
 			}),
-			Border(1.0, 0.0, 1.0, 0.0,
-				Size2(
-					select(dmB, \dm -> {
-						bm = getValue(bmB);
-						WidthHeight(dm.leftWidth + bm.width + dm.rightWidth, dm.leftHeight + bm.height + dm.rightHeight)
-					}),
-					Group([
-						Translate(select(dmB, \dm -> dm.leftWidth + max(0.0, dm.centerWidth - dm.topWidth) * 0.5), zero, topDots),
-						Translate(zero, select(dmB, \dm -> dm.topHeight + max(dm.centerHeight - dm.leftHeight, 0.0) * 0.5 + radius), leftDots),
-						Translate(select(dmB, \dm -> {bm = getValue(bmB); dm.leftWidth + max(0.0, dm.centerWidth - bm.width) * 0.5}), select(dmB, \dm -> dm.topHeight), bodyM),
-						Translate(select(dmB, \dm -> dm.leftWidth + dm.centerWidth), select(dmB, \dm -> dm.topHeight + max(dm.centerHeight - dm.rightHeight, 0.0) * 0.5 + radius), rightDots),
-						Translate(select(dmB, \dm -> dm.leftWidth + max(0.0, dm.centerWidth - dm.bottomWidth) * 0.5), select(dmB, \dm -> dm.topHeight + dm.centerHeight), bottomDots),
-						if (leftSign) signf else Empty(),
-						if (rightSign) Translate(select(dmB, \dm -> dm.leftWidth + dm.centerWidth), zero, signf) else Empty()
-					])
-				)
+			Size2(
+				select(dmB, \dm -> {
+					bm = getValue(bmB);
+					WidthHeight(dm.leftWidth + bm.width + dm.rightWidth, dm.leftHeight + bm.height + dm.rightHeight)
+				}),
+				Group([
+					Translate(select(dmB, \dm -> dm.leftWidth + max(0.0, dm.centerWidth - dm.topWidth) * 0.5), zero, topDots),
+					if (left > 0) Translate(zero, select(dmB, \dm -> dm.topHeight + max(dm.centerHeight - dm.leftHeight, 0.0) * 0.5 + radius), leftDots) else Empty(),
+					Translate(select(dmB, \dm -> {bm = getValue(bmB); dm.leftWidth + if (top > 1 || bottom > 1) {max(0.0, dm.centerWidth - bm.width) * 0.5} else 0.0}), select(dmB, \dm -> dm.topHeight), bodyM),
+					if (right> 0) Translate(select(dmB, \dm -> dm.leftWidth + dm.centerWidth), select(dmB, \dm -> dm.topHeight + max(dm.centerHeight - dm.rightHeight, 0.0) * 0.5 + radius), rightDots) else Empty(),
+					Translate(select(dmB, \dm -> dm.leftWidth + max(0.0, dm.centerWidth - dm.bottomWidth) * 0.5), select(dmB, \dm -> dm.topHeight + dm.centerHeight), bottomDots),
+					if (leftSign) signf else Empty(),
+					if (rightSign) Translate(select(dmB, \dm -> dm.leftWidth + dm.centerWidth), zero, signf) else Empty()
+				])
 			)
 		)
 	})


### PR DESCRIPTION
https://trello.com/c/t6Dp2VKd/13073-wigi-dotted-element-alignment
**Before:**
![before](https://user-images.githubusercontent.com/19254090/128734728-5841fd15-4719-4d5e-8152-f1f9ccb2abc8.png)
**After:**
![after](https://user-images.githubusercontent.com/19254090/128734746-e4b2c8c5-714b-4c57-b5e9-9f90f9cca178.png)

Related PR https://github.com/area9innovation/innovation/pull/2411