### PR TITLE
Added math fonts mapping for Arabic

### DIFF
--- a/lib/ui/fontmapping.flow
+++ b/lib/ui/fontmapping.flow
@@ -471,11 +471,15 @@ cjkFontMappingFn(family : string, size : double) -> Pair<string, double> {
 						Pair("Book", font),
 						Pair("Bold", makeFontBold(font)),
 						Pair("BoldItalic", makeFontSloped(makeFontBold(font))),
-						Pair("Italic", makeFontSloped(font))
+						Pair("Italic", makeFontSloped(font)),
+						Pair("MathFontItalic", "AmiriItalic"),
+						Pair("MathFont", "Amiri"),
+						Pair("MathSymbolFont", "StixTwoMath"),
+						Pair("MathGreekFont", "AmiriItalic"),
 					],
 				);
 
-				mapper = setDefaultFontMappingFnHelper(mappingPairs, true);
+				mapper = setDefaultFontMappingFnHelper(mappingPairs, false);
 				mapper(family, size) |> (\fm -> FontParams(fm.first, fm.first))
 			},
 			^defaultFontMappingFn(family, size) |> (\fm -> FontParams(fm.first, fm.first))


### PR DESCRIPTION
https://trello.com/c/N8HuKeTo/14753-math-font-is-not-working-in-the-arabic-interface

**Related PR:** https://git.area9lyceum.com/Lyceum/lyceum/pulls/3820