### PR TITLE
flowc: flatten unions is fixed

### DIFF
--- a/lib/ui/fontmapping.flow
+++ b/lib/ui/fontmapping.flow
@@ -330,7 +330,7 @@ getDefaultFontFamilyOverride() -> string {
 	else either(^fontFamilyOverride_,  defaultFontFamily_);
 }
 
-fontOverrides = ref eitherGetUrlValidParameterM("fontOverrides", \s -> {
+fontOverrides : ref [Triple<string, string, double>] = ref eitherGetUrlValidParameterM("fontOverrides", \s -> {
 	fold(strSplit(s, ","), Some([]), \acc, raw -> {
 		eitherMap(acc, \a -> {
 			parts1 = strSplit(raw, "*");

--- a/tools/flowc/backends/inca/lift_types.flow
+++ b/tools/flowc/backends/inca/lift_types.flow
@@ -68,7 +68,7 @@ liftIncaTypes(env : IncaEnv) -> string {
 	", [
 		"imports", fold(parsed, "", \acc, name -> acc + "import " + takeAfter(name, "tools/inca/", name)  + ";\n"),
 		"promotedStructs", foldTree(env.promotedStructs, "", \name, struct, acc -> {
-			acc + prettyFiStructOrUnion(FcPretty(true, true, makeTree(), makeTree()), struct, makeSet()) + ";\n"
+			acc + prettyFiStructOrUnion(FcPretty(true, true, makeTree(), makeTree()), struct) + ";\n"
 		}),
 		"structs", foldi(structs, "", \i, acc, name -> {
 			acc + name + "_ID = " + i2s(i) + ";\n"

--- a/tools/flowc/completion.flow
+++ b/tools/flowc/completion.flow
@@ -268,9 +268,9 @@ codeCompleteName(config : CompilerConfig, globEnv : FcTypeEnvGlobal, prefix : st
 			named = cached.named;
 			switch (named) {
 				FiTypeStruct(nm,__,__,__): 
-					CodeCompletion(nm, CompletionConstructor(), prettyFiStructOrUnion(conf, named, makeSet()), "struct", cached.module);
+					CodeCompletion(nm, CompletionConstructor(), prettyFiStructOrUnion(conf, named), "struct", cached.module);
 				FiTypeUnion(nm,__,__,__): 
-					CodeCompletion(nm, CompletionConstructor(), prettyFiStructOrUnion(conf, named, makeSet()), "union", cached.module);
+					CodeCompletion(nm, CompletionConstructor(), prettyFiStructOrUnion(conf, named), "union", cached.module);
 				FiFunctionDec(nm,__,type,__,__): 
 					CodeCompletion(nm, CompletionFunction(), prettyFiType(conf, type, makeSet()), "function", cached.module);
 				FiGlobalVar(nm,__,type,__,__):

--- a/tools/flowc/flowc_find.flow
+++ b/tools/flowc/flowc_find.flow
@@ -227,7 +227,7 @@ dumpFcProgramIds(env : FcTypeEnvGlobal, prog : FiProgram, file : string) -> void
 	ids = foldTree(prog.modules, [], \modname, module : FiModule, acc -> {
 		pc = FcPretty(true, true, makeTree(), makeTree());
 		pt = \t -> prettyFiType(pc, t, makeSet());
-		psu = \t -> prettyFiStructOrUnion(pc, t, makeSet());
+		psu = \t -> prettyFiStructOrUnion(pc, t);
 		allIds = isConfigParameterTrue(prog.config.config, "dump-ids-all");
 
 		pathParts = ["file " + module.fileinfo.flowfile]; //], strSplit(module.flowfile, "/")));
@@ -723,8 +723,8 @@ fcCacheNamed2s(cached : FcCacheNamed) -> string {
 fcCacheNamed2strSimple(cached : FcCacheNamed) -> string {
 	symbol = cached.named;
 	switch (symbol) {
-		FiStructOrUnion(): prettyFiStructOrUnion(FcPretty(true, true, makeTree(), makeTree()), symbol, makeSet());
-		FiDeclaration(): prettyFiDeclaration(dummyPretty, symbol, makeSet());
+		FiStructOrUnion(): prettyFiStructOrUnion(FcPretty(true, true, makeTree(), makeTree()), symbol);
+		FiDeclaration(): prettyFiDeclarationType(dummyPretty, symbol);
 	};
 }
 

--- a/tools/flowc/incremental/fiprettyprint.flow
+++ b/tools/flowc/incremental/fiprettyprint.flow
@@ -5,8 +5,9 @@ export {
 	// Prettyprinting for FiExp
 	prettyFiExp(conf : FcPretty, e : FiExp) -> string;
 	prettyFiType(conf : FcPretty, type : FiType, seen : Set<int>) -> string;
-	prettyFiStructOrUnion(conf : FcPretty, type : FiStructOrUnion, seen : Set<int>) -> string;
-	prettyFiDeclaration(conf : FcPretty, decl : FiDeclaration, seen : Set<int>) -> string;
+	prettyFiStructOrUnion(conf : FcPretty, type : FiStructOrUnion) -> string;
+	prettyFiDeclarationType(conf : FcPretty, decl : FiDeclaration) -> string;
+	prettyFiDeclaration(conf : FcPretty, decl : FiDeclaration) -> string;
 }
 
 prettyFiExp(conf : FcPretty, e : FiExp) -> string {
@@ -17,17 +18,38 @@ prettyFiType(conf : FcPretty, type : FiType, seen : Set<int>) -> string {
 	prettyFcType(conf, fitype2fc(type), seen)
 }
 
-prettyFiStructOrUnion(conf : FcPretty, type : FiStructOrUnion, seen : Set<int>) -> string {
+prettyFiStructOrUnion(conf : FcPretty, type : FiStructOrUnion) -> string {
 	switch (type) {
-		FiTypeStruct(__, __, __, __) : prettyFcType(conf, fitypestruct2fc(type), seen);
-		FiTypeUnion(__, __, __, __) : prettyFcType(conf, fitypeunion2fc(type), seen);
+		FiTypeStruct(__, __, __, __) : prettyFcType(conf, fitypestruct2fc(type), makeSet());
+		FiTypeUnion(__, __, __, __) : prettyFcType(conf, fitypeunion2fc(type), makeSet());
 	}
 }
 
-prettyFiDeclaration(conf : FcPretty, decl : FiDeclaration, seen : Set<int>) -> string {
+prettyFiDeclarationType(conf : FcPretty, decl : FiDeclaration) -> string {
 	switch (decl) {
-		FiFunctionDec(name, __, type,__,__): name + prettyFiType(conf, type, makeSet());
+		FiFunctionDec(name, lambda, type,__,__): name + prettyFiType(conf, type, makeSet());
 		FiGlobalVar(name, __, type, __,__): name + " : " + prettyFiType(conf, type, makeSet());
 		FiNativeDec(name, io, type, __,__,__,__): "native " + name + " :" + (if (io) "io " else " ") + prettyFiType(conf, type, makeSet());
+	}
+}
+
+prettyFiDeclaration(conf : FcPretty, decl : FiDeclaration) -> string {
+	switch (decl) {
+		FiFunctionDec(name, lambda, type,__,__): {
+			name + prettyFiType(conf, type, makeSet()) + " =\n" + 
+			prettyFiExp(conf, lambda);
+		}
+		FiGlobalVar(name, value, type, __,__): {
+			name + " : " + prettyFiType(conf, type, makeSet()) + " =\n" + 
+			prettyFiExp(conf, value);
+		}
+		FiNativeDec(name, io, type, nativeName, fallback,__,__): {
+			fallback_str = switch (fallback) {
+				FiLambda(__,__,__,__): prettyFiExp(conf, fallback);
+				default: "";
+			}
+			"native " + name + " :" + (if (io) "io " else " ") + prettyFiType(conf, type, makeSet()) + " =" + 
+			(if (strlen(fallback_str) == 0) " " + nativeName else "\n" + fallback_str);
+		}
 	}
 }

--- a/tools/flowc/manipulation/deadtypes.flow
+++ b/tools/flowc/manipulation/deadtypes.flow
@@ -1,5 +1,6 @@
 import tools/flowc/incremental/fi_helpers;
 import tools/flowc/manipulation/common;
+import string_utils;
 
 export {
 	// Remove unused structs/unions
@@ -8,21 +9,18 @@ export {
 
 deadFiTypes(prog: FiProgram, preserveNames: Set<string>, eliminateNames: Set<string>, verbose: int) -> FiProgram {
 	// Grab all type names, used in expression
-	used_in_exp = \e, acc -> fiFoldExp(e, acc, \x,__,ac ->
-		usedFiTypesAddType(fiExpType(x), ac),
-		AstTraverseOrder(true, true)
-	);
+	used_in_exp = \e, acc -> fiFoldExp(e, acc, \x,__,ac -> usedFiTypesAddTypeFlat(fiExpType(x), ac), AstTraverseOrder(true, true));
 	// Collect all type names, used in toplevel funcs/vars of a program
 	used_in_code = foldTree(prog.names.toplevel, makeSet(), \__,decl, acc ->
 		switch (decl) {
 			FiFunctionDec(__,lambda, type,__,__): {
-				usedFiTypesAddType(type, used_in_exp(lambda, acc));
+				usedFiTypesAddTypeFlat(type, used_in_exp(lambda, acc));
 			}
 			FiGlobalVar(__,value, type,__,__): {
-				usedFiTypesAddType(type, used_in_exp(value, acc));
+				usedFiTypesAddTypeFlat(type, used_in_exp(value, acc));
 			}
 			FiNativeDec(__,__,type,__,fallback,__,__): {
-				usedFiTypesAddType(type, used_in_exp(fallback, acc));
+				usedFiTypesAddTypeFlat(type, used_in_exp(fallback, acc));
 			}
 		}
 	);
@@ -38,12 +36,6 @@ deadFiTypes(prog: FiProgram, preserveNames: Set<string>, eliminateNames: Set<str
 	optimized = fiMapProgramToplevel(prog, \toplevel,__,__ -> 
 		switch (toplevel) {
 			FiTypeStruct(nm, typars, args,__): {
-				if (exists(typars, \tp -> switch (tp) {
-					FiTypeParameter(__): false;
-					default: true;
-				})) {
-					fail("typar is not FiTypeParameter!!1")
-				}
 				if (containsSet(eliminateNames, nm)) remove_dead(nm) else
 				if (containsSet(used, nm) || containsSet(preserveNames, nm)) [toplevel] else remove_dead(nm);
 			}
@@ -69,12 +61,12 @@ deadFiTypes(prog: FiProgram, preserveNames: Set<string>, eliminateNames: Set<str
 usedFiTypesAddName(nm: string, used: Set<string>, names: FiGlobalNames) -> Set<string> {
 	switch (lookupTree(names.structs, nm)) {
 		Some(struct): {
-			fold(struct.args, used, \acc, arg -> usedFiTypesAddType(arg.type, acc));
+			fold(struct.args, used, \acc, arg -> usedFiTypesAddTypeDeep(arg.type, acc, names));
 		}
 		None(): {
 			switch (lookupTree(names.unions, nm)) {
 				Some(union): {
-					fold(union.typenames, used, \acc, tn -> usedFiTypesAddType(tn, acc));
+					fold(union.typenames, used, \acc, tn -> usedFiTypesAddTypeDeep(tn, acc, names));
 				}
 				None(): {
 					fail0("type " + nm + " is not found");
@@ -84,10 +76,23 @@ usedFiTypesAddName(nm: string, used: Set<string>, names: FiGlobalNames) -> Set<s
 	}
 }
 
-usedFiTypesAddType(tp: FiType, used: Set<string>) -> Set<string> {
+usedFiTypesAddTypeFlat(tp: FiType, used: Set<string>) -> Set<string> {
 	fiFoldType(tp, used, \acc, t ->
 		switch (t) {
 			FiTypeName(nm,__): insertSet(acc, nm);
+			default: acc;
+		}
+	)
+}
+
+usedFiTypesAddTypeDeep(tp: FiType, used: Set<string>, names: FiGlobalNames) -> Set<string> {
+	fiFoldType(tp, used, \acc, t ->
+		switch (t) {
+			FiTypeName(nm,__): {
+				if (containsSet(acc, nm)) acc else {
+					usedFiTypesAddName(nm, insertSet(acc, nm), names);
+				}
+			}
 			default: acc;
 		}
 	)

--- a/tools/flowc/manipulation/flatten_unions.flow
+++ b/tools/flowc/manipulation/flatten_unions.flow
@@ -61,7 +61,7 @@ fiUnion2Structs(union : FiTypeUnion, acc: Tree<string, [FiTypeStruct]>, names : 
 							Pair(concat(ac.first, lookupTreeDef(ac1, union1.name, [])), ac1);
 						}
 						None(): {
-							fail("must not happen");
+							fail("must not happen, type: " + type.name + " is not found");
 							ac;
 						}
 					}
@@ -130,30 +130,30 @@ fiTransformImplicitStructTypars(program : FiProgram, fn: (FiTypeParameter) -> Ma
 		fcPrintln(msg, program.config.threadId);
 	}
 	names = program.names;
-	remove_func = \func -> {
+	remove_func = \func: FiFunctionDec -> {
 		typars = fiCollectTypars(func.type, makeSet());
-		lambda_removed = fiTransformImplicitStructTyparsFromFiExp(func.lambda, typars, on_err, fn, names);
+		lambda_removed = fiTransformImplicitStructTyparsFromFiExp(func.lambda, typars, on_err, fn, names, func.name);
 		FiFunctionDec(func with
 			lambda = cast(lambda_removed: FiExp -> FiLambda)
 		);
 	}
-	remove_var = \var -> {
+	remove_var = \var: FiGlobalVar -> {
 		typars = fiCollectTypars(var.type, makeSet());
 		FiGlobalVar(var with
-			value = fiTransformImplicitStructTyparsFromFiExp(var.value, typars, on_err, fn, names)
+			value = fiTransformImplicitStructTyparsFromFiExp(var.value, typars, on_err, fn, names, var.name)
 		);
 	}
-	remove_nat = \nat -> {
+	remove_nat = \nat: FiNativeDec -> {
 		typars = fiCollectTypars(nat.type, makeSet());
 		FiNativeDec(nat with
-			fallbackLambda = fiTransformImplicitStructTyparsFromFiExp(nat.fallbackLambda, typars, on_err, fn, names)
+			fallbackLambda = fiTransformImplicitStructTyparsFromFiExp(nat.fallbackLambda, typars, on_err, fn, names, nat.name)
 		);
 	}
 	toplevel_removed = mapTree(program.names.toplevel, \decl ->
 		switch (decl) {
 			FiFunctionDec(__,__,__, __, __): remove_func(decl);
 			FiGlobalVar(__,__,__,__,__): remove_var(decl);
-			FiNativeDec(__,__,type,__, fallback,__,__): remove_nat(decl);
+			FiNativeDec(__,__,__,__,__,__,__): remove_nat(decl);
 		}
 	);
 	FiProgram(program with
@@ -170,13 +170,17 @@ fiTransformImplicitStructTypars(program : FiProgram, fn: (FiTypeParameter) -> Ma
 	);
 }
 
-fiTransformImplicitStructTyparsFromFiExp(e : FiExp, typars: Set<string>, on_err: (string) -> void, fn: (FiTypeParameter) -> Maybe<FiType>, names: FiGlobalNames) -> FiExp {
-	re = \x -> fiTransformImplicitStructTyparsFromFiExp(x, typars, on_err, fn, names);
+fiTransformImplicitStructTyparsFromFiExp(e : FiExp, typars: Set<string>, on_err: (string) -> void, fn: (FiTypeParameter) -> Maybe<FiType>, names: FiGlobalNames, toplevel_name: string) -> FiExp {
+	re = \x -> fiTransformImplicitStructTyparsFromFiExp(x, typars, on_err, fn, names, toplevel_name);
 	rt = \x -> switch (fiTransformImplicitStructTyparsFromFiType(x, typars, fn, names)) {
 		Some(tp): tp;
 		None(): {
-			on_err("type dissapeared: " + prettyFiType(dummyPretty, x, makeSet()) + 
-				", typars: [" + strGlue(set2array(typars), ", ") + "]");
+			on_err(
+				"type dissapeared: " + prettyFiType(dummyPretty, x, makeSet()) + 
+				", typars: [" + strGlue(set2array(typars), ", ") + "]\n" + 
+				"expression: " + prettyFiExp(dummyPretty, e) + "\n" +
+				"in declaration: " + toplevel_name
+			);
 			x;
 		}
 	}
@@ -184,7 +188,7 @@ fiTransformImplicitStructTyparsFromFiExp(e : FiExp, typars: Set<string>, on_err:
 		FiLambda(args, body, type, start): {
 			body_typars = fold(args, typars, \acc, arg -> fiCollectTypars(arg.type, acc));
 			FiLambda(args,
-				fiTransformImplicitStructTyparsFromFiExp(body, body_typars, on_err, fn, names),
+				fiTransformImplicitStructTyparsFromFiExp(body, body_typars, on_err, fn, names, toplevel_name),
 				cast(rt(type): FiType -> FiTypeFunction), start
 			);
 		}


### PR DESCRIPTION
* bug with not all types accounted as used is fixed
* prettyFiDeclaration prints body of functions/vars, not only types
* old prettyFiDeclaration is now prettyFiDeclarationType - prints only type
* unused parameters are removed from prettyprinting functions