### PR TITLE
toStringForJson native

### DIFF
--- a/lib/runtime.flow
+++ b/lib/runtime.flow
@@ -289,19 +289,8 @@ export {
 	native preloadStaticResource : io (href : string, as : string) -> void = Native.preloadStaticResource;
 	preloadStaticResource(href : string, as : string) -> void {}
 
-	// escape chars not allowed for JSON
-	toStringForJson(v : ?) -> string;	
 }
 
-toStringForJson(v : ?) -> string {
-	toStringEscapeControlChars(flow(v));
-}
-
-native toStringEscapeControlChars : (flow) -> string = Native.toStringEscapeControlChars;
-
-toStringEscapeControlChars(v : flow) -> string {
-	toString(v);
-}
 
 // Only works in the C++ runner when debugging or profiling
 native callstack2string : io (native) -> string = Native.callstack2string;

--- a/lib/string.flow
+++ b/lib/string.flow
@@ -1383,7 +1383,7 @@ toStringForJson(v : string) -> string
 			fromCharCode(0x30 + hexDigit);
 		} else {
 			// 0x61 is 'a'
-			fromCharCode(97 + hexDigit - 10);
+			fromCharCode(0x61 + hexDigit - 10);
 		}
 	};
 

--- a/lib/string.flow
+++ b/lib/string.flow
@@ -356,6 +356,9 @@ export {
 
 	// checks if the word is an english auxiliary word
 	isAuxiliaryWord(word : string) -> bool;
+
+	// Make escaped string according to Json escaping
+	toStringForJson: (string) -> string;
 }
 
 _s(s) { s }
@@ -1365,4 +1368,46 @@ native cloneString : (s : string) -> string = Native.cloneString;
 
 cloneString(s : string) -> string {
 	s
+}
+
+// Haxe and Java have a native. 
+native toStringForJson : (string) -> string = Native.toStringForJson;
+
+// JSON all charaters below 0x20 must be escaped. The Flow toString method does not do this
+toStringForJson(v : string) -> string
+{
+	// Use lower case formatting, to be more consistent with most native Json formatters
+	formatHexDigit = \hexDigit: int -> {
+		if (hexDigit < 10) {
+			// 0x30 is '0'
+			fromCharCode(0x30 + hexDigit);
+		} else {
+			// 0x61 is 'a'
+			fromCharCode(97 + hexDigit - 10);
+		}
+	};
+
+	f = stringFold(v, makeList1("\""), \acc: List<string>, code: int -> {
+		Cons(
+			if (code < 0x20) {
+				if (code == 0x08) "\\b"
+				else if (code == 0x09) "\\t"
+				else if (code == 0x0A) "\\n"
+				else if (code == 0x0C) "\\f"
+				// Do not use \r to be consistent with Haxe implementation
+				// else if (code == 0x0D) "\\r"  
+				else if (code <= 0x10) {
+					"\\u000" + formatHexDigit(code);
+				} else {
+					"\\u001" + formatHexDigit(code - 0x10);
+				}
+			} else {
+				if (code == 0x22) "\\\""
+				else if (code == 0x5c) "\\\\"
+				else fromCharCode(code);
+			}, 
+			acc
+		);
+	});
+	list2string(Cons("\"", f));
 }

--- a/platforms/common/haxe/HaxeRuntime.hx
+++ b/platforms/common/haxe/HaxeRuntime.hx
@@ -370,8 +370,8 @@ if (a === b) return true;
 		});
 	}
 
-	public static function toStringEscapeControlChars(value : Dynamic, ?keepStringEscapes : Bool = false) : String {
-		return toStringCommon(value, keepStringEscapes, function(val, s){
+	public static function toStringForJson(value : String) : String {
+		return toStringCommon(value, false, function(val, s){
 			#if js
 				untyped __js__("
 					return '\"' + val.replace(HaxeRuntime.regexCharsToReplaceForJson, function (c) {

--- a/platforms/java/com/area9innovation/flow/Native.java
+++ b/platforms/java/com/area9innovation/flow/Native.java
@@ -2589,5 +2589,55 @@ public class Native extends NativeHost {
 			return "undef";
 		}
 	}
+
+	public static final String toStringForJson(String value) {
+		String sv = value;
+		// Make room for some escape
+		StringBuilder buf = new StringBuilder(sv.length() + 20);
+		buf.append('"');
+		for (int i = 0; i < sv.length(); i++) {
+			char c = sv.charAt(i);
+			switch (c) {
+				// In JSON all control charters must be escaped. 
+				case 0x00: buf.append("\\u0000"); break;	// Do not allow 0 in strings
+				case 0x01: buf.append("\\u0001"); break;
+				case 0x02: buf.append("\\u0002"); break;
+				case 0x03: buf.append("\\u0003"); break;
+				case 0x04: buf.append("\\u0004"); break;
+				case 0x05: buf.append("\\u0005"); break;
+				case 0x06: buf.append("\\u0006"); break;
+				case 0x07: buf.append("\\u0007"); break;	// Terminal bell, \a
+				case 0x08: buf.append("\\u0008"); break;	// Backspace \b
+				case '\t': buf.append("\\t"); break;
+				case '\n': buf.append("\\n"); break;
+				case 0x0b: buf.append("\\u000b"); break;	// Vertical Tab \v
+				case 0x0c: buf.append("\\u000c"); break;	// Formfeed \f
+				case '\r': buf.append("\\u000d"); break;	// Keep the flow tradition of not using \r
+				case 0x0e: buf.append("\\u000e"); break;
+				case 0x0f: buf.append("\\u000f"); break;
+				case 0x10: buf.append("\\u0010"); break;
+				case 0x11: buf.append("\\u0011"); break;
+				case 0x12: buf.append("\\u0012"); break;
+				case 0x13: buf.append("\\u0013"); break;
+				case 0x14: buf.append("\\u0014"); break;
+				case 0x15: buf.append("\\u0015"); break;
+				case 0x16: buf.append("\\u0016"); break;
+				case 0x17: buf.append("\\u0017"); break;
+				case 0x18: buf.append("\\u0018"); break;
+				case 0x19: buf.append("\\u0019"); break;
+				case 0x1a: buf.append("\\u001a"); break;
+				case 0x1b: buf.append("\\u001b"); break;
+				case 0x1c: buf.append("\\u001c"); break;
+				case 0x1d: buf.append("\\u001d"); break;
+				case 0x1e: buf.append("\\u001e"); break;
+				case 0x1f: buf.append("\\u001f"); break;
+				case '\\': buf.append("\\\\"); break;
+				case '"': buf.append("\\\""); break;
+				default: buf.append(c); break;
+			}
+		}
+		buf.append('"');
+		return buf.toString();
+	}
 }
 

--- a/platforms/js/Native.hx
+++ b/platforms/js/Native.hx
@@ -361,8 +361,8 @@ class Native {
 		return HaxeRuntime.toString(value, keepStringEscapes);
 	}
 
-	public static function toStringEscapeControlChars(value : Dynamic, ?keepStringEscapes : Bool = false) : String {
-		return HaxeRuntime.toStringEscapeControlChars(value, keepStringEscapes);
+	public static function toStringForJson(value : String) : String {
+		return HaxeRuntime.toStringForJson(value);
 	}
 
 	public static inline function gc() : Void {


### PR DESCRIPTION
See: https://trello.com/c/3INoUjvF/20971-mks-java-creates-invalid-json

The JSON string formatting was broken for all none JS targets. That includes Java and flowCpp. 

I have added a new Native for Java, that should escape correctly. 

All other targets now uses the default Flow implementation. 