### PR TITLE
Fix virtual screen overlays closing order

### DIFF
--- a/lib/form/virtual_screen_types.flow
+++ b/lib/form/virtual_screen_types.flow
@@ -6,7 +6,7 @@ export {
 	VirtualScreenInfo : (
 		size : Behaviour<WidthHeight>,
 		position : Behaviour<PositionScale>,
-		renderFn : (Form) -> void,
+		renderFn : (Form) -> () -> void,
 	);
 
 	makeDefaultVirtualScreenInfo() -> VirtualScreenInfo;
@@ -29,7 +29,7 @@ export {
 }
 
 makeDefaultVirtualScreenInfo() -> VirtualScreenInfo {
-	VirtualScreenInfo(makeWH(), make(zeroPositionScale), nop1);
+	VirtualScreenInfo(makeWH(), make(zeroPositionScale), \__ -> nop);
 }
 
 CenterPopupByVirtualScreenBox(
@@ -71,7 +71,6 @@ getScreenPopupRenderer(
 		virtualScreenInfoM,
 		\vsi -> \f -> {
 			vsi.renderFn(f);
-			\-> vsi.renderFn(Empty())
 		},
 		defRender
 	);


### PR DESCRIPTION
https://trello.com/c/SsGZGu61/19217-wrong-order-of-closing-wigi-popups

Related PR:
https://github.com/area9innovation/innovation/pull/3049
https://git.area9lyceum.com/Lyceum/lyceum/pulls/5432