### PR TITLE
Fix bug when pebbles updated twice

### DIFF
--- a/lib/pebbles/pebble_controller.flow
+++ b/lib/pebbles/pebble_controller.flow
@@ -528,8 +528,7 @@ pushPebble2(pebbleStackB : DynamicBehaviour<[Pebble]>, updateHashUrl : bool, peb
 
 	if (!equalPebbles(npebble, lastPebble2(pebbleStackB, makeEmptyPebble()))) {
 
-		//println("pushPebble:" + pebble2UrlHash(npebble) + (if (recordHistory) " recordHistory" else ""));
-		dynArrayPush(pebbleStackB, npebble);
+		//println("pushPebble: " + pebble2UrlHash(npebble) + " updateHashUrl: " + b2s(updateHashUrl));
 
 		if (updateHashUrl) {
 			if (js) {
@@ -540,6 +539,8 @@ pushPebble2(pebbleStackB : DynamicBehaviour<[Pebble]>, updateHashUrl : bool, peb
 				{}
 			}
 		}
+
+		dynArrayPush(pebbleStackB, npebble);
 	}
 }
 


### PR DESCRIPTION
Task: https://trello.com/c/7nuhemmz/1405-discard-tablepage-parameter-during-the-search