### PR TITLE
add jfif extension to file picker

### DIFF
--- a/lib/material/internal/filebrowser/material_filebrowser_internal_types.flow
+++ b/lib/material/internal/filebrowser/material_filebrowser_internal_types.flow
@@ -97,7 +97,7 @@ export {
 			// Should we show such files in the doalog
 			FbReduceShowInDialog(show : bool);
 
-	filebrowserPictureExtensions = [".jpg", ".jpeg", ".png", ".bmp", ".svg", ".gif"];
+	filebrowserPictureExtensions = [".jpg", ".jpeg", ".png", ".bmp", ".svg", ".gif", ".jfif"];
 	filebrowserVideoExtensions = [".mp4", ".webm", ".m4v", ".mov", ".flv", ".avi"];
 	filebrowserAudioExtensions = [".mp3", ".m4a"];
 


### PR DESCRIPTION
https://trello.com/c/XEpp2Qho/23161-files-usable-in-slideshow-not-allowed-by-file-picker