### PR TITLE
Flowc enable choice of backends

### DIFF
--- a/tools/flowc/backends/build.flow
+++ b/tools/flowc/backends/build.flow
@@ -21,6 +21,9 @@ import promise;
 
 export {
 	buildFiProgram(program : FiProgram, globEnv : FcTypeEnvGlobal, callback : (int) -> void) -> void;
+
+	// List of all backends, available in the current flowc build.
+	fcListBackends(available: bool) -> [string];
 }
 
 // A set of compile-time flags: which of backends are included to the flowc compiler build.
@@ -49,8 +52,33 @@ fc_enabled_cpp2_backend = true;
 fc_enabled_wise_backend = true;
 fc_enabled_cpp3_backend = true;
 
+fcListBackends(available: bool) -> [string] {
+	choose = \x -> if (available) x else !x;
+	filtermap([
+		if (choose(fc_enabled_bytecode_backend)) Some("bytecode") else None(),
+		if (choose(fc_enabled_javascript_backend)) Some("javascript") else None(),
+		if (choose(fc_enabled_html_backend)) Some("html") else None(),
+		if (choose(fc_enabled_java_backend)) Some("java") else None(),
+		if (choose(fc_enabled_rust_backend)) Some("rust") else None(),
+		if (choose(fc_enabled_nim_backend)) Some("nim") else None(),
+		if (choose(fc_enabled_d_backend)) Some("d") else None(),
+		if (choose(fc_enabled_lisp_backend)) Some("list") else None(),
+		if (choose(fc_enabled_cpp_backend)) Some("cpp") else None(),
+		if (choose(fc_enabled_protobuf_backend)) Some("protobuf") else None(),
+		if (choose(fc_enabled_speedy_backend)) Some("speedy") else None(),
+		if (choose(fc_enabled_ml_backend)) Some("ml") else None(),
+		if (choose(fc_enabled_doc_backend)) Some("doc") else None(),
+		if (choose(fc_enabled_wasm_backend)) Some("wasm") else None(),
+		if (choose(fc_enabled_flow_backend)) Some("flow") else None(),
+		if (choose(fc_enabled_cpp2_backend)) Some("cpp2") else None(),
+		if (choose(fc_enabled_wise_backend)) Some("wise") else None(),
+		if (choose(fc_enabled_cpp3_backend)) Some("cpp3") else None(),
+	], idfn);
+}
+
 buildFiProgram(program0 : FiProgram, globEnv : FcTypeEnvGlobal, callback : (int) -> void) -> void {
 	configs = getFcBackendConfigs(program0.config);
+	show_msg = \msg -> fcPrintln(msg, program0.config.threadId);
 
 	program = switch (configs.incaconfig) {
 		None(): program0;
@@ -60,27 +88,7 @@ buildFiProgram(program0 : FiProgram, globEnv : FcTypeEnvGlobal, callback : (int)
 	}
 	exit_code_callback = \fulfil, reject -> \e -> if (e == 0) fulfil(0) else reject(e);
 	absent_backend_reject = \name, reject -> {
-		available_backends = filtermap([
-			if (fc_enabled_bytecode_backend) Some("bytecode") else None(),
-			if (fc_enabled_javascript_backend) Some("javascript") else None(),
-			if (fc_enabled_html_backend) Some("html") else None(),
-			if (fc_enabled_java_backend) Some("java") else None(),
-			if (fc_enabled_rust_backend) Some("rust") else None(),
-			if (fc_enabled_nim_backend) Some("nim") else None(),
-			if (fc_enabled_d_backend) Some("d") else None(),
-			if (fc_enabled_lisp_backend) Some("list") else None(),
-			if (fc_enabled_cpp_backend) Some("cpp") else None(),
-			if (fc_enabled_protobuf_backend) Some("protobuf") else None(),
-			if (fc_enabled_speedy_backend) Some("speedy") else None(),
-			if (fc_enabled_ml_backend) Some("ml") else None(),
-			if (fc_enabled_doc_backend) Some("doc") else None(),
-			if (fc_enabled_wasm_backend) Some("wasm") else None(),
-			if (fc_enabled_flow_backend) Some("flow") else None(),
-			if (fc_enabled_cpp2_backend) Some("cpp2") else None(),
-			if (fc_enabled_wise_backend) Some("wise") else None(),
-			if (fc_enabled_cpp3_backend) Some("cpp3") else None(),
-		], idfn);
-		fcPrintln("Backend " + name + " is not present in this build of flowc. Available backends: [" + strGlue(available_backends, ", ") + "]", program.config.threadId);
+		fcPrintln("Backend " + name + " is not present in this build of flowc. Available backends: [" + strGlue(fcListBackends(true), ", ") + "]", program.config.threadId);
 		reject(5);
 	}
 	doneP(

--- a/tools/flowc/backends/build.flow
+++ b/tools/flowc/backends/build.flow
@@ -23,6 +23,32 @@ export {
 	buildFiProgram(program : FiProgram, globEnv : FcTypeEnvGlobal, callback : (int) -> void) -> void;
 }
 
+// A set of compile-time flags: which of backends are included to the flowc compiler build.
+// Particular backends may be excluded from build by overriding these variables
+// in flow.config with `env` option, like:
+//   `env += fc_enabled_lisp_backend=0`
+// or
+//   `env += fc_enabled_lisp_backend = false`
+
+fc_enabled_bytecode_backend = true;
+fc_enabled_javascript_backend = true;
+fc_enabled_html_backend = true;
+fc_enabled_java_backend = true;
+fc_enabled_rust_backend = true;
+fc_enabled_nim_backend = true;
+fc_enabled_d_backend = true;
+fc_enabled_lisp_backend = true;
+fc_enabled_cpp_backend = true;
+fc_enabled_protobuf_backend = true;
+fc_enabled_speedy_backend = true;
+fc_enabled_ml_backend = true;
+fc_enabled_doc_backend = true;
+fc_enabled_wasm_backend = true;
+fc_enabled_flow_backend = true;
+fc_enabled_cpp2_backend = true;
+fc_enabled_wise_backend = true;
+fc_enabled_cpp3_backend = true;
+
 buildFiProgram(program0 : FiProgram, globEnv : FcTypeEnvGlobal, callback : (int) -> void) -> void {
 	configs = getFcBackendConfigs(program0.config);
 
@@ -33,28 +59,172 @@ buildFiProgram(program0 : FiProgram, globEnv : FcTypeEnvGlobal, callback : (int)
 		}
 	}
 	exit_code_callback = \fulfil, reject -> \e -> if (e == 0) fulfil(0) else reject(e);
+	absent_backend_reject = \name, reject -> {
+		available_backends = filtermap([
+			if (fc_enabled_bytecode_backend) Some("bytecode") else None(),
+			if (fc_enabled_javascript_backend) Some("javascript") else None(),
+			if (fc_enabled_html_backend) Some("html") else None(),
+			if (fc_enabled_java_backend) Some("java") else None(),
+			if (fc_enabled_rust_backend) Some("rust") else None(),
+			if (fc_enabled_nim_backend) Some("nim") else None(),
+			if (fc_enabled_d_backend) Some("d") else None(),
+			if (fc_enabled_lisp_backend) Some("list") else None(),
+			if (fc_enabled_cpp_backend) Some("cpp") else None(),
+			if (fc_enabled_protobuf_backend) Some("protobuf") else None(),
+			if (fc_enabled_speedy_backend) Some("speedy") else None(),
+			if (fc_enabled_ml_backend) Some("ml") else None(),
+			if (fc_enabled_doc_backend) Some("doc") else None(),
+			if (fc_enabled_wasm_backend) Some("wasm") else None(),
+			if (fc_enabled_flow_backend) Some("flow") else None(),
+			if (fc_enabled_cpp2_backend) Some("cpp2") else None(),
+			if (fc_enabled_wise_backend) Some("wise") else None(),
+			if (fc_enabled_cpp3_backend) Some("cpp3") else None(),
+		], idfn);
+		fcPrintln("Backend " + name + " is not present in this build of flowc. Available backends: [" + strGlue(available_backends, ", ") + "]", program.config.threadId);
+		reject(5);
+	}
 	doneP(
 		allP(filtermap([
-			maybeMap(configs.bcconfig,       \cfg -> Promise(\fulfil, reject-> fi2bytecode(program, cfg, exit_code_callback(fulfil, reject)))),
-			maybeMap(configs.jsconfig,       \cfg -> Promise(\fulfil, reject-> fi2javascript(program, globEnv, cfg, exit_code_callback(fulfil, reject)))),
-			maybeMap(configs.es6config,      \cfg -> Promise(\fulfil, reject-> fi2javascript(program, globEnv, cfg, exit_code_callback(fulfil, reject)))),
-			maybeMap(configs.tsconfig,       \cfg -> Promise(\fulfil, reject-> fi2javascript(program, globEnv, cfg, exit_code_callback(fulfil, reject)))),
-			maybeMap(configs.htmlconfig,     \cfg -> Promise(\fulfil, reject-> fi2html(program, cfg, exit_code_callback(fulfil, reject)))),
-			maybeMap(configs.javaconfig,     \cfg -> Promise(\fulfil, reject-> fi2java(program, cfg, exit_code_callback(fulfil, reject)))),
-			maybeMap(configs.rustconfig,     \cfg -> Promise(\fulfil, reject-> fi2rust(program, cfg, exit_code_callback(fulfil, reject)))),
-			maybeMap(configs.nimconfig,      \cfg -> Promise(\fulfil, reject-> fi2nim(program, cfg, exit_code_callback(fulfil, reject)))),
-			maybeMap(configs.dconfig,        \cfg -> Promise(\fulfil, reject-> fi2d(program, cfg, exit_code_callback(fulfil, reject)))),
-			maybeMap(configs.lispconfig,     \cfg -> Promise(\fulfil, reject-> fi2lisp(program, cfg, exit_code_callback(fulfil, reject)))),
-			maybeMap(configs.cppconfig,      \cfg -> Promise(\fulfil, reject-> fc2cpp(program, cfg, exit_code_callback(fulfil, reject)))),
-			maybeMap(configs.protobufconfig, \cfg -> Promise(\fulfil, reject-> fi2protobuf(program, cfg, exit_code_callback(fulfil, reject)))),
-			maybeMap(configs.speedyconfig,   \cfg -> Promise(\fulfil, reject-> fi2speedy(program, cfg, exit_code_callback(fulfil, reject)))),
-			maybeMap(configs.mlconfig,       \cfg -> Promise(\fulfil, reject-> fi2ml(program, cfg, exit_code_callback(fulfil, reject)))),
-			maybeMap(configs.docconfig,      \cfg -> Promise(\fulfil, reject-> fi2doc(program, cfg, exit_code_callback(fulfil, reject)))),
-			maybeMap(configs.wasmconfig,     \cfg -> Promise(\fulfil, reject-> fi2wasm(program, globEnv, cfg, exit_code_callback(fulfil, reject)))),
-			maybeMap(configs.flowconfig,     \cfg -> Promise(\fulfil, reject-> fi2flow(program, cfg, exit_code_callback(fulfil, reject)))),
-			maybeMap(configs.cpp2config,     \cfg -> Promise(\fulfil, reject-> fi2cpp2(program, cfg, exit_code_callback(fulfil, reject)))),
-			maybeMap(configs.wiseconfig,     \cfg -> Promise(\fulfil, reject-> fi2wise(program, cfg, exit_code_callback(fulfil, reject)))),
-			maybeMap(configs.cpp3config,     \cfg -> Promise(\fulfil, reject-> fi2cpp3(program, cfg, exit_code_callback(fulfil, reject)))),
+			maybeMap(configs.bcconfig, \cfg -> Promise(\fulfil, reject->
+				if (fc_enabled_bytecode_backend) {
+					fi2bytecode(program, cfg, exit_code_callback(fulfil, reject))
+				} else {
+					absent_backend_reject("bytecode", reject)
+				}
+			)),
+			maybeMap(configs.jsconfig, \cfg -> Promise(\fulfil, reject->
+				if (fc_enabled_javascript_backend) {
+					fi2javascript(program, globEnv, cfg, exit_code_callback(fulfil, reject))
+				} else {
+					absent_backend_reject("javascript", reject)
+				}
+			)),
+			maybeMap(configs.es6config, \cfg -> Promise(\fulfil, reject->
+				if (fc_enabled_javascript_backend) {
+					fi2javascript(program, globEnv, cfg, exit_code_callback(fulfil, reject))
+				} else {
+					absent_backend_reject("javascript", reject)
+				}
+			)),
+			maybeMap(configs.tsconfig, \cfg -> Promise(\fulfil, reject->
+				if (fc_enabled_javascript_backend) {
+					fi2javascript(program, globEnv, cfg, exit_code_callback(fulfil, reject))
+				} else {
+					absent_backend_reject("javascript", reject)
+				}
+			)),
+			maybeMap(configs.htmlconfig, \cfg -> Promise(\fulfil, reject->
+				if (fc_enabled_html_backend) {
+					fi2html(program, cfg, exit_code_callback(fulfil, reject))
+				} else {
+					absent_backend_reject("html", reject)
+				}
+			)),
+			maybeMap(configs.javaconfig, \cfg -> Promise(\fulfil, reject->
+				if (fc_enabled_java_backend) {
+					fi2java(program, cfg, exit_code_callback(fulfil, reject))
+				} else {
+					absent_backend_reject("java", reject)
+				}
+			)),
+			maybeMap(configs.rustconfig, \cfg -> Promise(\fulfil, reject->
+				if (fc_enabled_rust_backend) {
+					fi2rust(program, cfg, exit_code_callback(fulfil, reject))
+				} else {
+					absent_backend_reject("rust", reject)
+				}
+			)),
+			maybeMap(configs.nimconfig, \cfg -> Promise(\fulfil, reject->
+				if (fc_enabled_nim_backend) {
+					fi2nim(program, cfg, exit_code_callback(fulfil, reject))
+				} else {
+					absent_backend_reject("nim", reject)
+				}
+			)),
+			maybeMap(configs.dconfig, \cfg -> Promise(\fulfil, reject->
+				if (fc_enabled_d_backend) {
+					fi2d(program, cfg, exit_code_callback(fulfil, reject))
+				} else {
+					absent_backend_reject("d", reject)
+				}
+			)),
+			maybeMap(configs.lispconfig,\cfg -> Promise(\fulfil, reject->
+				if (fc_enabled_lisp_backend) {
+					fi2lisp(program, cfg, exit_code_callback(fulfil, reject))
+				} else {
+					absent_backend_reject("lisp", reject)
+				}
+			)),
+			maybeMap(configs.cppconfig, \cfg -> Promise(\fulfil, reject->
+				if (fc_enabled_cpp_backend) {
+					fc2cpp(program, cfg, exit_code_callback(fulfil, reject))
+				} else {
+					absent_backend_reject("cpp", reject)
+				}
+			)),
+			maybeMap(configs.protobufconfig, \cfg -> Promise(\fulfil, reject->
+				if (fc_enabled_protobuf_backend) {
+					fi2protobuf(program, cfg, exit_code_callback(fulfil, reject))
+				} else {
+					absent_backend_reject("protobuf", reject)
+				}
+			)),
+			maybeMap(configs.speedyconfig, \cfg -> Promise(\fulfil, reject->
+				if (fc_enabled_speedy_backend) {
+					fi2speedy(program, cfg, exit_code_callback(fulfil, reject))
+				} else {
+					absent_backend_reject("speedy", reject)
+				}
+			)),
+			maybeMap(configs.mlconfig, \cfg -> Promise(\fulfil, reject->
+				if (fc_enabled_ml_backend) {
+					fi2ml(program, cfg, exit_code_callback(fulfil, reject))
+				} else {
+					absent_backend_reject("ml", reject)
+				}
+			)),
+			maybeMap(configs.docconfig, \cfg -> Promise(\fulfil, reject->
+				if (fc_enabled_doc_backend) {
+					fi2doc(program, cfg, exit_code_callback(fulfil, reject))
+				} else {
+					absent_backend_reject("doc", reject)
+				}
+			)),
+			maybeMap(configs.wasmconfig, \cfg -> Promise(\fulfil, reject->
+				if (fc_enabled_wasm_backend) {
+					fi2wasm(program, globEnv, cfg, exit_code_callback(fulfil, reject))
+				} else {
+					absent_backend_reject("wasm", reject)
+				}
+			)),
+			maybeMap(configs.flowconfig, \cfg -> Promise(\fulfil, reject->
+				if (fc_enabled_flow_backend) {
+					fi2flow(program, cfg, exit_code_callback(fulfil, reject))
+				} else {
+					absent_backend_reject("flow", reject)
+				}
+			)),
+			maybeMap(configs.cpp2config, \cfg -> Promise(\fulfil, reject->
+				if (fc_enabled_cpp2_backend) {
+					fi2cpp2(program, cfg, exit_code_callback(fulfil, reject))
+				} else {
+					absent_backend_reject("cpp2", reject)
+				}
+			)),
+			maybeMap(configs.wiseconfig, \cfg -> Promise(\fulfil, reject->
+				if (fc_enabled_wise_backend) {
+					fi2wise(program, cfg, exit_code_callback(fulfil, reject))
+				} else {
+					absent_backend_reject("wise", reject)
+				}
+			)),
+			maybeMap(configs.cpp3config, \cfg -> Promise(\fulfil, reject->
+				if (fc_enabled_cpp3_backend) {
+					fi2cpp3(program, cfg, exit_code_callback(fulfil, reject))
+				} else {
+					absent_backend_reject("cpp3", reject)
+				}
+			)),
 		], idfn)),
 		\codes -> if (forall(codes, \code -> code == 0)) callback(0) else callback(5),
 		callback

--- a/tools/flowc/flowc.flow
+++ b/tools/flowc/flowc.flow
@@ -15,7 +15,13 @@ main() {
 			quit(1);
 		}
 		Some(config): {
-			if (isConfigParameterSet(config.config, "compilefile")) {
+			if (isConfigParameterTrue(config.config, "list-available-backends")) {
+				fcPrintln("Available backends: [" + strGlue(fcListBackends(true), ", ") + "]", threadId);
+				quit(0);
+			} else if (isConfigParameterTrue(config.config, "list-disabled-backends")) {
+				fcPrintln("Disabled backends: [" + strGlue(fcListBackends(false), ", ") + "]", threadId);
+				quit(0);
+			} else if (isConfigParameterSet(config.config, "compilefile")) {
 				starttime = timestamp();
 				compilefile = getConfigParameter(config.config, "compilefile");
 				configs = reverseA(readConfigsFormCompileFile(config, compilefile));

--- a/tools/flowc/flowc_usage.flow
+++ b/tools/flowc/flowc_usage.flow
@@ -232,6 +232,9 @@ printUsage(config) {
 	prih(help,"                                If skipped or set to 0, the compiler will try to find these sources by itself.");
 	prih(help,"      compilefile=<file>        File contains a text file, where each line is a command-line invocation of the compiler");
 	prih(!help,"");
+	prih(help,"      list-available-backends=1 Print the names of backends, which are available in the current flowc build (some may be disabled).");
+	prih(help,"      list-disabled-backends=1  Print the names of backends, which are not available in the current flowc build, but are present in flowc source code.");
+	prih(!help,"");
 	prih(help,"      repl=1                    Run flowc interpreter in REPL loop. Use 'help' command to see documentation on flowc REPL mode.");
 	prih(!help,"Full options list:");
 	prih(!help,"  flowc help=1");

--- a/tools/flowc/flowc_version.flow
+++ b/tools/flowc/flowc_version.flow
@@ -2,5 +2,5 @@
 // Edit 'build-flowc' instead.
 export {
 	flowc_version = "3.0";
-	flowc_git_revision = "f03bc3aa7";
+	flowc_git_revision = "02d72a432";
 }

--- a/tools/flowc/flowc_version.flow
+++ b/tools/flowc/flowc_version.flow
@@ -2,5 +2,5 @@
 // Edit 'build-flowc' instead.
 export {
 	flowc_version = "3.0";
-	flowc_git_revision = "02d72a432";
+	flowc_git_revision = "c1c26c864";
 }

--- a/tools/flowc/manipulation/compile_time.flow
+++ b/tools/flowc/manipulation/compile_time.flow
@@ -25,14 +25,17 @@ export {
 substituteCompileTimeValues(program: FiProgram, on_err: (FcError) -> void) -> FiProgram {
 	env_opt = getConfigParameter(program.config.config, "env");
 	if (env_opt == "") program else {
-		if (program.config.verbose > 0) {
-			fcPrintln("Substituting compile-time constants from config:\n\t" + env_opt, program.config.threadId);
-		}
 		cp_vars = pairs2tree(map(strSplit(env_opt, ","), \opt -> {
 			name = trim2(takeBefore(opt, "=", opt), " \t");
 			value = trim2(takeAfter(opt, "=", ""), " \t");
 			Pair(name, value);
 		}));
+		if (program.config.verbose > 0) {
+			fcPrintln("Substituting compile-time constants from config:\n" + 
+				strGlue(map(tree2pairs(cp_vars), \p -> "\t" + p.first + " = " + p.second), "\n"), 
+				program.config.threadId
+			);
+		}
 		fiMapProgramExp(program, \e, decl, module,__ -> {
 			module_err = \msg, pos -> on_err(FcError(msg, [FcPosition(module.fileinfo.flowfile, pos, pos)]));
 			mapFiExp(e,


### PR DESCRIPTION
Particular backends may be excluded from build by overriding variables in flow.config with `env` option, like:
   `env += fc_enabled_lisp_backend=0`
 or
   `env += fc_enabled_lisp_backend = false`

or passing an explicit set of values of variables to the compiler via command line, i.e.:

`flowc1 jar=flowc_compact.jar file=flowc
env=fc_enabled_bytecode_backend=1,fc_enabled_javascript_backend=0,fc_enabled_html_backend=0,fc_enabled_java_backend=1,fc_enabled_rust_backend=0,fc_enabled_nim_backend=1,fc_enabled_d_backend=0,fc_enabled_lisp_backend=0,fc_enabled_cpp_backend=0,fc_enabled_protobuf_backend=0,fc_enabled_speedy_backend=0,fc_enabled_ml_backend=0,fc_enabled_doc_backend=0,fc_enabled_wasm_backend=0,fc_enabled_flow_backend=0,fc_enabled_cpp2_backend=0,fc_enabled_wise_backend=0,fc_enabled_cpp3_backend=0
dce-types=1`