### PR TITLE
added `responseEncoding` parameter into http request

### DIFF
--- a/lib/net/http.flow
+++ b/lib/net/http.flow
@@ -16,6 +16,10 @@ export {
 	// httpRequest("http://localhost:81/flow/myfile.txt", false, [], [], \c -> println(c), \e -> {}, \s -> {});
 
 	// The response is assumed to be UTF-8 encoded, unless a UTF-16 BOM is present
+	// Also, js target uses UTF-8 encoding with surrogate pairs
+	//  and cpp target uses correct UTF8 encoding, but it returns only two bytes of symbol (even if the character is represented by 3 bytes) - it is a BUG.
+	// But js surrogate pairs and cpp `cropped` character codes are not often. Only for specific symbols, like emoji and etc..
+	//  (which has code more than 0xFFFF, an example is emoji smile with code 0x1F609 (one symbol (😉) with 3 bytes code (0x1F609) and stored in UTF8 with 4 bytes (0xF09F9889)).
 
 	// at the moment of comment POST-request parameters were encoded differently for different compiler backends:
 	// in flowcpp POST-request parameters arent url-encoded, thus doesn't work with getUrlParameter
@@ -39,6 +43,21 @@ export {
 		onResponse : (responseStatus : int, responseData : string, responseHeaders : [KeyValue]) -> void,
 		async : bool
 	) -> void;
+	// Added `responseEncoding` parameter to return data in the requested encoding.
+	// Compiler or url parameter takes precedence:
+	//  - cpp flag is `use_utf8_js_style`;
+	//  - js flag is `utf8_no_surragates`.
+	// If there is no such - `responseEncoding` will be used.
+	httpCustomRequestExt(
+		url : string,
+		method : RequestMethod,
+		headers : [KeyValue],
+		data : RequestData,
+		responseEncoding : ResponseEncoding,
+		onResponse : (responseStatus : int, responseData : string, responseHeaders : [KeyValue]) -> void,
+		async : bool
+	) -> void;
+
 	// This version currently implemented only in java backend
 	httpCustomRequestWithTimeout(
 		url : string,
@@ -131,12 +150,18 @@ native makeHttpRequest : io (
 	onStatus : (int) -> void,
 ) -> void = HttpSupport.httpRequest;
 
+// responseEncoding parameter allows to set which encoding should be the response:
+//  'auto' - defined by target (js - 'utf8_js', cpp - 'utf8', but cropped by two bytes (it is bug));
+//  'utf8_js' -  UTF-8 encoding with surrogate pairs;
+//  'utf8' - original UTF-8 encoding with 1, 2, 3 bytes length;
+//  'byte' - 1 byte encoding (raw response).
 native httpCustomRequestNative : io (
 	url : string,
 	method : string,
 	headers : [[string]],
 	parameters : [[string]],
 	data : string,
+	responseEncoding : string, // ['auto', 'utf8_js', 'utf8', 'byte']
 	onResponse : (responseStatus : int, responseData : string, responseHeaders : [[string]]) -> void,
 	async : bool
 ) -> void = HttpSupport.httpCustomRequestNative;
@@ -163,7 +188,7 @@ httpCustomRequestWithTimeoutNative (
 	async : bool,
 	timeout : int
 ) -> void {
-	httpCustomRequestNative(url, method, headers, parameters, data, onResponse, async);
+	httpCustomRequestNative(url, method, headers, parameters, data, responseEncoding2string(ResponseEncodingAuto()), onResponse, async);
 }
 
 native doPreloadMediaUrl : io (url : string, onSuccess : () -> void, onError : (string) -> void) -> void = HttpSupport.preloadMediaUrl;
@@ -261,7 +286,20 @@ httpCustomRequest(
 	async : bool
 ) -> void {
 	// Timeout 0 means no real timeout - it will wait for the response infinitely.
-	httpCustomRequestWithTimeout(url, method, headers, data, onResponse, async, 0);
+	httpCustomRequestWithTimeoutExt(url, method, headers, data, onResponse, async, 0, ResponseEncodingAuto());
+}
+
+httpCustomRequestExt(
+	url : string,
+	method : RequestMethod,
+	headers : [KeyValue],
+	data : RequestData,
+	responseEncoding : ResponseEncoding,
+	onResponse : (responseStatus : int, responseData : string, responseHeaders : [KeyValue]) -> void,
+	async : bool
+) -> void {
+	// Timeout 0 means no real timeout - it will wait for the response infinitely.
+	httpCustomRequestWithTimeoutExt(url, method, headers, data, onResponse, async, 0, responseEncoding);
 }
 
 httpCustomRequestWithTimeout(
@@ -272,6 +310,19 @@ httpCustomRequestWithTimeout(
 	onResponse : (responseStatus : int, responseData : string, responseHeaders : [KeyValue]) -> void,
 	async : bool,
 	timeout : int
+) -> void {
+	httpCustomRequestWithTimeoutExt(url, method, headers, data, onResponse, async, timeout, ResponseEncodingAuto());
+}
+
+httpCustomRequestWithTimeoutExt(
+	url : string,
+	method : RequestMethod,
+	headers : [KeyValue],
+	data : RequestData,
+	onResponse : (responseStatus : int, responseData : string, responseHeaders : [KeyValue]) -> void,
+	async : bool,
+	timeout : int,
+	responseEncoding : ResponseEncoding
 ) -> void {
 	isPHPRequest = endsWith(url, ".php");
 	noCacheTimestamp = KeyValue("t", d2s(timestamp()));
@@ -317,6 +368,7 @@ httpCustomRequestWithTimeout(
 			map(headers, \header -> [header.key, header.value]),
 			map(params, \param -> [param.key, param.value]),
 			payload,
+			responseEncoding2string(responseEncoding),
 			\responseStatus, responseData, responseHeaders -> {
 				runningRealtimeHTTPrequests := ^runningRealtimeHTTPrequests - 1;
 

--- a/lib/net/http.flow
+++ b/lib/net/http.flow
@@ -46,27 +46,15 @@ export {
 	// Added `responseEncoding` parameter to return data in the requested encoding.
 	// Compiler or url parameter takes precedence:
 	//  - cpp flag is `use_utf8_js_style`;
-	//  - js flag is `utf8_no_surragates`.
+	//  - js flag is `utf8_no_surrogates`.
 	// If there is no such - `responseEncoding` will be used.
-	httpCustomRequestExt(
+	// 
+	// RequestTimeout currently implemented only in java backend.
+	httpCustomRequestStyled(
 		url : string,
 		method : RequestMethod,
-		headers : [KeyValue],
-		data : RequestData,
-		responseEncoding : ResponseEncoding,
 		onResponse : (responseStatus : int, responseData : string, responseHeaders : [KeyValue]) -> void,
-		async : bool
-	) -> void;
-
-	// This version currently implemented only in java backend
-	httpCustomRequestWithTimeout(
-		url : string,
-		method : RequestMethod,
-		headers : [KeyValue],
-		data : RequestData,
-		onResponse : (responseStatus : int, responseData : string, responseHeaders : [KeyValue]) -> void,
-		async : bool,
-		timeout : int
+		style : [RequestStyle]
 	) -> void;
 
 	// Here and below. onProgress callback receives (done, total) parameters, so progress is done/total.
@@ -286,35 +274,26 @@ httpCustomRequest(
 	async : bool
 ) -> void {
 	// Timeout 0 means no real timeout - it will wait for the response infinitely.
-	httpCustomRequestWithTimeoutExt(url, method, headers, data, onResponse, async, 0, ResponseEncodingAuto());
+	httpCustomRequestBase(url, method, headers, data, onResponse, async, 0, ResponseEncodingAuto());
 }
 
-httpCustomRequestExt(
+httpCustomRequestStyled(
 	url : string,
 	method : RequestMethod,
-	headers : [KeyValue],
-	data : RequestData,
-	responseEncoding : ResponseEncoding,
 	onResponse : (responseStatus : int, responseData : string, responseHeaders : [KeyValue]) -> void,
-	async : bool
+	style : [RequestStyle]
 ) -> void {
+	headers = extractStruct(style, RequestHeaders([])).headers;
+	data = either(tryExtractStruct(style, RequestPayload("")), extractStruct(style, RequestParameters([])));
+	async = extractStruct(style, RequestAsync(true)).async;
+	responseEncoding = extractStruct(style, RequestEncoding(ResponseEncodingAuto())).responseEncoding;
+	timeout = extractStruct(style, RequestTimeout(0)).timeout;
+
 	// Timeout 0 means no real timeout - it will wait for the response infinitely.
-	httpCustomRequestWithTimeoutExt(url, method, headers, data, onResponse, async, 0, responseEncoding);
+	httpCustomRequestBase(url, method, headers, data, onResponse, async, timeout, responseEncoding);
 }
 
-httpCustomRequestWithTimeout(
-	url : string,
-	method : RequestMethod,
-	headers : [KeyValue],
-	data : RequestData,
-	onResponse : (responseStatus : int, responseData : string, responseHeaders : [KeyValue]) -> void,
-	async : bool,
-	timeout : int
-) -> void {
-	httpCustomRequestWithTimeoutExt(url, method, headers, data, onResponse, async, timeout, ResponseEncodingAuto());
-}
-
-httpCustomRequestWithTimeoutExt(
+httpCustomRequestBase(
 	url : string,
 	method : RequestMethod,
 	headers : [KeyValue],

--- a/lib/net/http_types.flow
+++ b/lib/net/http_types.flow
@@ -53,6 +53,12 @@ export {
 
 	responseEncoding2string(responseEncoding : ResponseEncoding) -> string;
 	string2responseEncoding(responseEncoding : string) -> ResponseEncoding; // ResponseEncodingAuto() by default
+
+	RequestStyle ::= RequestAsync, RequestEncoding, RequestHeaders, RequestTimeout, RequestData;
+		RequestAsync(async : bool);
+		RequestEncoding(responseEncoding : ResponseEncoding);
+		RequestHeaders(headers : [KeyValue]);
+		RequestTimeout(timeout : int);
 }
 
 method2string(method : RequestMethod) -> string {

--- a/lib/net/http_types.flow
+++ b/lib/net/http_types.flow
@@ -40,6 +40,19 @@ export {
 
 	method2string(method : RequestMethod) -> string;
 	string2method(method : string) -> RequestMethod; // POST by default
+
+	ResponseEncoding ::= ResponseEncodingAuto, ResponseEncodingUtf8, ResponseEncodingByte;
+		// defined by target (js - ResponseEncodingUtf8(true), cpp - ResponseEncodingUtf8(false);
+		ResponseEncodingAuto();
+		// UTF8 encoding with two realisations:
+		// 	`withSurrogatePairs=true` -  UTF-8 encoding with surrogate pairs (like it works in js target by default);
+		//  `withSurrogatePairs=false` - original UTF-8 encoding with 1, 2, 3 bytes symbol length (in cpp target is a bug - symbol cropped by two bytes);
+		ResponseEncodingUtf8(withSurrogatePairs : bool);
+		// Without encoding - each symbol is a one byte length
+		ResponseEncodingByte();
+
+	responseEncoding2string(responseEncoding : ResponseEncoding) -> string;
+	string2responseEncoding(responseEncoding : string) -> ResponseEncoding; // ResponseEncodingAuto() by default
 }
 
 method2string(method : RequestMethod) -> string {
@@ -63,5 +76,30 @@ string2method(method : string) -> RequestMethod {
 		DELETE()
 	} else {
 		POST()
+	}
+}
+
+responseEncoding2string(responseEncoding : ResponseEncoding) -> string {
+	switch(responseEncoding) {
+		ResponseEncodingAuto(): "auto";
+		ResponseEncodingUtf8(withSurrogatePairs): {
+			if (withSurrogatePairs) "utf8_js"
+			else "utf8";
+		}
+		ResponseEncodingByte(): "byte";
+	}
+}
+
+string2responseEncoding(responseEncoding : string) -> ResponseEncoding {
+	if (responseEncoding == "auto") {
+		ResponseEncodingAuto()
+	} else if (responseEncoding == "utf8_js") {
+		ResponseEncodingUtf8(true)
+	} else if (responseEncoding == "utf") {
+		ResponseEncodingUtf8(false)
+	} else if (responseEncoding == "byte") {
+		ResponseEncodingByte()
+	} else {
+		ResponseEncodingAuto()
 	}
 }

--- a/platforms/common/cpp/core/STLHelpers.h
+++ b/platforms/common/cpp/core/STLHelpers.h
@@ -225,6 +225,7 @@ extern bool is_utf8_js_style;
 
 unicode_string parseUtf8(const std::string &str);
 unicode_string parseUtf8(const char *str, unsigned size);
+unicode_string parseUtf8Js(const char *str, unsigned size);
 
 unicode_string parseUtf8u(const unicode_string &str);
 

--- a/platforms/common/cpp/utils/AbstractHttpSupport.h
+++ b/platforms/common/cpp/utils/AbstractHttpSupport.h
@@ -5,6 +5,13 @@
 
 #include "utils/flowfilestruct.h"
 
+enum ResponseEncoding {
+    ResponseEncodingAuto,
+    ResponseEncodingUTF8,
+    ResponseEncodingUTF8js,
+    ResponseEncodingByte
+};
+
 struct HttpRequest {
     typedef std::map<unicode_string,unicode_string> T_SMap;
     typedef std::map<unicode_string,FlowFile*> T_FileMap;
@@ -13,6 +20,7 @@ struct HttpRequest {
 
     unicode_string url;
     unicode_string method;
+    ResponseEncoding response_enc;
     std::vector<uint8_t> payload;
     T_SMap headers, params;
     T_FileMap attachments;
@@ -108,6 +116,8 @@ protected:
     virtual void doDeleteAppCookies() {}
 
     NativeFunction *MakeNativeFunction(const char *name, int num_args);
+
+    ResponseEncoding GetResponseEncodingFromString(std::string str);
 
 private:
     static StackSlot cbCancel(ByteCodeRunner*, StackSlot*, void*);

--- a/platforms/js/HttpCustom.hx
+++ b/platforms/js/HttpCustom.hx
@@ -1,7 +1,11 @@
+import js.html.Uint8Array;
+
 class HttpCustom extends haxe.Http {
 	#if (js && !nwjs)
 	var method : String;
 	var availableMethods = ['GET', 'POST', 'DELETE', 'PATCH', 'PUT'];
+	var arrayBufferEncodings = ['utf8', 'byte'];
+	var defaultEncodings = ['auto', 'utf8_js'];
 
 	var responseHeaders : Array<Array<String>>;
 
@@ -17,6 +21,10 @@ class HttpCustom extends haxe.Http {
 	}
 
 	public override function request(?post : Bool) {
+		return this.requestExt(post, 'auto');
+	}
+
+	public function requestExt(post : Bool, responseEncoding : String) {
 		var me = this;
 		#if (haxe_ver >= "4.0.0")
 			me.responseAsString = null;
@@ -24,7 +32,23 @@ class HttpCustom extends haxe.Http {
 			me.responseData = null;
 		#end
 		var r = req = js.Browser.createXMLHttpRequest();
-		var onreadystatechange = function(_) {
+
+		var utf8NoSurragatesFlag = Util.getParameter("utf8_no_surragates");
+		// Url parameter takes precedence.
+		if (utf8NoSurragatesFlag != null && utf8NoSurragatesFlag != "0") {
+			responseEncoding = "utf8";
+		} else if (responseEncoding == "utf8_js") {
+			responseEncoding = "auto";
+		} else if (this.arrayBufferEncodings.indexOf(responseEncoding) == -1 && this.defaultEncodings.indexOf(responseEncoding) == -1) {
+			responseEncoding = "auto";
+		}
+
+		if (this.arrayBufferEncodings.indexOf(responseEncoding) != -1) r.responseType = ARRAYBUFFER;
+		else r.responseType = NONE;
+
+		var encodedResponse = "";
+
+		var onreadystatechange = function(v) {
 			if( r.readyState != 4 )
 				return;
 			var s = try r.status catch( e : Dynamic ) null;
@@ -34,7 +58,8 @@ class HttpCustom extends haxe.Http {
 				var rlocalProtocol = ~/^(?:about|app|app-storage|.+-extension|file|res|widget):$/;
 				var isLocal = rlocalProtocol.match( protocol );
 				if ( isLocal ) {
-					s = r.responseText != null ? 200 : 404;
+					if (r.responseType == ARRAYBUFFER) s = encodedResponse != null ? 200 : 404;
+					else s = r.responseText != null ? 200 : 404;
 				}
 			}
 			if( s == untyped __js__("undefined") )
@@ -42,11 +67,39 @@ class HttpCustom extends haxe.Http {
 			if( s != null )
 				me.onStatus(s);
 			me.req = null;
+
+			if (responseEncoding == "utf8") {
+				try {
+					encodedResponse = this.parseUtf8Real(
+						new Uint8Array(r.response),
+						r.response.byteLength
+					);
+				} catch (e : Dynamic) {
+					encodedResponse = null;
+					Native.println("ERROR: parseUtf8Full reported: " + e);
+				}
+			} else if (responseEncoding == "byte") {
+				try {
+					encodedResponse = this.respone2bytesString(
+						new Uint8Array(r.response),
+						r.response.byteLength
+					);
+				} catch (e : Dynamic) {
+					encodedResponse = null;
+					Native.println("ERROR: parseBinary reported: " + e);
+				}
+			} else {
+				// Ignore, we need no to decode content
+			}
+
 			#if (haxe_ver >= "4.0.0")
-				me.responseAsString = r.responseText;
+			if (r.responseType == ARRAYBUFFER) me.responseAsString = encodedResponse;
+			else me.responseAsString = r.responseText;
 			#else
-				me.responseData = r.responseText;
+			if (r.responseType == ARRAYBUFFER) me.responseData = encodedResponse;
+			else me.responseData = r.responseText;
 			#end
+			
 			me.responseHeaders =
 				r
 					.getAllResponseHeaders()
@@ -108,5 +161,91 @@ class HttpCustom extends haxe.Http {
 		if( !async )
 			onreadystatechange(null);
 	}
+
+	private function parseUtf8Real(str : Uint8Array, size : Int) : String {
+		var out = "";
+		var bytes = 0;
+		var decode_error = String.fromCharCode(0xfffd);
+
+		//second/third/fourth bytes should starts with 10xxxxxx
+		var is_sequence_correct = function(i : Int, bytes : Int) : Bool {
+			var is_correct = true;
+			if (size - i >= bytes) {
+				var mask = 0xc0; // xx000000
+				var next_octet_mask = 0x80; // 10xxxxxx
+
+				for (j in 1...bytes) {
+					var c = str[i + j];
+					is_correct = is_correct && ((c&mask) == next_octet_mask);
+				}
+			}
+			else {
+				is_correct = false;
+			}
+
+			return is_correct;
+		};
+
+		var push_sequence = function(mask : Int, c : Int, i : Int, bytes : Int) {
+			if (is_sequence_correct(i, bytes)) {
+				var w = (c & mask);
+
+				//second/third/fourth bytes
+				for (j in 1...bytes) {
+					c = str[i + j];
+					w = ((w << 6)|(c & 0x3f)); // 0x3f = 0011 1111
+				}
+				
+				out += String.fromCharCode(w);
+			}
+			else {
+				out += decode_error;
+			}
+
+			return;
+		};
+
+		var i = 0;
+		while (i < size) {
+			var c = str[i];
+
+			if (c <= 0x7f) { // 1 byte sequence, 0x7f = 0111 1111
+				out += String.fromCharCode(c);
+				i++;
+			}
+			else if (c <= 0xdf) { //2 bytes sequence, 0xdf = 1101 1111
+				bytes = 2;
+				push_sequence(0x1f, c, i, bytes); // 0x1f = 0001 1111
+				i += bytes;
+			}
+			else if (c <= 0xef) { // 3 bytes sequence, 0xef = 1110 1111
+				bytes = 3;
+				push_sequence(0x0f, c, i, bytes); // 0x0f = 0000 1111
+				i += bytes;
+			}
+			else if (c <= 0xf7) { // 4 bytes sequence, 0xf7 = 1111 0111
+				bytes = 4;
+				push_sequence(0x07, c, i, bytes); // 0x07 = 0000 0111
+				i += bytes;
+			}
+			else { //error, UTF-8 accept only max 4 octets 
+				out += decode_error;
+				i++;
+			}
+		}
+
+		return out;
+	}
+
+	private function respone2bytesString (str : Uint8Array, size : Int) : String {
+		var out = "";
+
+		for (i in 0...size) {
+			out += String.fromCharCode(str[i]);
+		}
+
+		return out;
+	}
+
 	#end
 }

--- a/platforms/js/HttpCustom.hx
+++ b/platforms/js/HttpCustom.hx
@@ -33,9 +33,9 @@ class HttpCustom extends haxe.Http {
 		#end
 		var r = req = js.Browser.createXMLHttpRequest();
 
-		var utf8NoSurragatesFlag = Util.getParameter("utf8_no_surragates");
+		var utf8NoSurrogatesFlag = Util.getParameter("utf8_no_surrogates");
 		// Url parameter takes precedence.
-		if (utf8NoSurragatesFlag != null && utf8NoSurragatesFlag != "0") {
+		if (utf8NoSurrogatesFlag != null && utf8NoSurrogatesFlag != "0") {
 			responseEncoding = "utf8";
 		} else if (responseEncoding == "utf8_js") {
 			responseEncoding = "auto";

--- a/platforms/js/HttpSupport.hx
+++ b/platforms/js/HttpSupport.hx
@@ -121,7 +121,8 @@ class HttpSupport {
 	#end
 
 	public static function httpRequest(url : String, post : Bool, headers : Array<Array<String>>,
-		params : Array<Array<String>>, onDataFn : String -> Void, onErrorFn : String -> Void, onStatusFn : Int -> Void, ?request : Dynamic = null) : Void {
+		params : Array<Array<String>>, onDataFn : String -> Void, onErrorFn : String -> Void,
+		onStatusFn : Int -> Void, ?request : Dynamic = null) : Void {
 		#if flow_nodejs
 
 		var options : HttpsRequestOptions = parseUrlToNodeOptions(url, request);
@@ -287,7 +288,7 @@ class HttpSupport {
 	}
 
 	public static function httpCustomRequestNative(url : String, method : String, headers : Array<Array<String>>,
-		params: Array<Array<String>>, data : String, onResponseFn : Int -> String -> Array<Array<String>> -> Void, async : Bool, ?request : Dynamic = null) : Void {
+		params: Array<Array<String>>, data : String, responseEncoding : String, onResponseFn : Int -> String -> Array<Array<String>> -> Void, async : Bool, ?request : Dynamic = null) : Void {
 
 		if ((method == 'DELETE' || method == 'PATCH' || method == "PUT") && !Lambda.exists(headers, function(h) return h[0] == "If-Match")) {
 			headers.push(["If-Match", "*"]);
@@ -502,9 +503,10 @@ class HttpSupport {
 
 		#if (js && !nwjs)
 		http.async = async;
-		#end
-
+		http.requestExt(method == "POST", responseEncoding);
+		#else
 		http.request(method == "POST");
+		#end
 		#end
 	}
 

--- a/platforms/js/Native.hx
+++ b/platforms/js/Native.hx
@@ -1376,6 +1376,7 @@ class Native {
 			}
 			return true;
 		#elseif js
+			Errors.print("setFileContent '" + file + "' does not work in this target. Use the C++ runner");
 			return false;
 		#else
 			try {

--- a/platforms/qt/bin/windows/QtByteRunner.exe
+++ b/platforms/qt/bin/windows/QtByteRunner.exe
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fb226bd06740b8bfea1a216d0c926159b8ba1e731620d047408e1a25f3f53dc2
-size 1782784
+oid sha256:5c5e6141b20c719f43d77aa11c4df0684e15d660ce16d32b81b16a10b4fb1f20
+size 1783296

--- a/platforms/qt/bin/windows32/QtByteRunner.exe
+++ b/platforms/qt/bin/windows32/QtByteRunner.exe
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8a11f0bf49e28b31c88496e6745ea08c6e1dd8db7f41164f89ee4d9b49f0da59
-size 1170432
+oid sha256:cfa2768d05707614b08ee5f03ddb996f2c8b7547b073ee0e3265185ea2fad6f6
+size 1171456


### PR DESCRIPTION
New parameter for the requests to get data in specific encoding. Or, to get data from the request in the same encoding for the different targets (js, cpp).

Now supports 4 encoding:
* ResponseEncodingAuto() - default, as was;
* ResponseEncodingUtf8(withSurrogatePairs = true) - js style;
* ResponseEncodingUtf8(withSurrogatePairs = false) - cpp style (but for cpp will be cropped by two bytes);
* ResponseEncodingByte() - without encoding, raw bytes (as string).

Compiler or url parameter/flags takes precedence:
 * cpp flag is `use_utf8_js_style`;
 * js flag is `utf8_no_surragates`.

![image](https://user-images.githubusercontent.com/19839037/173592793-7e12c337-caae-400c-b5fb-d72260d55301.png)

![image](https://user-images.githubusercontent.com/19839037/173592820-a0739248-0203-481d-8b61-279a56035c8b.png)
