### PR TITLE
Flowc: Fix Java field accessor generated code

### DIFF
--- a/tools/flowc/backends/java/fi2java_compile.flow
+++ b/tools/flowc/backends/java/fi2java_compile.flow
@@ -1020,7 +1020,7 @@ emitJavaExpression(ctx : JavaScopeContext, expcode : FiExp, rtype : string) -> s
 								if (argid < 0)
 									fail0("Struct " + cstruct.name+" has no field " + field);
 								vtype = type2javaObjType(gctx, cstruct.fields[argid].type, true, false, false);
-								result(refstr + ".f_" + field, vtype);
+								result("(" + refstr + ").f_" + field, vtype);
 							}
 							None(): {
 								javaRequireAccessor(gctx, field);


### PR DESCRIPTION
That fixes example

`import date;

main() {
	getCurrentDate().year - 5*2;
}`