### PR TITLE
Flowc compile time env vars

### DIFF
--- a/tools/common/compilerconfig.flow
+++ b/tools/common/compilerconfig.flow
@@ -317,16 +317,16 @@ readConfigFormString(config : CompilerConfig, str : string) -> Maybe<CompilerCon
 		opts = filter(strSplit(line, " "), \opt -> opt != "");
 		new_config = fold(opts, makeTree(),
 			\a, opt -> {
-				name_val = strSplit(opt, "=");
-				if (length(name_val) == 2) {
-					name = trim2(name_val[0], " \t\u000d");
-					val = trim2(name_val[1], " \t\u000d");
+				eq_ind = strIndexOf(opt, "=");
+				if (!strContains(opt, "=")) a else {
+					name = trim2(takeBefore(opt, "=", opt), " \t\u000d");
+					val = trim2(takeAfter(opt, "=", ""), " \t\u000d");
 					val1 = if (name == "resource-file") {
 						val2 = if (endsWith(val, ".swf")) val else val + ".swf";
 						if (strFindFirstOf(val2, "/\\") != -1) val2 else "resources/" + val2
 					} else val;
 					setTree(a, name, val1)
-				} else a;
+				}
 			}
 		);
 		conf = compilerConfigFromConfig(combineConfigsOverride(new_config, config.config));

