### PR TITLE
Flow9 : register __index

### DIFF
--- a/tools/flow9/backends/cpp/cpp_backend.flow
+++ b/tools/flow9/backends/cpp/cpp_backend.flow
@@ -60,6 +60,7 @@ cppBackend(info : CppInfo) -> Backend<CppInfo> {
 
 		BackGen("__ref", bvoidType, BackCall("std::make_tuple", [BackArg(0)])),
 		BackGen("__deref", bvoidType, BackCall("std::get<0>", [BackArg(0)])),
+		BackGen("__index", bvoidType, BackConcat([BackBinOp("[", 80, BackArg(0), BackArg(1)), BackText("]")])),
 	], info);
 }
 

--- a/tools/flow9/tests/cpp/array_index.flow
+++ b/tools/flow9/tests/cpp/array_index.flow
@@ -1,0 +1,20 @@
+native println : io (?) -> void = Native.println;
+
+Maybe ::= None, Some;
+
+None();
+Some();
+
+main() {
+	// error: ‘__index’ was not declared in this scope
+
+	arr : [Maybe] = [Some(), None()];
+	value = arr[1];
+	println(switch (value) {
+		Some(): "some";
+		None(): "none";
+	}); // none
+
+	intArr = [1, 2, 3, 4, 5, 6, 7];
+	println(intArr[0] + intArr[(1 + 1) * 2] + intArr[intArr[5]]); // 1 + 5 + 7 = 13
+}


### PR DESCRIPTION
fix the error: ‘__index’ was not declared in this scope