### PR TITLE
Flow9 : fixes for c++

### DIFF
--- a/tools/flow9/backends/cpp/cpp.flow
+++ b/tools/flow9/backends/cpp/cpp.flow
@@ -290,7 +290,7 @@ bstatement2cpp(backend : Backend<CppInfo>, s : BStatement, withReturn : bool) ->
 bexp2cpp(backend : Backend<CppInfo>, bexp : BExp, isGlobalExp : bool) -> string {
 	rec = \ee -> bexp2cpp(backend, ee, false);
 	switch (bexp) {
-		BVoid(): "{}";
+		BVoid(): "({})";
 		BBool(v): if (v) "true" else "false";
 		BInt(v): "int32_t(" + i2s(v) + ")";
 		BDouble(v): double2string(v);
@@ -326,10 +326,10 @@ bexp2cpp(backend : Backend<CppInfo>, bexp : BExp, isGlobalExp : bool) -> string 
 		}
 		BLambda(args, body, type): {
 			argtypes = getBArgTypes(type);
-			rt0 = btype2cpp(backend, getBReturnType(type));
+			returnType = btype2cpp(backend, getBReturnType(type));
 			blueprint("
 					%type%([%capture%](%args%) {
-						return %body%;
+						%return% %body%;
 					})",
 				[
 					"capture", if (isGlobalExp) "" else "&",
@@ -338,6 +338,7 @@ bexp2cpp(backend : Backend<CppInfo>, bexp : BExp, isGlobalExp : bool) -> string 
 						}, ", "),
 					"body", rec(body),
 					"type", btype2cpp(backend, type),
+					"return", if (returnType == bvoidType.id) "" else "return",
 			]);
 		}
 		BSequence(exps, type): {

--- a/tools/flow9/backends/cpp/cpp.flow
+++ b/tools/flow9/backends/cpp/cpp.flow
@@ -297,6 +297,9 @@ bexp2cpp(backend : Backend<CppInfo>, bexp : BExp, isGlobalExp : bool) -> string 
 		BDouble(v): double2string(v);
 		BString(v): "std::u16string(u" + toString(v) + ")";
 		BVar(id, type): {
+			// add function argument types to help the с++ compiler with polymorphism
+			// before : type12type2
+			// after : type12type2<Type1,Type2>
 			id + bVar2realFuncTypes(bexp, backend);
 		}
 		BLet(id, value, body, type): {
@@ -675,6 +678,8 @@ getStatFunctionTypes(declarations : [BDeclaration]) -> Tree<string, BType> {
 		"flow_fold",
 		"flow_map",
 		"flow_filter",
+		"flow_isSameStructType",
+		"flow_extractStruct",
 	]);
 	fold(declarations, makeTree(), \acc, decl -> {
 		switch (decl) {
@@ -685,6 +690,7 @@ getStatFunctionTypes(declarations : [BDeclaration]) -> Tree<string, BType> {
 	});
 }
 
+// find the type of function arguments
 bVar2realFuncTypes(var : BVar, backend : Backend<CppInfo>) -> string {
 	switch (var.type : BType) {
 		BTypePar(__) : "";

--- a/tools/flow9/backends/cpp/cpp.flow
+++ b/tools/flow9/backends/cpp/cpp.flow
@@ -32,6 +32,7 @@ bprogram2cpp(b : BProgram, flowpath : string) -> string {
 		}),
 		makeStructIds(b.structs, b.unions),
 		flatUnionTypes(typeHierarchy.unionTypes),
+		getStatFunctionTypes(b.declarations),
 	);
 
 	backend = cppBackend(info);
@@ -295,7 +296,9 @@ bexp2cpp(backend : Backend<CppInfo>, bexp : BExp, isGlobalExp : bool) -> string 
 		BInt(v): "int32_t(" + i2s(v) + ")";
 		BDouble(v): double2string(v);
 		BString(v): "std::u16string(u" + toString(v) + ")";
-		BVar(id, type): id;
+		BVar(id, type): {
+			id + bVar2realFuncTypes(bexp, backend);
+		}
 		BLet(id, value, body, type): {
 			blueprint("
 				[%capture%]() {
@@ -661,5 +664,50 @@ dType2id(type : DType) -> string {
 		DTypeName(id, __, __) : id;
 		DTypePar(id, __) : id;
 		DTypeFunction(__, __, __) : "";
+	}
+}
+
+getStatFunctionTypes(declarations : [BDeclaration]) -> Tree<string, BType> {
+	// TODO: find a better way
+	// native functions can have multiple implementations (polimorphic)
+	// add fn to this array if it has only 1 implementation with template + std::function
+	nativesWhiteList = buildSet([
+		"flow_fold",
+		"flow_map",
+		"flow_filter",
+	]);
+	fold(declarations, makeTree(), \acc, decl -> {
+		switch (decl) {
+			BGlobalVar(id, body, type): acc;
+			BStatFunction(id, args, body, tailCall, type): setTree(acc, id, type);
+			BExpNative(id, isio, type, nativeName): if (containsSet(nativesWhiteList, id)) setTree(acc, id, type) else acc;
+		}
+	});
+}
+
+bVar2realFuncTypes(var : BVar, backend : Backend<CppInfo>) -> string {
+	switch (var.type : BType) {
+		BTypePar(__) : "";
+		BTypeName(__, __) : "";
+		BTypeFunction(args, returnType) : {
+			eitherMap(
+				lookupTree(backend.info.statFunctions, var.id),
+				\statFuncType -> {
+					switch (statFuncType : BType) {
+						BTypePar(__) : "";
+						BTypeName(__, __) : "";
+						BTypeFunction(sfArgs, afReturnType) : {
+							polyvars = extractPolyTypes(makeTree(), BTypeFunction(args, returnType), statFuncType);
+							if (isEmptyTree(polyvars)) {
+								""
+							} else {
+								"<" + superglue(getTreeValues(polyvars), \pv -> "" + btype2cpp(backend, pv), ", ") + "> "
+							}
+						}
+					}
+				},
+				""
+			)
+		}
 	}
 }

--- a/tools/flow9/backends/cpp/cpp_backend.flow
+++ b/tools/flow9/backends/cpp/cpp_backend.flow
@@ -6,6 +6,7 @@ export {
 		globals : Set<string>,
 		structIds : Tree<string, int>, // id - globalIndex
 		unionTypes : Tree<string, [BType]>,
+		statFunctions : Tree<string, BType>, // id - type
 	);
 	cppBackend(info : CppInfo) -> Backend<CppInfo>;
 	cppBackendSpec() -> BackendSpec;
@@ -67,7 +68,7 @@ cppBackend(info : CppInfo) -> Backend<CppInfo> {
 
 cppBackendSpec() -> BackendSpec {
 	makeBackendSpec(
-		cppBackend(CppInfo(makeSet(), makeTree(), makeTree())),
+		cppBackend(CppInfo(makeSet(), makeTree(), makeTree(), makeTree())),
 		"", "flow_", "",
 		[
 			// Natives

--- a/tools/flow9/backends/cpp/cpp_backend.flow
+++ b/tools/flow9/backends/cpp/cpp_backend.flow
@@ -60,6 +60,7 @@ cppBackend(info : CppInfo) -> Backend<CppInfo> {
 
 		BackGen("__ref", bvoidType, BackCall("std::make_tuple", [BackArg(0)])),
 		BackGen("__deref", bvoidType, BackCall("std::get<0>", [BackArg(0)])),
+		BackGen(":=", bvoidType, BackBinOp(" = ", 70, BackArg(0), BackArg(1))),
 		BackGen("__index", bvoidType, BackConcat([BackBinOp("[", 80, BackArg(0), BackArg(1)), BackText("]")])),
 	], info);
 }

--- a/tools/flow9/backends/cpp/cpp_backend.flow
+++ b/tools/flow9/backends/cpp/cpp_backend.flow
@@ -93,6 +93,8 @@ cppBackendSpec() -> BackendSpec {
 			"Native.bitXor",
 			"Native.bitShl",
 			"Native.bitUshr",
+			"Native.d2s",
+			"Native.trunc",
 		]
 	)
 }

--- a/tools/flow9/backends/cpp/flow_natives.hpp
+++ b/tools/flow9/backends/cpp/flow_natives.hpp
@@ -95,7 +95,7 @@ std::vector<int32_t> flow_enumFromTo(int32_t start, int32_t end) {
 
 template <typename A, typename B>
 std::vector<B> flow_map(const std::vector<A> flow_a, const std::function<B(A)> & flow_fn) {
-  std::vector<int> res(flow_a.size());
+  std::vector<B> res(flow_a.size());
   for (std::size_t i = 0; i != flow_a.size(); ++i) {
     res[i] = flow_fn(flow_a[i]);
   }
@@ -104,7 +104,7 @@ std::vector<B> flow_map(const std::vector<A> flow_a, const std::function<B(A)> &
 
 template <typename A>
 std::vector<A> flow_filter(const std::vector<A> flow_a, const std::function<bool(A)> & flow_test) {
-  std::vector<int> res;
+  std::vector<A> res;
   std::copy_if (flow_a.begin(), flow_a.end(), std::back_inserter(res), flow_test);
   return res;
 }

--- a/tools/flow9/backends/cpp/flow_natives.hpp
+++ b/tools/flow9/backends/cpp/flow_natives.hpp
@@ -70,8 +70,6 @@ int32_t flow_getCharCodeAt(std::u16string s, int32_t i) {
 	return s.at(i);
 }
 
-// array
-
 template <typename A, typename B> B
 flow_fold(const std::vector<A> flow_a, const B flow_b, const std::function<B(B, A)> & flow_fn) {
   B _res = flow_b;
@@ -93,13 +91,17 @@ std::vector<int32_t> flow_enumFromTo(int32_t start, int32_t end) {
 	}
 }
 
+
 template <typename A, typename B>
 std::vector<B> flow_map(const std::vector<A> flow_a, const std::function<B(A)> & flow_fn) {
-  std::vector<B> res(flow_a.size());
-  for (std::size_t i = 0; i != flow_a.size(); ++i) {
-    res[i] = flow_fn(flow_a[i]);
-  }
-  return res;
+  // std::vector<B> res(flow_a.size());
+  // for (std::size_t i = 0; i != flow_a.size(); ++i) {
+  //   res[i] = flow_fn(flow_a[i]);
+  // }
+  //return res;
+	std::vector<B> res;
+	std::transform(flow_a.begin(), flow_a.end(), std::back_inserter(res), flow_fn);
+	return res;
 }
 
 template <typename A>
@@ -108,6 +110,7 @@ std::vector<A> flow_filter(const std::vector<A> flow_a, const std::function<bool
   std::copy_if (flow_a.begin(), flow_a.end(), std::back_inserter(res), flow_test);
   return res;
 }
+
 
 template <typename A>
 std::vector<A> flow_concat(const std::vector<A> flow_a, const std::vector<A> flow_b) {

--- a/tools/flow9/backends/cpp/flow_natives.hpp
+++ b/tools/flow9/backends/cpp/flow_natives.hpp
@@ -123,6 +123,11 @@ std::vector<A> flow_concat(const std::vector<A> flow_a, const std::vector<A> flo
 
 
 // flowstruct
+template <typename A, typename B>
+bool flow_isSameStructType(A struct1, B struct2) {
+	return struct1._id == struct2._id;
+}
+
 template <typename A, typename ...Args2>
 bool flow_isSameStructType(A struct1, std::variant<Args2...> struct2) {
 	unsigned int id2 = std::visit([&](auto&& x) {return x._id;}, struct2);
@@ -140,11 +145,6 @@ bool flow_isSameStructType(std::variant<Args1...> struct1, std::variant<Args2...
 	unsigned int id1 = std::visit([&](auto&& x) {return x._id;}, struct1);
 	unsigned int id2 = std::visit([&](auto&& x) {return x._id;}, struct2);
 	return id1 == id2;
-}
-
-template <typename A, typename B>
-bool flow_isSameStructType(A struct1, B struct2) {
-	return struct1._id == struct2._id;
 }
 
 template <typename A, typename ...B> A _extractStructVal(std::variant<B...> v) { return std::get<A>(v); }

--- a/tools/flow9/backends/cpp/flow_natives.hpp
+++ b/tools/flow9/backends/cpp/flow_natives.hpp
@@ -2,6 +2,8 @@
 #include <codecvt>
 #include <string>
 #include <locale>
+#include <sstream>
+#include <iomanip>
 // math
 #include <cmath>
 
@@ -56,6 +58,10 @@ int32_t flow_bitUshr(int32_t a, int32_t n) {
 	return ((unsigned int)a) >> n;
 }
 
+int32_t flow_trunc(double v) {
+	return (int32_t)v;
+}
+
 // string
 
 std::u16string flow_substring(std::u16string s, int32_t start, int32_t length) {
@@ -69,6 +75,18 @@ int32_t flow_strlen(std::u16string s) {
 int32_t flow_getCharCodeAt(std::u16string s, int32_t i) {
 	return s.at(i);
 }
+
+// precision = 20!
+std::u16string flow_d2s(double v) {
+	std::stringstream stream;
+	stream << std::fixed << std::setprecision(20) << v;
+	std::string s = stream.str();
+
+	std::wstring_convert<std::codecvt_utf8_utf16<char16_t>, char16_t> codecvt;
+	return codecvt.from_bytes(s);
+}
+
+// array
 
 template <typename A, typename B> B
 flow_fold(const std::vector<A> flow_a, const B flow_b, const std::function<B(B, A)> & flow_fn) {

--- a/tools/flow9/backends/type_hierarchy.flow
+++ b/tools/flow9/backends/type_hierarchy.flow
@@ -19,6 +19,17 @@ export {
 	extractPolymorphism(acc : Set<BTypePar>, b : BType) -> Set<BTypePar>;
 
 	// find a match between polyType (BTypePar) and real type (BTypeName)
+	// example:
+	// we have : 
+	//	BTypeFunction(												BTypeFunction(
+	//		[															[
+	//			BTypePar("?"),												BTypeName("int", []),
+	//			BTypeFunction([BTypePar("?")], BTypePar("??")),				BTypeFunction([BTypeName("int", [])], BTypeName("int", [])),
+	//			BTypeFunction([BTypePar("??")], BTypePar("???"))			BTypeFunction([BTypeName("int", [])], BTypeName("string", []))
+	//		],															],
+	//		BTypePar("???")												BTypeName("string", [])
+	//	)															)
+	// the result is a Tree of values : [?=int, ??=int, ???=string]
 	extractPolyTypes(acc : Tree<BTypePar, BTypeName>, type : BType, polyType : BType) -> Tree<BTypePar, BTypeName>;
 }
 

--- a/tools/flow9/backends/type_hierarchy.flow
+++ b/tools/flow9/backends/type_hierarchy.flow
@@ -126,7 +126,7 @@ extractBTypeFunctionArg(type : BType, i : int) -> Maybe<BType> {
 extractBTypeNameParam(type : BType, i : int) -> Maybe<BType> {
 	switch (type) {
 		BTypePar(id): None();
-		BTypeName(id, typars): None();
+		BTypeName(id, typars): if (existsIndex(typars, i)) Some(typars[i]) else None();
 		BTypeFunction(args, returnType): if (existsIndex(args, i)) Some(args[i]) else None();
 	}
 }

--- a/tools/flow9/backends/type_hierarchy.flow
+++ b/tools/flow9/backends/type_hierarchy.flow
@@ -17,6 +17,9 @@ export {
 	);
 
 	extractPolymorphism(acc : Set<BTypePar>, b : BType) -> Set<BTypePar>;
+
+	// find a match between polyType (BTypePar) and real type (BTypeName)
+	extractPolyTypes(acc : Tree<BTypePar, BTypeName>, type : BType, polyType : BType) -> Tree<BTypePar, BTypeName>;
 }
 
 resolveBTypeHierarchy(
@@ -56,5 +59,63 @@ extractPolymorphism(acc : Set<BTypePar>, b : BType) -> Set<BTypePar> {
 			fold(args, extractPolymorphism(acc, returnType), extractPolymorphism)
 		}
 
+	}
+}
+
+extractPolyTypes(acc : Tree<BTypePar, BTypeName>, type : BType, polyType : BType) -> Tree<BTypePar, BTypeName> {
+	switch (polyType) {
+		BTypePar(id): eitherMap(extractBTypeName(type), \t -> setTree(acc, polyType, t), acc);
+		BTypeName(id, typars): {
+			foldi(typars, acc, \i, acc2, t -> 
+				eitherMap(
+					extractBTypeNameParam(type, i),
+					\tt -> extractPolyTypes(acc2, tt, t),
+					acc2
+				)
+			);
+		}
+		BTypeFunction(args, returnType): {
+			eitherMap(
+				extractBTypeFunctionReturn(type),
+				\t -> foldi(args, extractPolyTypes(acc, t, returnType), \i, acc2, arg -> 
+					eitherMap(
+						extractBTypeFunctionArg(type, i),
+						\argType -> extractPolyTypes(acc2, argType, arg),
+						acc2
+					)
+				),
+				acc
+			)
+		}
+
+	}
+}
+
+extractBTypeName(type : BType) -> Maybe<BTypeName> {
+	switch (type) {
+		BTypePar(id): None();
+		BTypeName(id, typars): Some(type);
+		BTypeFunction(args, returnType): None();
+	}
+}
+extractBTypeFunctionReturn(type : BType) -> Maybe<BType> {
+	switch (type) {
+		BTypePar(id): None();
+		BTypeName(id, typars): None();
+		BTypeFunction(args, returnType): Some(returnType);
+	}
+}
+extractBTypeFunctionArg(type : BType, i : int) -> Maybe<BType> {
+	switch (type) {
+		BTypePar(id): None();
+		BTypeName(id, typars): None();
+		BTypeFunction(args, returnType): if (existsIndex(args, i)) Some(args[i]) else None();
+	}
+}
+extractBTypeNameParam(type : BType, i : int) -> Maybe<BType> {
+	switch (type) {
+		BTypePar(id): None();
+		BTypeName(id, typars): None();
+		BTypeFunction(args, returnType): if (existsIndex(args, i)) Some(args[i]) else None();
 	}
 }

--- a/tools/flow9/tests/cpp/array_fns.flow
+++ b/tools/flow9/tests/cpp/array_fns.flow
@@ -3,15 +3,38 @@ import string;
 
 native println : io (?) -> void = Native.println;
 
+testVal(v : int) -> bool {
+	v% 2 == 0
+}
+
+addVal(str : string, val : int) -> string {
+	str + " " + i2s(val);
+}
+
+changeVal(val : int) -> int {
+	val * 20
+}
+
 main() {
-	println(fold(enumFromTo(1, -1), "", \acc, v -> acc + " " + i2s(v)));
-	println(fold(enumFromTo(1, 1), "", \acc, v -> acc + " " + i2s(v)));
-	println(fold(enumFromTo(10, 20), "", \acc, v -> acc + " " + i2s(v)));
+	println(fold(enumFromTo(1, -1), "", \acc, v -> acc + " " + i2s(v))); // ""
+	println(fold(enumFromTo(1, 1), "", \acc, v -> acc + " " + i2s(v))); // 1
+	println(fold(enumFromTo(10, 20), "", \acc, v -> acc + " " + i2s(v))); // 10 11 12 13 14 15 16 17 18 19 20
+	println(fold(enumFromTo(1, 3), "", addVal)); // 1 2 3
 
 	arr1 = enumFromTo(1, 10);
 	arr2 = map(arr1, \v -> v * 10);
-	println(fold(arr1, "", \acc, v -> acc + "  " + i2s(v)));
-	println(fold(arr2, "", \acc, v -> acc + " " + i2s(v)));
+	println("EnumFromTo");
+	println(fold(arr1, "", \acc, v -> acc + "  " + i2s(v))); //  1  2  3  4  5  6  7  8  9  10
+	println("Map");
+	println(fold(arr2, "", \acc, v -> acc + " " + i2s(v))); // 10 20 30 40 50 60 70 80 90 100
+	println("Map fn");
+	println(fold(map(arr1, changeVal), "", \acc, v -> acc + " " + i2s(v))); // 20 40 60 80 100 120 140 160 180 200
 
-	println(fold(filter(arr1, \v -> v% 2 == 0), "", \acc, v -> acc + " " + i2s(v)));
+	println("Filter");
+	println(fold(filter(arr1, \v -> v% 2 == 0), "", \acc, v -> acc + " " + i2s(v))); // 2 4 6 8 10
+	println("Filter fn");
+	println(fold(filter(arr1, testVal), "", \acc, v -> acc + " " + i2s(v))); // 2 4 6 8 10
+
+	println("Concat");
+	println(fold(concat([-1, 0], arr1), "", addVal)); // -1 0 1 2 3 4 5 6 7 8 9 10
 }

--- a/tools/flow9/tests/cpp/fn_arg_type.flow
+++ b/tools/flow9/tests/cpp/fn_arg_type.flow
@@ -2,6 +2,7 @@ native println2 : io (?) -> void = Native.println;
 native i2s : (int) -> string = Native.i2s;
 native isSameStructType : (value1 : ?, value2 : ??) -> bool = Native.isSameStructType;
 native extractStruct : (a : [?], e : ??) -> ?? = Native.extractStruct;
+native strlen : (string) -> int = Native.strlen;
 
 changeVal(val : int) -> int {
 	val * 20
@@ -19,6 +20,14 @@ mapval3(val : [?], val2 : ??, fn : ([?], ??) -> ??) -> ?? {
 	fn(val, val2)
 }
 
+mapval1(val : ?, fn : (?) -> ??) -> ?? {
+	fn(val)
+}
+
+tranformToBool(v : ?) -> bool {
+	true;
+}
+
 
 S1();
 S2();
@@ -31,9 +40,12 @@ main() {
 
 	println2(mapval(S1(), \v -> v, \v -> isSameStructType(v, S2())));
 
-	println2(mapval3([S1(), S2()], S2(), extractStruct));
+	res = mapval3([S1(), S2()], S2(), extractStruct);
+	// println2(res); // TODO
 	
 	println2(mapval2(S1(), S2(), isSameStructType));
-	// workaround. add to cpp.flow ?
 	println2(mapval2(S1(), S2(), \v1, v2 -> isSameStructType(v1, v2)));
+
+	println2(mapval1("sq", strlen));
+	println2(mapval1("sq", tranformToBool));
 }

--- a/tools/flow9/tests/cpp/fn_arg_type.flow
+++ b/tools/flow9/tests/cpp/fn_arg_type.flow
@@ -1,6 +1,7 @@
 native println2 : io (?) -> void = Native.println;
 native i2s : (int) -> string = Native.i2s;
 native isSameStructType : (value1 : ?, value2 : ??) -> bool = Native.isSameStructType;
+native extractStruct : (a : [?], e : ??) -> ?? = Native.extractStruct;
 
 changeVal(val : int) -> int {
 	val * 20
@@ -14,14 +15,25 @@ mapval2(val : ?, val2 : ??, fn : (?, ??) -> ???) -> ??? {
 	fn(val, val2)
 }
 
+mapval3(val : [?], val2 : ??, fn : ([?], ??) -> ??) -> ?? {
+	fn(val, val2)
+}
+
 
 S1();
 S2();
+
+U ::= S1, S2;
 
 main() {
 	println2(mapval(10, changeVal, i2s));
 	println2(mapval(10, \v -> v + 1, \v2 -> "res " + i2s(v2)));
 
 	println2(mapval(S1(), \v -> v, \v -> isSameStructType(v, S2())));
+
+	println2(mapval3([S1(), S2()], S2(), extractStruct));
+	
 	println2(mapval2(S1(), S2(), isSameStructType));
+	// workaround. add to cpp.flow ?
+	println2(mapval2(S1(), S2(), \v1, v2 -> isSameStructType(v1, v2)));
 }

--- a/tools/flow9/tests/cpp/fn_arg_type.flow
+++ b/tools/flow9/tests/cpp/fn_arg_type.flow
@@ -1,5 +1,6 @@
 native println2 : io (?) -> void = Native.println;
 native i2s : (int) -> string = Native.i2s;
+native isSameStructType : (value1 : ?, value2 : ??) -> bool = Native.isSameStructType;
 
 changeVal(val : int) -> int {
 	val * 20
@@ -9,7 +10,18 @@ mapval(val : ?, fn1 : (?) -> ??, fn2 : (??) -> ???) -> ??? {
 	fn2(fn1(val))
 }
 
+mapval2(val : ?, val2 : ??, fn : (?, ??) -> ???) -> ??? {
+	fn(val, val2)
+}
+
+
+S1();
+S2();
+
 main() {
 	println2(mapval(10, changeVal, i2s));
 	println2(mapval(10, \v -> v + 1, \v2 -> "res " + i2s(v2)));
+
+	println2(mapval(S1(), \v -> v, \v -> isSameStructType(v, S2())));
+	println2(mapval2(S1(), S2(), isSameStructType));
 }

--- a/tools/flow9/tests/cpp/fn_arg_type.flow
+++ b/tools/flow9/tests/cpp/fn_arg_type.flow
@@ -1,0 +1,13 @@
+native println2 : io (?) -> void = Native.println;
+
+changeVal(val : int) -> int {
+	val * 20
+}
+
+mapval(val : ?, fn : (?) -> ??) -> ?? {
+	fn(val)
+}
+
+main() {
+	println2(mapval(10, changeVal));
+}

--- a/tools/flow9/tests/cpp/fn_arg_type.flow
+++ b/tools/flow9/tests/cpp/fn_arg_type.flow
@@ -1,13 +1,15 @@
 native println2 : io (?) -> void = Native.println;
+native i2s : (int) -> string = Native.i2s;
 
 changeVal(val : int) -> int {
 	val * 20
 }
 
-mapval(val : ?, fn : (?) -> ??) -> ?? {
-	fn(val)
+mapval(val : ?, fn1 : (?) -> ??, fn2 : (??) -> ???) -> ??? {
+	fn2(fn1(val))
 }
 
 main() {
-	println2(mapval(10, changeVal));
+	println2(mapval(10, changeVal, i2s));
+	println2(mapval(10, \v -> v + 1, \v2 -> "res " + i2s(v2)));
 }

--- a/tools/flow9/tests/cpp/return_void.flow
+++ b/tools/flow9/tests/cpp/return_void.flow
@@ -1,0 +1,31 @@
+native println2: io (?) -> void = Native.println;
+idfn(x) x;
+
+fori(start : int, end : int, fn : (i : int) -> void) -> void {
+    if (start <= end) {
+        fn(start);
+        fori(start + 1, end, fn);
+    }
+}
+
+nop() -> void {}
+
+main() {
+    fori(2, 8, \i -> {
+        {}
+    });
+    fori(2, 7, \i -> {
+        println2(10 + i);
+        idfn(i);
+        {}
+    });
+
+     fori(2, 8, \i -> {
+        2;
+        nop()
+    });
+    fori(2, 8, \i -> {
+        println2(i);
+        if (i < 5) {{}} else {{}};
+    });
+}


### PR DESCRIPTION
- ':='
- 'return {};' and 'return (fn(); {});'
- error: template argument deduction/substitution failed (WIP)

![image](https://user-images.githubusercontent.com/19932962/142451701-0e127d4c-c1f1-4fb5-bc5a-e8617aeb6ba4.png)
