### PR TITLE
Dsl parse made more readable

### DIFF
--- a/lib/tools/dsl/dsl_parse.flow
+++ b/lib/tools/dsl/dsl_parse.flow
@@ -89,7 +89,7 @@ defineGrammar(name : string, grammar : string, add : [string]) -> DslGrammar {
 }
 
 parseGrammarExtension(extension : string) ->  Tree<string, GTerm> {
-	extend = defineGrammar("grammar_extension", gramma_extension_str, ["ws", "id", "string"]);
+	extend = defineGrammar("grammar_extension", grammar_extension_str, ["ws", "id", "string"]);
 
 	extensions : List<DslAst> = getDslList(parseProgram("extension", extend, extension));
 	foldList(extensions, makeTree(), \acc, ex : DslAst -> {
@@ -205,7 +205,7 @@ parseProgram(file : string, grammar : DslGrammar, program : string) -> DslAst {
 	popDslStack(genv.output, "").first;
 }
 
-gramma_extension_str = <<
+grammar_extension_str = <<
 	extensions = ws $"nil" (extension $"cons")+;
 	extension = id "=" $('"' (!'"' anychar)* '"' | "'" (!"'" anychar)* "'" | !";" anychar)* ";" ws $"extension_2";
 	extensions

--- a/lib/tools/dsl/dsl_parse.flow
+++ b/lib/tools/dsl/dsl_parse.flow
@@ -89,11 +89,7 @@ defineGrammar(name : string, grammar : string, add : [string]) -> DslGrammar {
 }
 
 parseGrammarExtension(extension : string) ->  Tree<string, GTerm> {
-	extend = defineGrammar("grammar_extension", <<
-		extensions = ws $"nil" (extension $"cons")+;
-		extension = id "=" $('"' (!'"' anychar)* '"' | "'" (!"'" anychar)* "'" | !";" anychar)* ";" ws $"extension_2";
-		extensions
-	>>, ["ws", "id", "string"]);
+	extend = defineGrammar("grammar_extension", gramma_extension_str, ["ws", "id", "string"]);
 
 	extensions : List<DslAst> = getDslList(parseProgram("extension", extend, extension));
 	foldList(extensions, makeTree(), \acc, ex : DslAst -> {
@@ -208,3 +204,9 @@ parseProgram(file : string, grammar : DslGrammar, program : string) -> DslAst {
 	genv = doGringoParse(file, grammar.term, dslAction, makeList(), program, false, false);
 	popDslStack(genv.output, "").first;
 }
+
+gramma_extension_str = <<
+	extensions = ws $"nil" (extension $"cons")+;
+	extension = id "=" $('"' (!'"' anychar)* '"' | "'" (!"'" anychar)* "'" | !";" anychar)* ";" ws $"extension_2";
+	extensions
+>>;


### PR DESCRIPTION
The definition of `grammar_extension` as raw string breaks the vscode
syntax highlighting, so extracting it to a separate variable and moving
it to the bottom of the file makes code mode readable

