### PR TITLE
make java 'double' serialization uniform with cpp backend

### DIFF
--- a/platforms/java/com/area9innovation/flow/FlowRuntime.java
+++ b/platforms/java/com/area9innovation/flow/FlowRuntime.java
@@ -3,6 +3,9 @@ package com.area9innovation.flow;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.Locale;
 
+import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
+
 public abstract class FlowRuntime {
 	public static Struct[] struct_prototypes;
 	public static ConcurrentHashMap<String, Integer> struct_ids = new ConcurrentHashMap<String, Integer>();
@@ -200,8 +203,12 @@ public abstract class FlowRuntime {
 	}
 
 	public static String doubleToString(double value) {
-		String rstr = Double.toString(value);
-		return rstr.endsWith(".0") ? rstr.substring(0, rstr.length()-2) : rstr;
+		DecimalFormat df = new DecimalFormat("0");
+		df.setDecimalFormatSymbols(new DecimalFormatSymbols(Locale.US));
+		df.setMaximumFractionDigits(340); // DecimalFormat.DOUBLE_FRACTION_DIGITS
+
+		String rstr = df.format(value);
+		return rstr;
 	}
 
 	public static final Struct makeStructValue(String name, Object[] fields, Struct default_value) {

--- a/platforms/java/com/area9innovation/flow/FlowRuntime.java
+++ b/platforms/java/com/area9innovation/flow/FlowRuntime.java
@@ -11,7 +11,17 @@ public abstract class FlowRuntime {
 	public static ConcurrentHashMap<String, Integer> struct_ids = new ConcurrentHashMap<String, Integer>();
 	public static String[] program_args;
 	private static ConcurrentHashMap<Class, NativeHost> hosts = new ConcurrentHashMap<Class, NativeHost>();
-	private static DecimalFormat decimalFormat = getDecimalFormat();
+
+	private static final ThreadLocal<DecimalFormat> decimalFormat = new ThreadLocal<DecimalFormat>(){
+        @Override
+        protected DecimalFormat initialValue()
+        {
+			DecimalFormat df = new DecimalFormat("0.0");
+			df.setDecimalFormatSymbols(new DecimalFormatSymbols(Locale.US));
+			df.setMaximumFractionDigits(340); // DecimalFormat.DOUBLE_FRACTION_DIGITS
+			return df;
+        }
+    };
 
 	@SuppressWarnings("unchecked")
 	protected static final <T extends NativeHost> T getNativeHost(Class<T> cls) {
@@ -137,14 +147,6 @@ public abstract class FlowRuntime {
 		return Integer.valueOf(o1.hashCode()).compareTo(o2.hashCode());
 	}
 
-	private static DecimalFormat getDecimalFormat() {
-		DecimalFormat df = new DecimalFormat("0.0");
-		df.setDecimalFormatSymbols(new DecimalFormatSymbols(Locale.US));
-		df.setMaximumFractionDigits(340); // DecimalFormat.DOUBLE_FRACTION_DIGITS
-
-		return df;
-	}
-
 	public static String toString(Object value) {
 		if (value == null) {
 			return "{}";
@@ -212,7 +214,7 @@ public abstract class FlowRuntime {
 	}
 
 	private static String doubleToStringInternal(double value) {
-		return decimalFormat.format(value);
+		return decimalFormat.get().format(value);
 	}
 
 	public static String doubleToString(double value) {

--- a/platforms/java/com/area9innovation/flow/Struct.java
+++ b/platforms/java/com/area9innovation/flow/Struct.java
@@ -29,10 +29,7 @@ public abstract class Struct implements Comparable<Struct>, Cloneable {
 			if (i > 0)
 				buf.append(", ");
 
-			if (types[i] == RuntimeType.DOUBLE && values[i] instanceof Number)
-				buf.append(((Number)values[i]).doubleValue());
-			else
-				FlowRuntime.toStringAppend(values[i], buf);
+			FlowRuntime.toStringAppend(values[i], buf);
 		}
 
 		buf.append(')');


### PR DESCRIPTION
https://trello.com/c/F2qM0Gz0/19450-for-json-serialization-should-not-use-e-notation-for-integers

cpp: 
source string: "[{\"id\": 100405271}]"                                                                                                                                                                                                                                         parsed json: JsonArray([JsonObject([Pair("id", JsonDouble(100405271.0))])])     
java before fix:
source string: "[{\"id\": 100405271}]"                                                                                                                                                                                                                                         parsed json: JsonArray([JsonObject([Pair("id", JsonDouble(1.00405271E8))])])
java after fix:
source string: "[{\"id\": 100405271}]"                                                                                                                                                                                                                                         parsed json: JsonArray([JsonObject([Pair("id", JsonDouble(100405271.0))])])     
