### PR TITLE
Fixed `println` in js target

### DIFF
--- a/platforms/common/haxe/HaxeRuntime.hx
+++ b/platforms/common/haxe/HaxeRuntime.hx
@@ -265,7 +265,7 @@ if (a === b) return true;
 			var r = "[";
 			var s = "";
 			for (v in a) {
-				var vc = toStringCommon(v, keepStringEscapes, additionalEscapingFn);
+				var vc = toStringCommon(v, false, additionalEscapingFn);
 				r += s + vc;
 				s = ", ";
 			}
@@ -273,7 +273,7 @@ if (a === b) return true;
 		}
 		if (Reflect.hasField(value, "__v")) {
 			// Reference
-			return "ref " + toStringCommon(value.__v, keepStringEscapes, additionalEscapingFn);
+			return "ref " + toStringCommon(value.__v, false, additionalEscapingFn);
 		}
 		#if (js && readable)
 		if (Reflect.hasField(value, "_name")) {
@@ -304,7 +304,7 @@ if (a === b) return true;
 						r += s + v + ( (Std.int(v) == v) ? ".0" : "" );
 					}
 					case RTArray(arrtype): {
-						if (!isArray(v) || arrtype != RTDouble) r += s + toStringCommon(v, keepStringEscapes, additionalEscapingFn);
+						if (!isArray(v) || arrtype != RTDouble) r += s + toStringCommon(v, false, additionalEscapingFn);
 						else {
 							r += s + "[";
 							for (j in 0...v.length)
@@ -313,7 +313,7 @@ if (a === b) return true;
 						}
 					}
 					default:
-						r += s + toStringCommon(v, keepStringEscapes, additionalEscapingFn);
+						r += s + toStringCommon(v, false, additionalEscapingFn);
 				}
 				s = ", ";
 			}
@@ -365,7 +365,7 @@ if (a === b) return true;
 				s = StringTools.replace(s, "\n", "\\n");
 				s = StringTools.replace(s, "\t", "\\t");
 			#end
-			
+
 			return "\"" + s + "\"";
 		});
 	}

--- a/tools/flowc/backends/javascript/fi2javascript_compile.flow
+++ b/tools/flowc/backends/javascript/fi2javascript_compile.flow
@@ -999,7 +999,7 @@ fiJsSubstituteJSNative(cfg : FiJsConfig, ctx : FiJsToplevelContext, expr : FiExp
 		("~" + args[0])
 
 	else if (cfg.debug && op == "println")
-		"console.log(HaxeRuntime.toString(" + args[0] + "))"
+		"console.log(HaxeRuntime.toString(" + args[0] + ", true))"
 
 	else closure;
 }

--- a/tools/flowc/flowc_version.flow
+++ b/tools/flowc/flowc_version.flow
@@ -2,5 +2,5 @@
 // Edit 'build-flowc' instead.
 export {
 	flowc_version = "3.0";
-	flowc_git_revision = "0e7a9f184";
+	flowc_git_revision = "699d741c0";
 }


### PR DESCRIPTION
`println` in js target works differently depending on "debug=1" flag, both are weird.

The test case.
```flow
import runtime;

main() {
	println("string");
	println(Some("string"));
	println("Output: " + toString(Some("string")));
	println(["a", "\n", "c"]);
	println(ref "1\n2");

	quit(0);
}
```

Output without "debug=1"
![image](https://user-images.githubusercontent.com/24790385/208893032-9891cdaa-2683-4d33-bbdf-16fcc7bbada6.png)

Output with "debug=1"
![image](https://user-images.githubusercontent.com/24790385/208893132-f26fdf18-ff70-4b10-9601-0667d33747c2.png)

After the fix the output does not depend on the flag and is the same as in cpp target:
![image](https://user-images.githubusercontent.com/24790385/208893744-26daa21e-af8e-477b-88c1-e6f816d977b4.png)
