### PR TITLE
for discussion : speed up getTreeValues

### DIFF
--- a/lib/ds/dlist.flow
+++ b/lib/ds/dlist.flow
@@ -166,19 +166,18 @@ popFirstDList(list : DList<?>) -> Maybe<?> {
 	switch (f : DNode) {
 		DEnd(): None();
 		DLink(v, __, __, __): {
-			removeDList(list, f);
+			removeFirstFromDList(list, f);
 			Some(v)
 		}
 	}
 }
 
-removeDList(list : DList<?>, n : DLink<?>) -> void {
-	if (isSameObj(list.first, n)) {
-		list.first ::= n.after;
-	};
-	if (isSameObj(list.last, n)) {
-		list.last ::= n.before;
-	};
+removeFirstFromDList(list : DList<?>, firstItem : DLink<?>) -> void {
+	list.first ::= firstItem.after;
+	removeDListItem(list, firstItem);
+}
+
+removeDListItem(list : DList<?>, n : DLink<?>) -> void {
 	prevv = n.before;
 	switch (prevv : DNode) {
 		DEnd(): {}
@@ -196,6 +195,16 @@ removeDList(list : DList<?>, n : DLink<?>) -> void {
 	n.before ::= DEnd();
 	n.after ::= DEnd();
 	n.attached ::= false;
+}
+
+removeDList(list : DList<?>, n : DLink<?>) -> void {
+	if (isSameObj(list.first, n)) {
+		list.first ::= n.after;
+	};
+	if (isSameObj(list.last, n)) {
+		list.last ::= n.before;
+	};
+	removeDListItem(list, n);
 }
 
 iterDList(list : DList<?>, fn : (?) -> void) -> void {
@@ -328,7 +337,7 @@ concatDList(l1, l2) {
 }
 
 dList2array(dList : DList<?>) -> [?] {
-	dList |> dList2list |> list2array
+	list2array(dList2list(dList));
 }
 
 dList2list(dList : DList<?>) -> List<?> {
@@ -336,5 +345,12 @@ dList2list(dList : DList<?>) -> List<?> {
 }
 
 doDList2list(dList : DList<?>, acc : List<?>) -> List<?> {
-	eitherMap(popFirstDList(dList), \v -> doDList2list(dList, Cons(v, acc)), acc)
+	f = dList.first;
+	switch (f : DNode) {
+		DEnd(): acc;
+		DLink(v, __, __, __): {
+			removeFirstFromDList(dList, f);
+			doDList2list(dList, Cons(v, acc));
+		}
+	}
 }

--- a/lib/ds/tree.flow
+++ b/lib/ds/tree.flow
@@ -6,6 +6,7 @@ import maybe;
 import ds/tuples;
 import runtime;
 import ds/list;
+import ds/dlist;
 
 export {
 	// A binary tree with keys of type ? and values of type ??
@@ -663,10 +664,17 @@ getTreeKeys(tree : Tree<?, ??>) -> [?] {
 }
 
 getTreeValues(tree : Tree<?, ??>) -> [??] {
+	dList2array(getTreeValuesList(tree))
+}
+
+getTreeValuesList(tree : Tree<?, ??>) -> DList<??> {
 	switch (tree : Tree) {
-		TreeEmpty(): [];
+		TreeEmpty(): makeDList();
 		TreeNode(k, v, left, right, depth): {
-			concat3(getTreeValues(left), [v], getTreeValues(right));
+			leftList = getTreeValuesList(left);
+			pushDList(leftList, v) |> ignore;
+			concatDList(leftList, getTreeValuesList(right));
+			leftList;
 		}
 	}
 }


### PR DESCRIPTION
<img width="646" alt="curator_4" src="https://user-images.githubusercontent.com/19932962/224719157-8ef7b7d7-226f-4e9f-98dc-3eee2aa901de.png">

This PR speed up the fn, but there are 2 points to discuss here:
1) dlist2array is not good : dlist -> list -> array. (memory)
2) maybe a native Tree is better?

__
in PR:
dlist :
- make doDList2list tail recursive
- avoid garbage in doDList2list
- 
tree :
- attempt to improve getTreeValues

