### PR TITLE
JS: measureText fix bug with letterspacing

### DIFF
--- a/platforms/js/PixiWorkarounds.hx
+++ b/platforms/js/PixiWorkarounds.hx
@@ -677,7 +677,7 @@ class PixiWorkarounds {
 				{
 					let lineWidth;
 					lineWidth = widthContext.measureText(lines[i]).width / widthMulti;
-					lineWidth += (lines[i].length - 1) * style.letterSpacing / 2 + (style.wordSpacing ? style.wordSpacing * (lines[i].split(' ').length - 1) : 0.0);
+					lineWidth += ((style.letterSpacing > 0) ? Math.floor(lines[i].length / 2) : lines[i].length - 1) * style.letterSpacing + (style.wordSpacing ? style.wordSpacing * (lines[i].split(' ').length - 1) : 0.0);
 					console.log(lines[i], lineWidth, widthContext.measureText(lines[i]));
 
 					lineWidths[i] = lineWidth;


### PR DESCRIPTION
We have found that PIXI.measureText using canvas to measure text supports letterspacing only partly:
it counts it and adds to the measured width, but the canvas used for measuring does not aware about letterspacing at all so some fonts use ligatures so width measured by canvas is wrong in this case compared to the rendered in DOM real text.

in branch:
![image](https://user-images.githubusercontent.com/14361571/134662541-0cb5b977-0cef-4ff9-9b38-ba34c6e58423.png)

in master:
![image](https://user-images.githubusercontent.com/14361571/134662697-9c1f0e40-5c38-4d6d-9284-781bcfbcb56c.png)
