### PR TITLE
Fix svg scaling with Chrome

### DIFF
--- a/platforms/js/FlowSprite.hx
+++ b/platforms/js/FlowSprite.hx
@@ -262,8 +262,30 @@ class FlowSprite extends Sprite {
 							}
 						});
 
-						var width = Math.isFinite(widgetBounds.maxX) ? widgetBounds.maxX : 0;
-						var height = Math.isFinite(widgetBounds.maxY) ? widgetBounds.maxY : 0;
+						// With Chrome svg data:img images are not scaled correctly for devicePixelRatio > 1.
+						// For instance, with Retina display, which has a factor from 2 to 3.
+						var width = Math.isFinite(widgetBounds.maxX) ? {
+							if (
+								forceSvg
+								&& Browser.window.devicePixelRatio > 1
+								&& Platform.isChrome
+							) {
+								widgetBounds.maxX / Browser.window.devicePixelRatio;
+							 } else {
+								widgetBounds.maxX;
+							}
+						} : 0;
+						var height = Math.isFinite(widgetBounds.maxY) ? {
+							if (
+								forceSvg
+								&& Browser.window.devicePixelRatio > 1
+								&& Platform.isChrome
+							) {
+								widgetBounds.maxY / Browser.window.devicePixelRatio;
+							 } else {
+								widgetBounds.maxY;
+							}
+						} : 0;
 
 						metricsFn(width, height);
 					} else {


### PR DESCRIPTION
- https://trello.com/c/Bp8dMc7w/2485-pngs-in-svg-containers-arent-scaled-properly-on-retina-displays

Before
![Screenshot_20230112_113508](https://user-images.githubusercontent.com/6875018/212093512-0212ab0a-b437-4b33-a342-57344cd9e1fc.png)
After
![Screenshot_20230112_152644](https://user-images.githubusercontent.com/6875018/212093590-60beaa4b-05c9-480d-bb4e-a79613d00746.png)

