### PR TITLE
Show Policy for video links

### DIFF
--- a/lib/form/videoform.flow
+++ b/lib/form/videoform.flow
@@ -63,19 +63,6 @@ Video : (filename : string, parameters : [VideoParameter], listeners: [VideoStre
 		privacyPolicyURL : string,
 		termsOfServiceURL : string
 	);
-
-	getPrivacyPolicy(url : string) -> Maybe<PrivacyPolicy>;
-}
-
-getExternalPlayerURL(url : string) -> Maybe<string> {
-	parsers = [getYouTubeURL, getVimeoURL, getBrightcoveURL, getVidizmoURL];
-	fold(parsers, None(), \acc, parser ->
-		if (isSome(acc)) acc
-		else parser(url)
-	);
-}
-
-getPrivacyPolicy(url : string) -> Maybe<PrivacyPolicy> {
 	youTubePrivacy = PrivacyPolicy(
 		"YouTube",
 		"Google",
@@ -102,7 +89,18 @@ getPrivacyPolicy(url : string) -> Maybe<PrivacyPolicy> {
 		"https://vidizmo.com/privacy-policy",
 		"https://vidizmo.com/terms-of-use"
 	);
+	getPrivacyPolicy(url : string) -> Maybe<PrivacyPolicy>;
+}
 
+getExternalPlayerURL(url : string) -> Maybe<string> {
+	parsers = [getYouTubeURL, getVimeoURL, getBrightcoveURL, getVidizmoURL];
+	fold(parsers, None(), \acc, parser ->
+		if (isSome(acc)) acc
+		else parser(url)
+	);
+}
+
+getPrivacyPolicy(url : string) -> Maybe<PrivacyPolicy> {
 	parsers = [getYouTubeURL, getVimeoURL, getBrightcoveURL, getVidizmoURL];
 	policy = [youTubePrivacy, vimeoPrivacy, brightcovePrivacy, vimeoPrivacy];
 

--- a/lib/form/videoform.flow
+++ b/lib/form/videoform.flow
@@ -56,6 +56,15 @@ Video : (filename : string, parameters : [VideoParameter], listeners: [VideoStre
 	getVimeoURL(url : string) -> Maybe<string>;
 	getBrightcoveURL(url : string) -> Maybe<string>;
 	getVidizmoURL(url : string) -> Maybe<string>;
+
+	PrivacyPolicy(
+		service : string,
+		company : string,
+		privacyPolicyURL : string,
+		termsOfServiceURL : string
+	);
+
+	getPrivacyPolicy(url : string) -> Maybe<PrivacyPolicy>;
 }
 
 getExternalPlayerURL(url : string) -> Maybe<string> {
@@ -65,6 +74,44 @@ getExternalPlayerURL(url : string) -> Maybe<string> {
 		else parser(url)
 	);
 }
+
+getPrivacyPolicy(url : string) -> Maybe<PrivacyPolicy> {
+	youTubePrivacy = PrivacyPolicy(
+		"YouTube",
+		"Google",
+		"https://policies.google.com/privacy",
+		"https://developers.google.com/youtube/terms/api-services-terms-of-service"
+	);
+	vimeoPrivacy = PrivacyPolicy(
+		"Vimeo",
+		"Vimeo",
+		"https://vimeo.com/privacy",
+		"https://vimeo.com/terms"
+	);
+
+	brightcovePrivacy = PrivacyPolicy(
+		"Brightcove",
+		"Brightcove Inc",
+		"https://www.brightcove.com/en/legal/brightcove-privacy-policies/",
+		"https://www.brightcove.com/en/terms-and-conditions/"
+	);
+	
+	vidizmoPrivacy = PrivacyPolicy(
+		"VIDIZMO",
+		"VIDIZMO LLC",
+		"https://vidizmo.com/privacy-policy",
+		"https://vidizmo.com/terms-of-use"
+	);
+
+	parsers = [getYouTubeURL, getVimeoURL, getBrightcoveURL, getVidizmoURL];
+	policy = [youTubePrivacy, vimeoPrivacy, brightcovePrivacy, vimeoPrivacy];
+
+	foldi(parsers, None(), \i, acc, parser ->
+		if (isSome(acc)) acc
+		else maybeBind(parser(url), \__ -> Some(policy[i]))
+	);
+}
+
 
 getYouTubeURL(url0 : string) -> Maybe<string> {
 	if (strContains(url0, "youtu.be") || strContains(url0, "youtube.com")) {


### PR DESCRIPTION
https://trello.com/c/DJM7uy2Q/23391-adding-a-youtube-or-vimeo-player-as-an-embedded-website-in-wigi-should-show-their-policy