### PR TITLE
Initial support for VS Code Dev containers

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,33 @@
+
+# See: 
+# https://github.com/devcontainers/images/tree/main/src/base-ubuntu
+# https://containers.dev/guide/dockerfile
+
+FROM mcr.microsoft.com/devcontainers/base:ubuntu-22.04
+
+# Install add-apt-repository and git-lfs
+RUN apt-get update && apt-get install -y \
+	software-properties-common \
+	git-lfs
+
+# Add java
+RUN apt-get install -y \
+	default-jdk \
+	maven
+
+# Configure some haxe paths in the share folder.
+ENV HAXEPATH=/usr/share/haxe
+ENV HAXE_STD_PATH=$HAXEPATH/std
+ENV HAXELIB_PATH=$HAXEPATH/lib
+
+# Add haxe repository (need the 'software-properties-common' package), and install haxe
+RUN add-apt-repository ppa:haxe/releases -y \
+	&& apt-get update \
+	&& apt-get install -y haxe
+	
+# Installing haxelib in a share folder (The current user need to run 'haxelib setup $HAXELIB_PATH' as well)
+RUN haxelib setup $HAXELIB_PATH \
+	&& haxelib install format 3.4.2 \
+	&& haxelib install pixijs 4.8.4 \
+	&& haxelib install threejs
+

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,54 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/ubuntu
+{
+	"name": "Flow9",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+
+	"build": {
+		// Path is relative to the devcontainer.json file.
+		"dockerfile": "Dockerfile"
+	},
+
+	"features": {
+		//"ghcr.io/devcontainers/features/java:1": {},
+		//"ghcr.io/devcontainers/features/python:1": {},
+		//"ghcr.io/devcontainers-contrib/features/haxe-asdf:2": {},
+		//"ghcr.io/devcontainers-contrib/features/maven-sdkman:2": {}
+	},
+
+	"remoteEnv": {
+		"FLOW": "/workspaces/flow9",
+		"PATH": "/workspaces/flow9/bin:${containerEnv:PATH}"
+	},
+
+	// Configure vscode tool-specific properties.
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				// Add the flow9 extension pr default
+				"/workspaces/flow9/resources/vscode/flow.vsix"
+			]
+		}
+	}
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Configure tool-specific properties.
+	// "customizations": {},
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+
+	// onCreateCommand is the first of three (along with updateContentCommand and postCreateCommand) that finalizes 
+	// container setup when a dev container is created. It and subsequent commands execute inside the container 
+	// immediately after it has started for the first time.
+	// "onCreateCommand": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": []
+}
+

--- a/doc/devcontainer.markdown
+++ b/doc/devcontainer.markdown
@@ -1,0 +1,90 @@
+# Flow9 with VS Code DevContainer
+
+The flow9 repository have a Development Container configuration. This makes it possible to get started using flow9 without installing dependencies. For more info about Development Containers see: https://containers.dev/. The Flow9 Development Container configurations works well with Visual Studio Code. 
+
+## VS Code and Docker
+
+You will need VS Code installed (https://code.visualstudio.com/download). And add the the "Dev Containers" extension: 
+
+	https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers
+
+You will also need to have Docker. Test this with: 
+
+	docker run hello-world
+
+If it is working it should display "Hello from Docker!" and a lot more.
+
+### Linux or WSL (Windows Subsystem for Linux)
+
+Clone the flow9 git repository to a sub folder. For example "prg"
+
+	cd ~
+	mkdir prg
+	cd prg
+	git clone https://github.com/area9innovation/flow9.git
+
+Start VS Code: 
+
+	cd ~/prg/flow9
+	code .
+
+When VS Code starts, it will ask if you if you want to open the DevContainer. Select yes to this. The first time it will need to build the Docker image, this will take between 1 and 10 minutes.
+
+When the DevContainer is active, the lower right corner of VS Code will display a green text "Dev Container: Flow9". 
+
+In the DevContainer you now have an environment with your git checkout and the required java, haxe and haxelib installed. 
+
+If you open a terminal in VS Code you should have a prompt that looks something like this: 
+
+	vscode ➜ /workspaces/flow9 (master) $ 
+
+The workspace/flow9 folder is the same as your ~/prg/flow9 folder. 
+
+### Windows
+
+For Windows it is recommended to use the Ubuntu WSL on Windows. This is because the Linux filesystem is much faster. But it also works with the Windows file system. Create a sub folder: 
+
+	c:\
+	mkdir prg
+	cd prg
+	git clone https://github.com/area9innovation/flow9.git
+
+Start VS Code: 
+
+	c:\
+	cd /prg/flow9
+	code .
+
+### MAC
+
+TODO
+
+## Verify that the Dev Container is working
+
+In VS Code with the DevContainer open, do the following in a Terminal: 
+
+	cd /workspaces/flow9
+	flowc1 jar=sandbox/hello.jar sandbox/hello.flow
+	java -jar sandbox/hello.jar
+
+If it is working, it should print: Hello console.
+
+Try the http target with:
+
+	cd /workspaces/flow9
+	flowc1 html=sandbox/graph.html sandbox/graph.flow
+
+In the host open the created graph.html file in a browser. In WSL it might be something like: 
+
+	file://wsl.localhost/Ubuntu/home/ub/prg/flow9/sandbox/graph.html
+
+Verify the flow9 Plugin. TODO
+
+## Trouble shooting VS Code image builds. 
+
+If VS Code fails to create the dev-container it might be needed to remove the bad images and container. Do that by listing all the containers and remove the flow9 container:  
+
+	docker container ls --all
+	docker container rm xyz
+
+Where xyz is the id vsc-flow9-* container


### PR DESCRIPTION
Added support for dev containers in VS Code. See the devcontainer.markdown file for details.

The dev container still does not work with flowcpp. 

It should be possible to add support for flowcpp, but the asmjit git checkout inside the flow9 git checkout might be something people will need to do manually.