### PR TITLE
Mfullscreen fix

### DIFF
--- a/lib/material/material_ui.flow
+++ b/lib/material/material_ui.flow
@@ -1813,7 +1813,7 @@ MFullScreenNoReattachments(fs : DynamicBehaviour<bool>, m : Material) -> Materia
 						false
 					)
 				),
-				false
+				true
 			)
 		);
 	});

--- a/lib/material/tests/test_fullscreen_no_reattachments_dialog.flow
+++ b/lib/material/tests/test_fullscreen_no_reattachments_dialog.flow
@@ -1,0 +1,70 @@
+import lib/material/material_ui;
+import material/material_dialog;
+
+main() {
+	manager = makeMaterialManager([]);
+	setRendererType("html");
+
+	fullscreenB = make(false);
+	closeB = make(false);
+
+	dialogFrame = MDialogCustomFrame(0.0, 0.0, 0.0, 0.0, MBackground(6, TFillXY()));
+	dialogClose = \bh -> MDialogActions([MTextButton(_("CLOSE"), \-> nextDistinct(bh, true), [], [])]);
+
+	showDialog = \-> {
+		next(closeB, false);
+		ShowMDialog(
+			manager,
+			closeB,
+			[
+				dialogFrame,
+				dialogClose(closeB)
+			],
+			MFullScreenNoReattachments(fullscreenB,
+				MCols([
+					MIconButton("help", \-> {
+						close1B = make(false);
+						ShowMDialog(manager, close1B,
+							[
+								dialogFrame,
+								dialogClose(close1B)
+							],
+							MText("Hello", [])
+						)
+					}, [], []),
+					MIf(fullscreenB,
+						MIconButton(
+							"fullscreen_exit",
+							\ -> {
+								nextDistinct(fullscreenB, false);
+							},
+							[],
+							[MTooltipText(const(_("Exit Fullscreen")))]
+						),
+						MIconButton(
+							"fullscreen",
+							\ -> {
+								nextDistinct(fullscreenB, true);
+							},
+							[],
+							[MTooltipText(const(_("Fullscreen")))]
+						)
+					),
+					MIconButton(
+						"exit_to_app",
+						\ -> {
+							nextDistinct(fullscreenB, false);
+							nextDistinct(closeB, true);
+						},
+						[],
+						[MTooltipText(const(_("Exit Presentation")))]
+					)
+				])
+			)
+		);
+	}
+
+	content = MCenter(MIconButton("home", showDialog, [], []));
+
+	mrender(manager, true, content)
+}


### PR DESCRIPTION
Fix for https://trello.com/c/4P1RD9mF/21026-ligth-editor-issue-click-on-help-with-make-all-other-buttons-unclickable
Related to https://trello.com/c/GiZvXaqj/20605-scorm-pacakge-in-preview-mode-if-you-zoom-in-scorm-package-will-dissappear
Can you please check if there is some regression in the related card?