### PR TITLE
 small doc improvements for flow and vscode 

### DIFF
--- a/doc/form.markdown
+++ b/doc/form.markdown
@@ -249,7 +249,7 @@ Next up is the Text, which we saw a minute ago:
 
 	Text(text : string, style : [CharacterStyle]);
 
-This is a static text in a given character style. `CharacterStyle` is a sub-type for concrete
+This is a static text in a given character style. `CharacterStyle` is a union of concrete
 style attributes such as `FontFamily`, `FontSize`, and `Fill` for specifying the text color. It
 uses another pattern in `Form`: Instead of having an ever increasing number of arguments, we use 
 an array of properties instead and only include those we need to change from the defaults. This 

--- a/resources/vscode/flow/README.md
+++ b/resources/vscode/flow/README.md
@@ -5,7 +5,7 @@ This folder contains Visual Studio Code extension for flow and lingo.
 ## INSTALLATION and UPDATE
 1. Launch Visual Studio Code
 2. Click the Extensions bar on the left (ctrl+shift+x)
-3. Click `More -> Install from VSIX...` and choose `flow.vsix`
+3. Click `More -> Install from VSIX...` and choose `resources/vscode/flow.vsix`
 
 Alternatively, run the following command line: `code --install-extension flow.vsix` or one of the `install-or-update` scripts provided. 
 


### PR DESCRIPTION
CharacterStyle is indeed a union, not a subtype. And I think full path to flow.vsix is clearer.