### PR TITLE
Fill an icon in a tab the same color as text heading

### DIFF
--- a/lib/material/internal/material_tabs.flow
+++ b/lib/material/internal/material_tabs.flow
@@ -141,6 +141,7 @@ MDynamicTabs2T(manager : MaterialManager, parent : MFocusGroup, m : MDynamicTabs
 						[onClick, AccessRole("tab"), FAccessAttribute("aria-controls", tabPanelId), MRippleType(const(MRippleFill()))]
 					);
 					tabIcon = tryExtractStruct(tb.style, MTabIcon(TEmpty()));
+					
 					rescaleEnabled = fand(rescaleEnabled0, extractStruct(tb.style, MTabTitleRescaleEnabled(const(true))).enabled);
 					maxLines = extractStruct(tb.style, MMaxLines(2)).lines;
 					widthByContent = contains(tb.style, MWidthByContent());
@@ -150,27 +151,28 @@ MDynamicTabs2T(manager : MaterialManager, parent : MFocusGroup, m : MDynamicTabs
 					iconW = make(0.);
 					isIconVisible = make(true);
 					dynArrayPush(iconsVisible, isIconVisible);
+					colorT = fselectLift(fand(const(!isKeepTabColor), feq(m.selected, i)), \selected -> if (selected) Some(indicatorColor) else itemsColor);
 
-					TSelect2(tb.text, fand(const(!isKeepTabColor), feq(m.selected, i)), \txt, selected ->
-						TShow(const(txt != ""), {
-							if (isSome(iconAlign)) TFillX() 
-							else {color = if (selected) Some(indicatorColor) else itemsColor;
+					TSelect2(tb.text, colorT, \txt, color ->
+						if (txt != "") {
 							MTabsText(manager, p2, txt, capitalizeTitle, centerTitle, rescaleEnabled, showTooltip, maxLines, tabsFontStyle, color, fullWidth, widthByContent, m2t)
-							|> TBorderTopBottom(2.)}
-						})
-						|> ( if (oneLineTitle && isSome(tabIcon)) idfn else TSetMinWidth2(if (widthByContent) fullWidth else const(tabMinWidth)))
-						|> \t -> eitherMap(tabIcon, \ti -> {
-							iconName = switch (ti.icon) {
-									MIcon(name, style) : name;
-									default : "grade";
-							}
-							iconStyle = if (selected) MIcon(iconName, [indicatorColor]) else ti.icon;
-							m2t(iconStyle, p2)
-							|> (if (oneLineTitle)
-									TBorderLeftRight(2.)
-								else
-									\t2 -> TCenterX(t2) |> TBorderTopBottom(2.)
-							)
+							|> TBorderTopBottom(2.)
+						} else if (isSome(iconAlign)) TFillX()
+						else TEmpty()
+					)
+					|> (
+						if (oneLineTitle && isSome(tabIcon)) idfn
+						else TSetMinWidth2(if (widthByContent) fullWidth else const(tabMinWidth) )
+					)
+					|> (\t -> eitherMap(tabIcon, \ti ->  {
+							m2t(
+								 switch (ti.icon) {
+									MIcon(name, style) :  MSelect(colorT, \color -> eitherFn(color, \iconColor -> MIcon(name, replaceStruct(style, iconColor)), \ -> ti.icon));
+									default : ti.icon;
+								}, 
+								p2
+							) 
+							|> (if (oneLineTitle) TBorderLeftRight(2.) else\t2 -> TCenterX(t2) |> TBorderTopBottom(2.))
 							|> (\t2 -> TAttachWidth(t2, iconW))
 							|> (\t2 -> if (oneLineTitle) {
 								isRightAlign = eitherMap(iconAlign, \align -> commonAlignment2abs(align.align, p.rtl) == RightAlign(), false);
@@ -178,9 +180,9 @@ MDynamicTabs2T(manager : MaterialManager, parent : MFocusGroup, m : MDynamicTabs
 								|> (\t3 -> if (titleAlignIcon) TCenterX(t3) else t3)
 							} else {
 								TLines2(t2, t)
-							})
-						}, t)
-					)
+							})},
+						t
+					))
 					|> TBorderLeftRight(bordersGap / 2.)
 					|> (if (oneLineTitle) TCenterY else TCenter)
 					|> (\t ->

--- a/lib/material/internal/material_tabs.flow
+++ b/lib/material/internal/material_tabs.flow
@@ -162,17 +162,17 @@ MDynamicTabs2T(manager : MaterialManager, parent : MFocusGroup, m : MDynamicTabs
 					)
 					|> (
 						if (oneLineTitle && isSome(tabIcon)) idfn
-						else TSetMinWidth2(if (widthByContent) fullWidth else const(tabMinWidth) )
+						else TSetMinWidth2(if (widthByContent) fullWidth else const(tabMinWidth))
 					)
-					|> (\t -> eitherMap(tabIcon, \ti ->  {
-							m2t(
-								 switch (ti.icon) {
-									MIcon(name, style) :  MSelect(colorT, \color -> eitherFn(color, \iconColor -> MIcon(name, replaceStruct(style, iconColor)), \ -> ti.icon));
-									default : ti.icon;
-								}, 
-								p2
-							) 
-							|> (if (oneLineTitle) TBorderLeftRight(2.) else\t2 -> TCenterX(t2) |> TBorderTopBottom(2.))
+					|> (\t -> eitherMap(tabIcon, \ti ->
+							switch (ti.icon) {
+								MIcon(name, style) : MSelect(colorT, \color ->
+									eitherMap(color, \iconColor -> MIcon(name, replaceStruct(style, iconColor)), ti.icon)
+								);
+								default : ti.icon;
+							}
+							|> (\ic -> m2t(ic, p2))
+							|> (\t2 -> if (oneLineTitle) TBorderLeftRight(2.)(t2) else TCenterX(t2) |> TBorderTopBottom(2.))
 							|> (\t2 -> TAttachWidth(t2, iconW))
 							|> (\t2 -> if (oneLineTitle) {
 								isRightAlign = eitherMap(iconAlign, \align -> commonAlignment2abs(align.align, p.rtl) == RightAlign(), false);
@@ -180,7 +180,7 @@ MDynamicTabs2T(manager : MaterialManager, parent : MFocusGroup, m : MDynamicTabs
 								|> (\t3 -> if (titleAlignIcon) TCenterX(t3) else t3)
 							} else {
 								TLines2(t2, t)
-							})},
+							}),
 						t
 					))
 					|> TBorderLeftRight(bordersGap / 2.)

--- a/lib/material/internal/material_tabs.flow
+++ b/lib/material/internal/material_tabs.flow
@@ -145,7 +145,6 @@ MDynamicTabs2T(manager : MaterialManager, parent : MFocusGroup, m : MDynamicTabs
 					maxLines = extractStruct(tb.style, MMaxLines(2)).lines;
 					widthByContent = contains(tb.style, MWidthByContent());
 					centerTitle = !(titleAlignIcon && isSome(tabIcon));
-
 					availableW = make(0.);
 					fullWidth = make(0.);
 					iconW = make(0.);
@@ -153,19 +152,20 @@ MDynamicTabs2T(manager : MaterialManager, parent : MFocusGroup, m : MDynamicTabs
 					dynArrayPush(iconsVisible, isIconVisible);
 
 					TSelect2(tb.text, fand(const(!isKeepTabColor), feq(m.selected, i)), \txt, selected ->
-						if (txt != "") {
-							color = if (selected) Some(indicatorColor) else itemsColor;
+						TShow(const(txt != ""), {
+							if (isSome(iconAlign)) TFillX() 
+							else {color = if (selected) Some(indicatorColor) else itemsColor;
 							MTabsText(manager, p2, txt, capitalizeTitle, centerTitle, rescaleEnabled, showTooltip, maxLines, tabsFontStyle, color, fullWidth, widthByContent, m2t)
-							|> TBorderTopBottom(2.)
-						} else if (isSome(iconAlign)) TFillX()
-						else TEmpty()
-					)
-					|> (
-						if (oneLineTitle && isSome(tabIcon)) idfn
-						else TSetMinWidth2(if (widthByContent) fullWidth else const(tabMinWidth))
-					)
-					|> (\t -> eitherMap(tabIcon, \ti ->
-							m2t(ti.icon, p2)
+							|> TBorderTopBottom(2.)}
+						})
+						|> ( if (oneLineTitle && isSome(tabIcon)) idfn else TSetMinWidth2(if (widthByContent) fullWidth else const(tabMinWidth)))
+						|> \t -> eitherMap(tabIcon, \ti -> {
+							iconName = switch (ti.icon) {
+									MIcon(name, style) : name;
+									default : "grade";
+							}
+							iconStyle = if (selected) MIcon(iconName, [indicatorColor]) else ti.icon;
+							m2t(iconStyle, p2)
 							|> (if (oneLineTitle)
 									TBorderLeftRight(2.)
 								else
@@ -178,9 +178,9 @@ MDynamicTabs2T(manager : MaterialManager, parent : MFocusGroup, m : MDynamicTabs
 								|> (\t3 -> if (titleAlignIcon) TCenterX(t3) else t3)
 							} else {
 								TLines2(t2, t)
-							}),
-						t
-					))
+							})
+						}, t)
+					)
 					|> TBorderLeftRight(bordersGap / 2.)
 					|> (if (oneLineTitle) TCenterY else TCenter)
 					|> (\t ->


### PR DESCRIPTION
fill the icon by the same color as its heading when the "Color Selected Tab Text" is used, so the icon and text are in harmony