--- a/tools/common/compilerconfig.flow
+++ b/tools/common/compilerconfig.flow
@@ -317,7 +317,6 @@ readConfigFormString(config : CompilerConfig, str : string) -> Maybe<CompilerCon
 		opts = filter(strSplit(line, " "), \opt -> opt != "");
 		new_config = fold(opts, makeTree(),
 			\a, opt -> {
-				eq_ind = strIndexOf(opt, "=");
 				if (!strContains(opt, "=")) a else {
 					name = trim2(takeBefore(opt, "=", opt), " \t\u000d");
 					val = trim2(takeAfter(opt, "=", ""), " \t\u000d");

--- a/tools/flowc/backends/common.flow
+++ b/tools/flowc/backends/common.flow
@@ -650,11 +650,9 @@ getFcBackendConfigs(config : CompilerConfig) {
 	htmlAdditionalScripts = filter(strSplit(getConfigParameterDef(config.config, "html-additional-scripts", ""), ","), \e -> e != "");
 	htmlPredefinedParams =
 		map(filter(strSplit(getConfigParameterDef(config.config, "html-predefined-params", ""), ","), \e -> e != ""), \e -> {
-			r = strSplit(e, "=");
-			if (length(r) == 1)
-				Pair(r[0], "")
-			else
-				Pair(r[0], r[1]);
+			key = takeBefore(e, "=", e);
+			val = takeAfter(e, "=", "");
+			Pair(key, val);
 		});
 
 	htmlManifest = getConfigParameterDef(config.config, "html-app-manifest", "");

--- a/tools/flowc/flowc_interpreter.flow
+++ b/tools/flowc/flowc_interpreter.flow
@@ -1,6 +1,7 @@
 import tools/flowc/eval;
 import tools/flowc/flowc_typecheck;
 import tools/flowc/manipulation/deadcode;
+import tools/flowc/manipulation/compile_time;
 import tools/flowc/manipulation/tail_call;
 
 export {
@@ -18,7 +19,8 @@ fcInterpret(conf : CompilerConfig) -> void {
 	);
 	globEnv = initFcTypeEnvGlobal();
 	pair = parseAndTypecheckProgram(run_config, globEnv, run_config.flowfile);
-	program = deadFiCode(pair.first, collectFiEffects(pair.first), makeSet1("for"), makeSet(), false, true, conf.verbose);
+	program1 = substituteCompileTimeValues(pair.first, \err -> printFcError(run_config, globEnv, err));
+	program = deadFiCode(program1, collectFiEffects(program1), makeSet1("for"), makeSet(), false, true, conf.verbose);
 	optimzied = fcOptimizeTailCalls(program);
 	if (pair.second == 0) {
 		globals = fcInitEvalGlobals(optimzied, fail, globEnv);

--- a/tools/flowc/flowc_local.flow
+++ b/tools/flowc/flowc_local.flow
@@ -7,6 +7,7 @@ import tools/flowc/flowc_rename;
 import tools/flowc/flowc_outline;
 import tools/flowc/callgraph;
 import tools/flowc/backends/build;
+import tools/flowc/manipulation/compile_time;
 import tools/flowc/manipulation/deadcode;
 import tools/flowc/manipulation/deadtypes;
 import tools/flowc/manipulation/cse;
@@ -67,11 +68,13 @@ fcCompile(config : CompilerConfig, globEnv : FcTypeEnvGlobal, showStopper : (int
 	errors = ref parsedAndChecked.second;
 
 	if (^errors == 0 || forceBuild) {
-		progOptimized = doFiProgramAnalysis(globEnv, progTypechecked,
-			\err -> {
-				errors := ^errors + 1;
-				printFcError(config, globEnv, err)
-			},
+		on_err = \err -> {
+			errors := ^errors + 1;
+			printFcError(config, globEnv, err)
+		}
+		progSubstitutedCompileTime = substituteCompileTimeValues(progTypechecked, on_err);
+		progOptimized = doFiProgramAnalysis(globEnv, progSubstitutedCompileTime,
+			on_err,
 			config.flowfile
 		);
 		if (^errors == 0 || forceBuild) {

--- a/tools/flowc/flowc_repl.flow
+++ b/tools/flowc/flowc_repl.flow
@@ -271,10 +271,10 @@ fcReplLoopStep(env : FcReplEnv) -> FcReplEnv {
 			FcReplEnv(env with 
 				config = setConfigOptions(env.config, filtermap(opts, \opt0 -> {
 					opt = trim2(opt0, " \t\r\n");
-					if (opt == "") None() else 
-					if (!strContains(opt, "=")) Some(Pair(opt, "")) else {
-						splitted = strSplit(opt, "=");
-						Some(Pair(splitted[0], splitted[1]))
+					if (opt == "") None() else  {
+						key = takeBefore(opt, "=", opt);
+						val = takeAfter(opt, "=", "");
+						Some(Pair(key, val));
 					}
 				}))
 			);

--- a/tools/flowc/flowc_version.flow
+++ b/tools/flowc/flowc_version.flow
@@ -2,5 +2,5 @@
 // Edit 'build-flowc' instead.
 export {
 	flowc_version = "3.0";
-	flowc_git_revision = "d5daeab1f";
+	flowc_git_revision = "f03bc3aa7";
 }

--- a/tools/flowc/flowc_version.flow
+++ b/tools/flowc/flowc_version.flow
@@ -2,5 +2,5 @@
 // Edit 'build-flowc' instead.
 export {
 	flowc_version = "3.0";
-	flowc_git_revision = "9391ffc7f";
+	flowc_git_revision = "d5daeab1f";
 }

--- a/tools/flowc/manipulation/compile_time.flow
+++ b/tools/flowc/manipulation/compile_time.flow
@@ -26,7 +26,7 @@ substituteCompileTimeValues(program: FiProgram, on_err: (FcError) -> void) -> Fi
 	env_opt = getConfigParameter(program.config.config, "env");
 	if (env_opt == "") program else {
 		if (program.config.verbose > 0) {
-			fcPrintln("Substituting compile-time constants from config", program.config.threadId);
+			fcPrintln("Substituting compile-time constants from config:\n\t" + env_opt, program.config.threadId);
 		}
 		cp_vars = pairs2tree(map(strSplit(env_opt, ","), \opt -> {
 			name = trim2(takeBefore(opt, "=", opt), " \t");
@@ -61,7 +61,7 @@ compileTimeValue(val: string, type: FiType, start: int, on_err: (string, int) ->
 		FiTypeDouble(): Some(FiDouble(s2d(val), start));
 		FiTypeString(): Some(FiString(val, start));
 		default: {
-			on_err("Compile-time constant cannot be of type: " + pretFiType(type) + ", must be one of: bool, int, double, string or array of these types", start);
+			on_err("Compile-time constant cannot be of type: " + pretFiType(type) + ", must be one of: bool, int, double or string", start);
 			None();
 		}
 	}

--- a/tools/flowc/manipulation/compile_time.flow
+++ b/tools/flowc/manipulation/compile_time.flow
@@ -1,0 +1,68 @@
+import tools/flowc/incremental/fiprettyprint;
+import tools/flowc/manipulation/common;
+
+export {
+	// Try to find a named constant from config and pass it to AST.
+	// The definition of constants in options is done with `env` option and looks like:
+	//    env=bar=1,js=true,bit_width=32,pi=3.14,app_id=A9_APP
+	//
+	// If `env` option is defined in flow.config file, more sparse format is available:
+	//    env += bar = 1
+	//    env += js=true, bit_width = 32
+	//    env += pi = 3.14, app_id=A9_APP
+	//
+	// Following types of compile-time constants are supported:
+	//    boolean, integer, double and string
+	//
+	// LIMITATIONS:
+	//  - spaces, tabs, etc. are not allowed in string values
+	//  - commas are not allowed in string values
+	//  - booleans are of the form: 1, 0, true, false, TRUE, FALSE
+	//
+	substituteCompileTimeValues(program: FiProgram, on_err: (FcError) -> void) -> FiProgram;
+}
+
+substituteCompileTimeValues(program: FiProgram, on_err: (FcError) -> void) -> FiProgram {
+	env_opt = getConfigParameter(program.config.config, "env");
+	if (env_opt == "") program else {
+		if (program.config.verbose > 0) {
+			fcPrintln("Substituting compile-time constants from config", program.config.threadId);
+		}
+		cp_vars = pairs2tree(map(strSplit(env_opt, ","), \opt -> {
+			name = trim2(takeBefore(opt, "=", opt), " \t");
+			value = trim2(takeAfter(opt, "=", ""), " \t");
+			Pair(name, value);
+		}));
+		fiMapProgramExp(program, \e, decl, module,__ -> {
+			module_err = \msg, pos -> on_err(FcError(msg, [FcPosition(module.fileinfo.flowfile, pos, pos)]));
+			mapFiExp(e,
+				\x -> switch (x) {
+					FiVar(name, type, start): {
+						switch (lookupTree(cp_vars, name)) {
+							Some(val):
+								switch (compileTimeValue(val, type, start, module_err)) {
+									Some(c): c;
+									None(): x;
+								}
+							None(): x;
+						}
+					}
+					default: x;
+				}
+			);
+		});
+	}
+}
+
+compileTimeValue(val: string, type: FiType, start: int, on_err: (string, int) -> void) -> Maybe<FiExp> {
+	switch (type) {
+		FiTypeBool():   Some(FiBool(s2b(val), start));
+		FiTypeInt():    Some(FiInt(s2i(val), start));
+		FiTypeDouble(): Some(FiDouble(s2d(val), start));
+		FiTypeString(): Some(FiString(val, start));
+		default: {
+			on_err("Compile-time constant cannot be of type: " + pretFiType(type) + ", must be one of: bool, int, double, string or array of these types", start);
+			None();
+		}
+	}
+}

--- a/tools/flowc/manipulation/deadcode.flow
+++ b/tools/flowc/manipulation/deadcode.flow
@@ -86,9 +86,18 @@ deadFiCode(prog0 : FiProgram, effects : FiEffects, preserveNames : Set<string>, 
 		prog.config,
 		modules,
 		prog.traversal,
-		// Filter toplevels as well 
+		// Arrange a new, toplevels, with deadcode removed
 		FiGlobalNames(prog.names with
-			toplevel = filterTree(prog.names.toplevel, \name,__ -> containsSet(used, name))
+			//toplevel = filterTree(prog.names.toplevel, \name,__ -> containsSet(used, name))
+			toplevel = foldTree(modules, makeTree(), \name, module, acc ->
+				fold(module.natives,
+					fold(module.globalVars,
+						fold(module.functions, acc, \ac, f -> setTree(ac, f.name, f)),
+						\ac, v -> setTree(ac, v.name, v)
+					),
+					\ac, n -> setTree(ac, n.name, n)
+				)
+			)
 		)
 	);
 }

--- a/tools/flowc/manipulation/deadcode.flow
+++ b/tools/flowc/manipulation/deadcode.flow
@@ -88,7 +88,6 @@ deadFiCode(prog0 : FiProgram, effects : FiEffects, preserveNames : Set<string>, 
 		prog.traversal,
 		// Arrange a new, toplevels, with deadcode removed
 		FiGlobalNames(prog.names with
-			//toplevel = filterTree(prog.names.toplevel, \name,__ -> containsSet(used, name))
 			toplevel = foldTree(modules, makeTree(), \name, module, acc ->
 				fold(module.natives,
 					fold(module.globalVars,


### PR DESCRIPTION
// Try to find a named constant from config and pass it to AST.
// The definition of constants in options is done with `env` option and looks like:
//    env=bar=1,js=true,bit_width=32,pi=3.14,app_id=A9_APP
//
// If `env` option is defined in flow.config file, more sparse format is available:
//    env += bar = 1
//    env += js=true, bit_width = 32
//    env += pi = 3.14, app_id=A9_APP
//
// Following types of compile-time constants are supported:
//    boolean, integer, double and string
//
// LIMITATIONS:
//  - spaces, tabs, etc. are not allowed in string values
//  - commas are not allowed in string values
//  - booleans are of the form: 1, 0, true, false, TRUE, FALSE
//