### PR TITLE
fixed to works firebase notifications for inactive/unfocused/closed application

### DIFF
--- a/lib/sys/firebasenotifications.flow
+++ b/lib/sys/firebasenotifications.flow
@@ -22,6 +22,19 @@ export {
 
 	// *** How to send a message using Firebase API *** //
 	// Please, follow next page describing Firebase Messaging API: https://firebase.google.com/docs/cloud-messaging/http-server-ref#send-downstream
+	//
+	// Just to note, there is three ways to send notification (JSON-structure):
+	//  1. message = { notification = { "title = "...", body = "...", "click_action" = "...", ...} }
+	//  2. message = { data = { notification = { "title = "...", body = "...", "click_action" = "...", ...} } }
+	//  3. message = { "title = "...", body = "...", "click_action" = "...", ...}
+	//   where "click_action" is an application url to search it in the browser windows/tabs
+	//
+	// The first one will fire notification callback only if the application is active and focused.
+	// The second one will show notification and fire notification callback only if the application is not focused or closed.
+	//  Clicking on the notification windows will open exists application windows or create new one.
+	// The third one should works for both cases - for focused or inactive/closed application.
+	// Tested only on JS target.
+	// 
 
 	// Loads Firebase libs and initializes Firebase app.
 	// JS: Required to be used before subscribe/unsubscribe
@@ -46,4 +59,11 @@ export {
 
 	// Unsubscribes an application from receiving messages for given topic.
 	native unsubscribeFromFBTopic : io (name : string) -> void = NotificationsSupport.unsubscribeFromFBTopic;
+
+	//
+	native subscribeOnBackgroundMessages : io (
+        delay : int,
+        onOK : () -> void,
+        onError : (string) -> void
+    ) -> () -> void = NotificationsSupport.subscribeOnBackgroundMessages;
 }

--- a/www/js/firebase/firebase-messaging-sw.js
+++ b/www/js/firebase/firebase-messaging-sw.js
@@ -4,12 +4,102 @@ importScripts('firebase-messaging.js');
 
 firebase.initializeApp(firebaseConfig);
 const messaging = firebase.messaging();
+var sendMessageToClient = {
+  fn: function(data) { /* Do nothing */ }
+}
 
 messaging.setBackgroundMessageHandler(function(payload) {
-    return self.registration.showNotification(payload.data.title, {
-        body: payload.data.body,
-        icon: payload.data.icon,
-        tag: payload.data.tag,
-        data: payload.data.link
-    });
+  var title = (payload.data.notification && payload.data.notification.title) ? payload.data.notification.title : (payload.data.title ? payload.data.title : "undefined");
+  var body = (payload.data.notification && payload.data.notification.body) ? payload.data.notification.body : (payload.data.body ? payload.data.body : "undefined");
+  var tag = (payload.data.notification && payload.data.notification.tag) ? payload.data.notification.tag : (payload.data.tag ? payload.data.tag : "");
+  var action = (payload.data.notification && payload.data.notification.click_action) ? payload.data.notification.click_action : (payload.data.click_action ? payload.data.click_action : null);
+  var icon = (payload.data.notification && payload.data.notification.icon) ? payload.data.notification.icon : (payload.data.icon ? payload.data.icon : null);
+
+  sendMessageToClient.fn({
+    action: "notification",
+    title: title,
+    body: body,
+    data: JSON.stringify(payload.data),
+    id: payload.data["google.c.a.c_id"],
+    from: payload.from,
+    stamp: payload.data["google.c.a.ts"]
+  });
+
+  self.registration.showNotification(title, {
+    body: body,
+    icon: icon,
+    tag: tag,
+    data: action
+  });
+});
+
+self.addEventListener('notificationclick', function(event) {
+    const target = event.notification.data || '/';
+    event.notification.close();
+
+    // Let's see if we already have an application window open:
+    event.waitUntil(clients.matchAll({
+      type: "window",
+      includeUncontrolled: true
+    }).then(function (clientList) {
+      for (const client of clientList) {
+        const urlClient = new URL(client.url);
+        const urlNotif = new URL(target);
+        if (urlClient.host == urlNotif.host && urlClient.pathname == urlNotif.pathname && 'focus' in client) {
+            return client.focus();
+        }
+      }
+
+      // If we didn't find an existing application window, open a new one:
+      return clients.openWindow(target);
+    }));
+});
+
+self.addEventListener('message', function(event) {
+  var respond = function(data) {
+    if (event.ports.length > 0) {
+      event.ports[0].postMessage(data);
+    } else {
+      console.error("ServiceWorker: Failed to respond!");
+    }
+  };
+
+  if (event.data.action == "subscribe_on_messages" && typeof event.data.delay !== "undefined" && event.data.delay !== null) {
+    var delay = event.data.delay;
+    if (delay < 10) delay = 10;
+
+    var clientId = event.clientId;
+    if (!clientId && event.ports.length == 0) {
+      sendMessageToClient.fn = function(data) { /* Do nothing */ };
+      respond({ action: "subscribe_on_messages", status: "Failed", error: "clientId is empty" });
+    } else if (clientId) {
+      sendMessageToClient.fn = function(data) {
+        // Post message with delay
+        // Otherwise makes problem for caching
+        setTimeout(function() {
+          clients.get(clientId).then(function(client) {
+            if (!isEmpty(client)) client.postMessage(data);
+          });
+        }, delay);
+      };
+
+      respond({ action: "subscribe_on_messages", status: "OK" });
+    } else {
+      var port = event.ports[0];
+      sendMessageToClient.fn = function(data) {
+        // Post message with delay
+        // Otherwise makes problem for caching
+        setTimeout(function() {
+          port.postMessage(data);
+        }, delay);
+      };
+
+      respond({ action: "subscribe_on_messages", status: "OK" });
+    }
+  } else if (event.data.action == "unsubscribe_from_messages") {
+    sendMessageToClient.fn = function(data) { /* Do nothing */ };
+    respond({ action: "unsubscribe_from_messages", status: "OK" });
+  } else {
+    respond({ status: "Failed", error: "Unknown operation: " + event.data.action });
+  }
 });


### PR DESCRIPTION
Added new firebase feature which allows to fire the same messages callback (which registered with `addFBNotificationListener`) on background messages. Also, added supporting of new json-structure of the message to get works foreground and background notifications. Tested on JS target.