### PR TITLE
Flowc fix initorder

### DIFF
--- a/tools/flowc/flowc_version.flow
+++ b/tools/flowc/flowc_version.flow
@@ -2,5 +2,5 @@
 // Edit 'build-flowc' instead.
 export {
 	flowc_version = "3.0";
-	flowc_git_revision = "bbf9f77c9";
+	flowc_git_revision = "ef074ed94";
 }

--- a/tools/flowc/flowc_version.flow
+++ b/tools/flowc/flowc_version.flow
@@ -2,5 +2,5 @@
 // Edit 'build-flowc' instead.
 export {
 	flowc_version = "3.0";
-	flowc_git_revision = "ef074ed94";
+	flowc_git_revision = "0c6916441";
 }

--- a/tools/flowc/typechecker/initorder.flow
+++ b/tools/flowc/typechecker/initorder.flow
@@ -9,10 +9,8 @@ export {
 	makeInitOrder(config : CompilerConfig, module : FcModule, initOrder : [string]) -> [[string]];
 }
 
-
 makeInitOrder(config : CompilerConfig, module : FcModule, initOrder : [string]) -> [[string]] {
 	names = buildSet(initOrder);
-
 	track = fold(initOrder, makeDependencyTracker(), \acc, o -> {
 		gvar = lookupTree(module.globalVars, o);
 		mexp : Maybe<FcExp> = switch (gvar) {
@@ -62,10 +60,14 @@ makeOrder(config : CompilerConfig, module : FcModule, d : DependencyTracker<stri
 		vars_funcs = unzip(unresolved, \nm -> containsKeyTree(module.globalVars, nm));
 		vars = vars_funcs.first;
 		funcs = vars_funcs.second;
-		concat3(acc,
-			if (length(vars) == 0) [] else makeInitOrder(config, module, vars),
-			if (length(funcs) == 0) [] else makeInitOrder(config, module, funcs)
-		);
+		if (length(vars) == 0) {
+			concat(acc, map(unresolved, \fn -> [fn]));
+		} else {
+			concat3(acc,
+				if (length(vars) == 0) [] else makeInitOrder(config, module, vars),
+				if (length(funcs) == 0) [] else makeInitOrder(config, module, funcs)
+			);
+		}
 	} else {
 		nacc = arrayPush(acc, resolved);
 		nd = fold(resolved, n.first, \acc2, res -> {

--- a/tools/flowc/typechecker/initorder.flow
+++ b/tools/flowc/typechecker/initorder.flow
@@ -56,11 +56,16 @@ makeOrder(config : CompilerConfig, module : FcModule, d : DependencyTracker<stri
 			fcPrintln("There is a loop amongst these names: " + strGlue(unresolved, ", "), config.threadId);
 		}
 		// When there is a loop, we will have to do them one by one to avoid any problems,
-		// but we have to put all variables before functions.
-		vars_go_first = sortCustom(unresolved, \nm ->
-			if (containsKeyTree(module.globalVars, nm)) 0 else 1, true
+		// but we have to put:
+		//  1) all variables before functions.
+		//  2) in each group (vars and funcs) order names by dependency relation
+		vars_funcs = unzip(unresolved, \nm -> containsKeyTree(module.globalVars, nm));
+		vars = vars_funcs.first;
+		funcs = vars_funcs.second;
+		concat3(acc,
+			if (length(vars) == 0) [] else makeInitOrder(config, module, vars),
+			if (length(funcs) == 0) [] else makeInitOrder(config, module, funcs)
 		);
-		concat(acc, map(vars_go_first, \u -> [u]));
 	} else {
 		nacc = arrayPush(acc, resolved);
 		nd = fold(resolved, n.first, \acc2, res -> {

--- a/tools/flowc/typechecker/initorder.flow
+++ b/tools/flowc/typechecker/initorder.flow
@@ -41,11 +41,11 @@ makeInitOrder(config : CompilerConfig, module : FcModule, initOrder : [string]) 
 		addDependencies(acc, o, set2array(norec));
 	});
 
-	order = makeOrder(config, track, []);
+	order = makeOrder(config, module, track, []);
 	order;
 }
 
-makeOrder(config : CompilerConfig, d : DependencyTracker<string>, acc : [[string]]) -> [[string]] {
+makeOrder(config : CompilerConfig, module : FcModule, d : DependencyTracker<string>, acc : [[string]]) -> [[string]] {
 	n = extractNonDependent(d);
 	resolved = set2array(n.second);
 	if (resolved == []) {
@@ -55,13 +55,17 @@ makeOrder(config : CompilerConfig, d : DependencyTracker<string>, acc : [[string
 			// TODO: Check that these have reasonable types declared
 			fcPrintln("There is a loop amongst these names: " + strGlue(unresolved, ", "), config.threadId);
 		}
-		// When there is a loop, we will have to do them one by one to avoid any problems
-		concat(acc, map(unresolved, \u -> [u]));
+		// When there is a loop, we will have to do them one by one to avoid any problems,
+		// but we have to put all variables before functions.
+		vars_go_first = sortCustom(unresolved, \nm ->
+			if (containsKeyTree(module.globalVars, nm)) 0 else 1, true
+		);
+		concat(acc, map(vars_go_first, \u -> [u]));
 	} else {
 		nacc = arrayPush(acc, resolved);
 		nd = fold(resolved, n.first, \acc2, res -> {
 			resolveDependency(acc2, res);
 		});
-		makeOrder(config, nd, nacc)
+		makeOrder(config, module, nd, nacc)
 	}
 }

--- a/tools/flowc/typechecker/initorder.flow
+++ b/tools/flowc/typechecker/initorder.flow
@@ -64,7 +64,7 @@ makeOrder(config : CompilerConfig, module : FcModule, d : DependencyTracker<stri
 			concat(acc, map(unresolved, \fn -> [fn]));
 		} else {
 			concat3(acc,
-				if (length(vars) == 0) [] else makeInitOrder(config, module, vars),
+				makeInitOrder(config, module, vars),
 				if (length(funcs) == 0) [] else makeInitOrder(config, module, funcs)
 			);
 		}


### PR DESCRIPTION
Fix to the:
When a variable is mutually dependent on a function, i.e. there's no
strict dependence precedence between a variable and function,
if we put typechecking of a function before typechecking of a variable,
typecheker fails. So, in such situations we put all variables before
function in init order.
Appended:
When we resolve init order in a group of mutually dependent names:
  a) place all vars before functions
  b) order vars by dependency
  c) order funcs by dependency


https://trello.com/c/4GmNFWsZ/794-compiling-depends-on-naming