### PR TITLE
Previews for pictures that displayed on the screen instead of all.

### DIFF
--- a/lib/material/internal/filebrowser/material_filebrowser_internal.flow
+++ b/lib/material/internal/filebrowser/material_filebrowser_internal.flow
@@ -60,6 +60,31 @@ makeSearchState(engine : FilebrowserEngine<?, ??>, text : string, ext : [string]
 	)
 }
 
+createRequestPreviewFn(state : FilebrowserState<?, ??, ???>, onError) -> Pair<(Material) -> Material, (Pair<string, DynamicBehaviour<Maybe<Material>>>) -> void> {
+	filesB : DynamicBehaviour<[Pair<string, DynamicBehaviour<Maybe<Material>>>]> = make([]);
+	
+	requestPreviews = \files -> state.engine.getPathsPreview(
+		map(files, \f -> f.first),
+		\pairs -> {
+			iter(pairs, \pair -> {maybeApply(find(files, \file -> file.first == pair.first), \file -> nextDistinct(file.second, Some(pair.second)))});
+		},
+		onError
+	);
+
+	materialWrapper = \m -> MConstruct(
+		[makeSubscribe(fstall(filesB, 0), \files -> if (length(files) > 0) {requestPreviews(files); nextDistinct(filesB, []);})],
+		m
+	);
+
+	requestPreviewfn = \file : Pair<string, DynamicBehaviour<Maybe<Material>>> -> {
+		currentFiles = fgetValue(filesB);
+		if(isNone(find(currentFiles, \f -> f.first == file.first))) nextDistinct(filesB, arrayPush(currentFiles, file))
+	};
+
+	Pair(materialWrapper, requestPreviewfn);
+
+}
+
 startTimestampR : ref double = ref 0.0;
 // calls the content loading and view creating for the current path
 getLibraryUI(state : FilebrowserState<Pair<string, bool>, ?>, ext : [string], filterFn : (string) -> bool, changesCallback : ([string], [string], [string]) -> void, folderSelection : bool) -> Material {
@@ -71,27 +96,22 @@ getLibraryUI(state : FilebrowserState<Pair<string, bool>, ?>, ext : [string], fi
 	startTimestampR := curTimestamp;
 	getContentAPI(state.engine, currentPath, ext, filterFn,
 		\dirs : [string], files : [string] -> {
-			previewsB = make([]);
+
 			previewsLoadingStatusB = make(Some(_("Thumbnails updating, please wait...")));
-			next(viewB, prepareAndGetContentUI(
+			previewRequestFn = createRequestPreviewFn(state, onError);
+
+			newView = prepareAndGetContentUI(
 				state,
 				map(dirs, \d -> Pair(d, true)),
 				if (folderSelection) [] else map(files, \d -> Pair(d, false)),
 				contains(dirs, ".."),
-				previewsB,
+				previewRequestFn.second,
 				previewsLoadingStatusB
-			));
-			timer(100, \-> {
-				state.engine.getPathsPreview(
-					map(files, \f -> currentPath + f),
-					\pairs -> {
-						//nextDistinct(previewsLoadingStatusB, None());
-						nextDistinct(previewsB, pairs);
-					},
-					onError
-				);
-				checkWhatIsChanged(currentPath, dirs, files, state.engine, changesCallback, previewsLoadingStatusB, curTimestamp)
-			});
+			) |> previewRequestFn.first;
+			
+			next(viewB, newView);
+			deferUntilRender(\-> checkWhatIsChanged(currentPath, dirs, files, state.engine, changesCallback, previewsLoadingStatusB, curTimestamp));
+
 		},
 		onError
 	);
@@ -218,6 +238,7 @@ getSearchResultUI(state : FilebrowserState<Pair<string, bool>, ?>, searchText : 
 
 		if (!getValue(stateSearch.breakSearchB)) {
 			l = length(dirs) + length(files);
+			previewRequestFn = createRequestPreviewFn(state, nop1);
 			next(
 				itemB,
 				if (l == 0)
@@ -225,7 +246,7 @@ getSearchResultUI(state : FilebrowserState<Pair<string, bool>, ?>, searchText : 
 				else
 					MLines2(
 						MText(_("Elements found") + ": " + i2s(l), []),
-						getContentUI(state2, dirs, files, None(), make([]), make(None()))
+						getContentUI(state2, dirs, files, None(), previewRequestFn.second , make(None()))|> previewRequestFn.first
 					)
 			)
 		}

--- a/lib/material/internal/filebrowser/material_filebrowser_internal.flow
+++ b/lib/material/internal/filebrowser/material_filebrowser_internal.flow
@@ -72,7 +72,7 @@ createRequestPreviewFn(state : FilebrowserState<?, ??, ???>, onError) -> Pair<(M
 	);
 
 	materialWrapper = \m -> MConstruct(
-		[makeSubscribe(fstall(filesB, 0), \files -> if (length(files) > 0) {requestPreviews(files); nextDistinct(filesB, []);})],
+		[makeSubscribe(fstall(filesB, 100), \files -> if (length(files) > 0) { requestPreviews(files); nextDistinct(filesB, []);})],
 		m
 	);
 
@@ -87,7 +87,7 @@ createRequestPreviewFn(state : FilebrowserState<?, ??, ???>, onError) -> Pair<(M
 
 startTimestampR : ref double = ref 0.0;
 // calls the content loading and view creating for the current path
-getLibraryUI(state : FilebrowserState<Pair<string, bool>, ?>, ext : [string], filterFn : (string) -> bool, changesCallback : ([string], [string], [string]) -> void, folderSelection : bool) -> Material {
+getLibraryUI(state : FilebrowserState<Pair<string, bool>, ?>, ext : [string], filterFn : (string) -> bool, changesCallback : ([string], [string], [string]) -> void, folderSelection : bool, scrollPosition : DynamicBehaviour<Point>, setPosM : Maybe<(DynamicBehaviour<Point>) -> void>) -> Material {
 	currentPath = getValue(state.currentPathB);
 	viewB = make(MCenter(MLoading(_("Loading content, please wait..."))));
 	onError = \error -> next(viewB, MCenter(MText("Error: " + error, [])));
@@ -100,16 +100,19 @@ getLibraryUI(state : FilebrowserState<Pair<string, bool>, ?>, ext : [string], fi
 			previewsLoadingStatusB = make(Some(_("Thumbnails updating, please wait...")));
 			previewRequestFn = createRequestPreviewFn(state, onError);
 
-			newView = prepareAndGetContentUI(
-				state,
-				map(dirs, \d -> Pair(d, true)),
-				if (folderSelection) [] else map(files, \d -> Pair(d, false)),
-				contains(dirs, ".."),
-				previewRequestFn.second,
-				previewsLoadingStatusB
-			) |> previewRequestFn.first;
-			
-			next(viewB, newView);
+			next(
+				viewB,
+				prepareAndGetContentUI(
+					state,
+					map(dirs, \d -> Pair(d, true)),
+					if (folderSelection) [] else map(files, \d -> Pair(d, false)),
+					contains(dirs, ".."),
+					previewRequestFn.second,
+					previewsLoadingStatusB,
+					scrollPosition,
+					setPosM
+				) |> previewRequestFn.first
+			);
 			deferUntilRender(\-> checkWhatIsChanged(currentPath, dirs, files, state.engine, changesCallback, previewsLoadingStatusB, curTimestamp));
 
 		},
@@ -220,7 +223,7 @@ getContentAPI(engine : FilebrowserEngine<?, ??>, path : string, ext : [string], 
 }
 
 // start the elements searching (which names contains searchText string) and updating the content view
-getSearchResultUI(state : FilebrowserState<Pair<string, bool>, ?>, searchText : string, ext : [string], filterFn : (string) -> bool) -> Material {
+getSearchResultUI(state : FilebrowserState<Pair<string, bool>, ?>, searchText : string, ext : [string], filterFn : (string) -> bool, scrollPosition : DynamicBehaviour<Point>) -> Material {
 	// Special state2 for search case to have tooltips in result view.
 	// Without dummy `currentPathB` files in the current folder will be without tooltips.
 	state2 = FilebrowserState(state with currentPathB=make("-1"));
@@ -246,7 +249,7 @@ getSearchResultUI(state : FilebrowserState<Pair<string, bool>, ?>, searchText : 
 				else
 					MLines2(
 						MText(_("Elements found") + ": " + i2s(l), []),
-						getContentUI(state2, dirs, files, None(), previewRequestFn.second , make(None()))|> previewRequestFn.first
+						getContentUI(state2, dirs, files, None(), previewRequestFn.second , make(None()), scrollPosition, None())|> previewRequestFn.first
 					)
 			)
 		}
@@ -348,6 +351,7 @@ renderCustomMFileBrowser(manager : MaterialManager, parent : MFocusGroup, captio
 	dialogContentB = make(TEmpty());
 	closeMe = \-> next(closeB, true);
 	normalExts = uniq(map(ext, toLowerCase));
+	scrollPositionB = make(zeroPoint);
 
 	curPathOutAll = map(extractStructMany(styles, FbGetCurrentPathB(make(""))), \s -> s.path);
 	curPathOutArrB = tail(curPathOutAll);
@@ -454,13 +458,17 @@ renderCustomMFileBrowser(manager : MaterialManager, parent : MFocusGroup, captio
 	changesCallbackFn = \added, removed, updated -> iter(callbackOnUpdateFns, \fn -> fn(added, removed, updated, closeMe));
 
 	lastUpdateTimeMR = ref None();
-	updateFilesView = \-> {
+	updateFilesView = \setPosM-> {
 		if (eitherMap(^lastUpdateTimeMR, \t -> timestamp() - t, 10.0) > 1.0) {
-			nextDistinct(dialogContentB, getLibraryUI(state, normalExts, filterFn, changesCallbackFn, folderSelection));
+			nextDistinct(dialogContentB, getLibraryUI(state, normalExts, filterFn, changesCallbackFn, folderSelection, scrollPositionB, setPosM));
 			lastUpdateTimeMR := Some(timestamp());
 		}
 	}
-	iter(doUpdateCallArr, \fn -> fn(updateFilesView));
+
+	updateFilesViewWithZeroScrollPosition = \-> updateFilesView(None());
+	updateFilesViewWithSameScrollPosition = \-> {sp0 = getValue(scrollPositionB); updateFilesView(Some(\sp -> nextDistinct(sp, sp0)))};
+
+	iter(doUpdateCallArr, \fn -> fn(updateFilesViewWithSameScrollPosition));
 
 	state.engine.isDirectory(
 		state.startDir,
@@ -500,7 +508,7 @@ renderCustomMFileBrowser(manager : MaterialManager, parent : MFocusGroup, captio
 								MTextButton(_("CREATE"), \-> {
 									state.engine.createDirectory(
 										getValue(state.currentPathB) + getValue(nameB) + "/",
-										updateFilesView,
+										updateFilesViewWithSameScrollPosition,
 										println
 									);
 									next(closeDialogB, true);
@@ -636,7 +644,7 @@ renderCustomMFileBrowser(manager : MaterialManager, parent : MFocusGroup, captio
 							[copied.first],
 							copyTo,
 							\-> {
-								updateFilesView();
+								updateFilesViewWithSameScrollPosition();
 								if (copied.second) next(state.copiedElementsB, Pair("", false));
 							},
 							println
@@ -889,7 +897,7 @@ renderCustomMFileBrowser(manager : MaterialManager, parent : MFocusGroup, captio
 				initClickB(5, nop);
 
 				MTextButton(cap |> toUpperCase, \->
-					func(getValue(state.currentPathB), getValue(state.selectedElementsB), updateFilesView),
+					func(getValue(state.currentPathB), getValue(state.selectedElementsB), updateFilesViewWithSameScrollPosition),
 					[],
 					[]
 				)
@@ -1125,7 +1133,7 @@ renderCustomMFileBrowser(manager : MaterialManager, parent : MFocusGroup, captio
 											onContentError
 										);
 									},
-									updateFilesView,
+									updateFilesViewWithSameScrollPosition,
 									println
 								),
 								println
@@ -1254,19 +1262,19 @@ renderCustomMFileBrowser(manager : MaterialManager, parent : MFocusGroup, captio
 			}),
 			subscribe(zoomValueB, \zoomValue -> nextDistinct(state.iconSizeB, 20.0 + zoomValue * 100.0)),
 			// Update content if the current path changed
-			subscribe(state.currentPathB, \__ -> updateFilesView()),
+			subscribe(state.currentPathB, \__ -> updateFilesViewWithZeroScrollPosition()),
 			// Update content if the "searchText" changed. Updating starts if the "searchText" has not changed during one sec.
 			subscribe2(state.searchTextB, \searchText -> {
 				// clear selection on search start
 				nextDistinct(state.selectedElementsB, []);
 
-				if (strlen(searchText) == 0) updateFilesView()
+				if (strlen(searchText) == 0) updateFilesViewWithZeroScrollPosition()
 				else timer(1000, \-> {
 					if (searchText == getValue(state.searchTextB))
-						next(dialogContentB, getSearchResultUI(state, searchText, normalExts, filterFn))
+						next(dialogContentB, getSearchResultUI(state, searchText, normalExts, filterFn, scrollPositionB))
 				})
 			}),
-			state.engine.subscribeOnUpdates(updateFilesView),
+			state.engine.subscribeOnUpdates(updateFilesViewWithSameScrollPosition),
 			fBidirectionalLink(
 				selectedFilesB,
 				fmerge(selectedFilesMany),

--- a/lib/material/internal/filebrowser/material_filebrowser_internal_view.flow
+++ b/lib/material/internal/filebrowser/material_filebrowser_internal_view.flow
@@ -268,9 +268,17 @@ createItemUI(state : FilebrowserState<?, ??, ???>, itemCP : FBContentPath, chang
 	tooltip = if (itemCP.dirPath != getValue(state.currentPathB)) fullName else "";
 
 	previewBM = make(None());
-	fContent = MSelect(
+	fContent = MSelect2(
+		state.contentViewIconsB,
 		previewBM, 
-		\previewM -> either(previewM, state.getDefaultIcon(itemCP.isFolder, itemCP.filename))
+		\showPreview, previewM -> {
+			icon = state.getDefaultIcon(itemCP.isFolder, itemCP.filename);
+			if(showPreview) {
+				either(previewM, icon)
+			} else {
+				icon
+			}
+		}
 	);
 
 	// We release item click if it is a folder or if the CTRL button is not down
@@ -286,18 +294,14 @@ createItemUI(state : FilebrowserState<?, ??, ???>, itemCP : FBContentPath, chang
 
 	item = 	fsCustomElement(state, fContent, itemCP.filename, tooltip, isSelectedB, onDown, onClick, onLongClick);
 	
-	if(fgetValue(state.contentViewIconsB)) {
-		MConstruct(
-			[makeSubscribe(renderableB, \renderable -> {
-				if(renderable && isNone(getValue(previewBM))) {
-					requestPreview(Pair(fullName, previewBM));
-				}
-			})],
-			MRenderable(renderableB, item)
-		)
-	} else {
-		item
-	}
+	MConstruct(
+		[make2Subscribe(renderableB, state.contentViewIconsB, \renderable, showPreview -> {
+			if(renderable && isNone(getValue(previewBM)) && showPreview) {
+				requestPreview(Pair(fullName, previewBM));
+			}
+		})],
+		MRenderable(renderableB, item)
+	)
 }
 
 // creating material view of the filebrowser element using own "icon"

--- a/lib/material/internal/filebrowser/material_filebrowser_internal_view.flow
+++ b/lib/material/internal/filebrowser/material_filebrowser_internal_view.flow
@@ -286,14 +286,18 @@ createItemUI(state : FilebrowserState<?, ??, ???>, itemCP : FBContentPath, chang
 
 	item = 	fsCustomElement(state, fContent, itemCP.filename, tooltip, isSelectedB, onDown, onClick, onLongClick);
 	
-	MConstruct(
-		[makeSubscribe(renderableB, \renderable -> {
-			if(renderable && isNone(getValue(previewBM))) {
-				requestPreview(Pair(fullName, previewBM));
-			}
-		})],
-		MRenderable(renderableB, item)
-	)
+	if(fgetValue(state.contentViewIconsB)) {
+		MConstruct(
+			[makeSubscribe(renderableB, \renderable -> {
+				if(renderable && isNone(getValue(previewBM))) {
+					requestPreview(Pair(fullName, previewBM));
+				}
+			})],
+			MRenderable(renderableB, item)
+		)
+	} else {
+		item
+	}
 }
 
 // creating material view of the filebrowser element using own "icon"

--- a/lib/material/internal/filebrowser/material_filebrowser_internal_view.flow
+++ b/lib/material/internal/filebrowser/material_filebrowser_internal_view.flow
@@ -44,7 +44,9 @@ export {
 		files : [?],
 		addBackButton : bool,
 		requestPreview : (Pair<string, DynamicBehaviour<Maybe<Material>>>) -> void,
-		previewsLoadingStatusB : DynamicBehaviour<Maybe<string>>
+		previewsLoadingStatusB : DynamicBehaviour<Maybe<string>>,
+		scrollPosition : DynamicBehaviour<Point>,
+		setPosM : Maybe<(DynamicBehaviour<Point>) -> void>
 	) -> Material;
 
 	getContentUI(
@@ -53,7 +55,9 @@ export {
 		files : [FBContentPath],
 		backButtonM : Maybe<Material>,
 		requestPreview : (Pair<string, DynamicBehaviour<Maybe<Material>>>) -> void,
-		previewsLoadingStatusB : DynamicBehaviour<Maybe<string>>
+		previewsLoadingStatusB : DynamicBehaviour<Maybe<string>>,
+		scrollPosition : DynamicBehaviour<Point>,
+		setPosM : Maybe<(DynamicBehaviour<Point>) -> void>
 	) -> Material;
 
 	getStateSubscribers(
@@ -129,7 +133,9 @@ prepareAndGetContentUI(
 	files : [?],
 	addBackButton : bool,
 	requestPreview : (Pair<string, DynamicBehaviour<Maybe<Material>>>) -> void,
-	previewsLoadingStatusB : DynamicBehaviour<Maybe<string>>
+	previewsLoadingStatusB : DynamicBehaviour<Maybe<string>>,
+	scrollPosition : DynamicBehaviour<Point>,
+	setPosM : Maybe<(DynamicBehaviour<Point>) -> void>
 ) -> Material {
 	correctCurPath = addSlash2pathEnd(getValue(state.currentPathB));
 	curPath = if (strlen(correctCurPath) > 0) strLeft(correctCurPath, strlen(correctCurPath) - 1) else correctCurPath;
@@ -148,7 +154,9 @@ prepareAndGetContentUI(
 		map(files, \f -> FBContentPath(f, ref makeTree(), false, correctCurPath, state.item2name(f))),
 		backButtonM,
 		requestPreview,
-		previewsLoadingStatusB
+		previewsLoadingStatusB,
+		scrollPosition,
+		setPosM
 	);
 }
 
@@ -159,7 +167,9 @@ getContentUI(
 	filesCP : [FBContentPath],
 	backButtonM : Maybe<Material>,
 	requestPreview : (Pair<string, DynamicBehaviour<Maybe<Material>>>) -> void,
-	previewsLoadingStatusB : DynamicBehaviour<Maybe<string>>
+	previewsLoadingStatusB : DynamicBehaviour<Maybe<string>>,
+	scrollPosition : DynamicBehaviour<Point>,
+	setPosM : Maybe<(DynamicBehaviour<Point>) -> void>
 ) -> Material {
 	createContentItemWrapper = \itemCP -> createContentItem(state, itemCP, requestPreview);
 
@@ -183,24 +193,30 @@ getContentUI(
 	};
 
 	boxSize = make(zeroWH);
+	sp = make(zeroPoint);
 	view = MConstruct([
 			make3Subscribe(fmerge(ddItems), fmerge(ffItems), state.contentSortTypeB, onSortChanged)
 		],
 		MLines([
-			MDynamicGrid(
-				fconcat(
-					const(eitherMap(backButtonM, \b -> [b], [])),
-					itemsListB
-				),
-				[
-					MBoxSize(boxSize),
-					MItemSize(fselect4(boxSize, state.contentViewIconsB, state.iconSizeB, state.thumbnailSize, \bs, ic, is, thumbnailSize -> {
-						if (ic)
-							WidthHeight(is + 20., is + 37.)
-						else
-							WidthHeight(bs.width, thumbnailSize + 12.)
-					}))
-				]
+			MConstruct(
+				eitherMap(setPosM, \setFn -> [\-> {timer(100, \-> {setFn(sp)}); nop}], []),
+				MDynamicGrid(
+					fconcat(
+						const(eitherMap(backButtonM, \b -> [b], [])),
+						itemsListB
+					),
+					[
+						MBoxSize(boxSize),
+						MItemSize(fselect4(boxSize, state.contentViewIconsB, state.iconSizeB, state.thumbnailSize, \bs, ic, is, thumbnailSize -> {
+							if (ic)
+								WidthHeight(is + 20., is + 37.)
+							else
+								WidthHeight(bs.width, thumbnailSize + 12.)
+						})),
+						TScrollPosition(sp),
+						TScrollInspectVisible(scrollPosition, makeWH())
+					]
+				)
 			),
 			MSelect(previewsLoadingStatusB, \loadingStatusM -> {
 				eitherMap(
@@ -296,7 +312,7 @@ createItemUI(state : FilebrowserState<?, ??, ???>, itemCP : FBContentPath, chang
 	
 	MConstruct(
 		[make2Subscribe(renderableB, state.contentViewIconsB, \renderable, showPreview -> {
-			if(renderable && isNone(getValue(previewBM)) && showPreview) {
+			if(renderable && showPreview) {
 				requestPreview(Pair(fullName, previewBM));
 			}
 		})],

--- a/lib/material/internal/filebrowser/material_filebrowser_internal_view.flow
+++ b/lib/material/internal/filebrowser/material_filebrowser_internal_view.flow
@@ -43,7 +43,7 @@ export {
 		dirs : [?],
 		files : [?],
 		addBackButton : bool,
-		previewsB : DynamicBehaviour<[Pair<string, Material>]>,
+		requestPreview : (Pair<string, DynamicBehaviour<Maybe<Material>>>) -> void,
 		previewsLoadingStatusB : DynamicBehaviour<Maybe<string>>
 	) -> Material;
 
@@ -52,7 +52,7 @@ export {
 		dirs : [FBContentPath],
 		files : [FBContentPath],
 		backButtonM : Maybe<Material>,
-		previewsB : DynamicBehaviour<[Pair<string, Material>]>,
+		requestPreview : (Pair<string, DynamicBehaviour<Maybe<Material>>>) -> void,
 		previewsLoadingStatusB : DynamicBehaviour<Maybe<string>>
 	) -> Material;
 
@@ -128,7 +128,7 @@ prepareAndGetContentUI(
 	dirs : [?],
 	files : [?],
 	addBackButton : bool,
-	previewsB : DynamicBehaviour<[Pair<string, Material>]>,
+	requestPreview : (Pair<string, DynamicBehaviour<Maybe<Material>>>) -> void,
 	previewsLoadingStatusB : DynamicBehaviour<Maybe<string>>
 ) -> Material {
 	correctCurPath = addSlash2pathEnd(getValue(state.currentPathB));
@@ -147,7 +147,7 @@ prepareAndGetContentUI(
 		map(dirs, \d -> FBContentPath(d, ref makeTree(), true, correctCurPath, state.item2name(d))),
 		map(files, \f -> FBContentPath(f, ref makeTree(), false, correctCurPath, state.item2name(f))),
 		backButtonM,
-		previewsB,
+		requestPreview,
 		previewsLoadingStatusB
 	);
 }
@@ -158,10 +158,10 @@ getContentUI(
 	dirsCP : [FBContentPath],
 	filesCP : [FBContentPath],
 	backButtonM : Maybe<Material>,
-	previewsB : DynamicBehaviour<[Pair<string, Material>]>,
+	requestPreview : (Pair<string, DynamicBehaviour<Maybe<Material>>>) -> void,
 	previewsLoadingStatusB : DynamicBehaviour<Maybe<string>>
 ) -> Material {
-	createContentItemWrapper = \itemCP -> createContentItem(state, itemCP, previewsB);
+	createContentItemWrapper = \itemCP -> createContentItem(state, itemCP, requestPreview);
 
 	ddItems = map(
 		filter(dirsCP, \dir -> dir.filename != ".." && dir.filename != "."),
@@ -242,7 +242,7 @@ wrapWithSubscribers(state : FilebrowserState<?, ??, ???>, content : Material) ->
 	|> (\m -> MBorder4(4.0, m));
 }
 
-createContentItem(state : FilebrowserState<?, ??, ???>, itemCP : FBContentPath, previewsB : DynamicBehaviour<[Pair<string, Material>]>) -> Transform<Maybe<FBContentItem>> {
+createContentItem(state : FilebrowserState<?, ??, ???>, itemCP : FBContentPath, requestPreview : (Pair<string, DynamicBehaviour<Maybe<Material>>>) -> void) -> Transform<Maybe<FBContentItem>> {
 	itemItemMB = make(Some(itemCP.item));
 	changeItem = \value -> nextDistinct(itemItemMB, value);
 
@@ -253,7 +253,7 @@ createContentItem(state : FilebrowserState<?, ??, ???>, itemCP : FBContentPath, 
 				newCPItem = FBContentPath(itemItem, itemCP.propertiesR, itemCP.isFolder, itemCP.dirPath, state.item2name(itemItem));
 				FBContentItem(
 					newCPItem,
-					createItemUI(state, newCPItem, changeItem, fif(state.contentViewIconsB, previewsB, const([])))
+					createItemUI(state, newCPItem, changeItem, requestPreview)
 				)
 			}
 		);
@@ -261,17 +261,16 @@ createContentItem(state : FilebrowserState<?, ??, ???>, itemCP : FBContentPath, 
 }
 
 // creating material view of the file/folder
-createItemUI(state : FilebrowserState<?, ??, ???>, itemCP : FBContentPath, changeItem : (Maybe<?>) -> void, previewsB : Transform<[Pair<string, Material>]>) -> Material {
+createItemUI(state : FilebrowserState<?, ??, ???>, itemCP : FBContentPath, changeItem : (Maybe<?>) -> void, requestPreview : (Pair<string, DynamicBehaviour<Maybe<Material>>>) -> void) -> Material {
+	renderableB = make(false);
 	fullName = getItemFullname(itemCP);
 	isSelectedB = fselect(state.selectedElementsB, FLift(\elements -> contains(elements, fullName)));
 	tooltip = if (itemCP.dirPath != getValue(state.currentPathB)) fullName else "";
 
-	fContent = MSelect(previewsB, \previews ->
-		eitherMap(
-			find(previews, \p -> p.first == fullName),
-			\p -> p.second,
-			state.getDefaultIcon(itemCP.isFolder, itemCP.filename)
-		)
+	previewBM = make(None());
+	fContent = MSelect(
+		previewBM, 
+		\previewM -> either(previewM, state.getDefaultIcon(itemCP.isFolder, itemCP.filename))
 	);
 
 	// We release item click if it is a folder or if the CTRL button is not down
@@ -285,7 +284,16 @@ createItemUI(state : FilebrowserState<?, ??, ???>, itemCP : FBContentPath, chang
 		\-> onDownElementFn(state, fullName);
 	}
 
-	fsCustomElement(state, fContent, itemCP.filename, tooltip, isSelectedB, onDown, onClick, onLongClick);
+	item = 	fsCustomElement(state, fContent, itemCP.filename, tooltip, isSelectedB, onDown, onClick, onLongClick);
+	
+	MConstruct(
+		[makeSubscribe(renderableB, \renderable -> {
+			if(renderable && isNone(getValue(previewBM))) {
+				requestPreview(Pair(fullName, previewBM));
+			}
+		})],
+		MRenderable(renderableB, item)
+	)
 }
 
 // creating material view of the filebrowser element using own "icon"

--- a/lib/material/internal/material_grid.flow
+++ b/lib/material/internal/material_grid.flow
@@ -366,7 +366,8 @@ MDynamicGrid2T(manager : MaterialManager, parent : MFocusGroup, m : MDynamicGrid
 
 	boxSize = extractStruct(m.style, MBoxSize(make(zeroWH))).wh;
 	contentSize = make(zeroWH);
-	position = make(zeroPoint);
+	position = extractStruct(m.style, TScrollPosition(make(zeroPoint))).position;
+	inspectVisible = extractStruct(m.style, TScrollInspectVisible(make(zeroPoint), makeWH()));
 	containers = make([]);
 	itemSize = extractStruct(m.style, MItemSize(fselect(boxSize, FLift(\cs -> WidthHeight(cs.width / 5., cs.width / 5.))))).wh;
 
@@ -411,7 +412,7 @@ MDynamicGrid2T(manager : MaterialManager, parent : MFocusGroup, m : MDynamicGrid
 			MScroll(
 				f,
 				TFillXY(),
-				[MScrollPosition(position), MScrollWidthHeight(make(zeroWH), boxSize)]
+				[MScrollPosition(position), MScrollWidthHeight(make(zeroWH), boxSize), inspectVisible]
 			),
 			m2t
 		)

--- a/lib/material/material.flow
+++ b/lib/material/material.flow
@@ -1390,7 +1390,7 @@ export {
 		MReorderGrid(items : [MReorderItem], order : DynamicBehaviour<[int]>, style : [MReorderGridStyle]);
 
 		MDynamicGrid(items : Transform<[Material]>, style : [MDynamicGridStyle]);
-			MDynamicGridStyle ::= MBoxSize, MItemSize;
+			MDynamicGridStyle ::= MBoxSize, MItemSize, TScrollPosition, TScrollInspectVisible;
 				// Scroll box size
 				MBoxSize(wh : DynamicBehaviour<WidthHeight>);
 				// Set cell height


### PR DESCRIPTION
Additionally add preview of the pictures in search mode.

https://trello.com/c/cMevJitP/16244-speed-up-filebrowser-for-large-partitions?filter=label:Release%202.5