### PR TITLE
Gringo : optional parameters

### DIFF
--- a/tools/gringo/type/output_types.flow
+++ b/tools/gringo/type/output_types.flow
@@ -280,7 +280,8 @@ processRuleGType(acc : GTypeAcc, rule : string, t : GType) -> GTypeAcc {
 			tname = mktypename(rule);
 			sname = tname.typename;
 			stypes = fold2(types, acc, [], \acc2, atypes, tt -> {
-				acc3 = processRuleGType(acc2, rule, tt);
+				// allow optional parameters (GTypeNil)
+				acc3 = if (tt == GTypeNil()) GTypeAcc(acc with type = mktypename(rule)) else processRuleGType(acc2, rule, tt);
 				ut : GfType = acc3.type;
 				if (ut == tname) Pair(acc3, atypes)
 				else {


### PR DESCRIPTION
grammar example :

```
templates = ("[" ws templateName "]" ws) | $"nil";
templateName = $"nil" $templateid $"cons"("," ws $templateid $"cons")*;
function = optexport id templates ws "(" lambdaargs ")" ws "->" ws type exp decl $"function_7";
```
-> function = _name\[T\](...)->..._ or _name(...)->..._

Empty list is only allowed in GTypeUnion, not as a type or whatever

@alstrup  is PR the right fix?
