### PR TITLE
Fix words grouping for leading spaces

### DIFF
--- a/lib/tropic/tropic_paragraph.flow
+++ b/lib/tropic/tropic_paragraph.flow
@@ -296,7 +296,7 @@ TRenderParagraph(
 		rtl,
 		ignoreLetterSpacing
 	);
-
+	
 	paragraphWHB = makeWH();
 	paragraphBaselineB = make(0.0);
 
@@ -713,16 +713,16 @@ joinTextWords(
 				EmptyList(): zeroPoint;
 				Cons(head, __): Point(getValue(head.inspector.x), getValue(head.inspector.y));
 			};
-			joinResult = foldList(
+		joinResult = foldList(
 				words,
 				JoinTextAcc("", "", [], None(), -1, point, EmptyList()),
 				\acc, word -> appendOrJoinWord(
-					acc,
-					word,
-					genIndent,
-					wordsViewConstructor,
-					ignoreLetterSpacing
-				)
+						acc,
+						word,
+						genIndent,
+						wordsViewConstructor,
+						ignoreLetterSpacing
+					)
 			);
 			TGroup(
 				// here we get group because words of the same style(wigiText) can be placed on few lines
@@ -769,7 +769,9 @@ appendOrJoinWord(
 		if (acc.lineNumber == -1) {
 			// There are no words yet.
 			if (isSpace(wordString)) {
-				acc
+				JoinTextAcc(acc with
+					currentOffset = wordOffset
+				)
 			} else {
 				JoinTextAcc(
 					wordString,
@@ -786,7 +788,8 @@ appendOrJoinWord(
 			// just concat to current string
 			if (isSpace(wordString)) {
 				JoinTextAcc(acc with
-					currentSpaces = wordString + acc.currentSpaces
+					currentSpaces = wordString + acc.currentSpaces,
+					currentOffset = ofs
 				)
 			} else {
 				JoinTextAcc(acc with
@@ -829,7 +832,7 @@ addLastLine(
 		TTranslate(
 			const(joinResult.currentOffset),
 			wordsViewConstructor(
-				joinResult.currentString,
+				joinResult.currentSpaces + joinResult.currentString,
 				if (ignoreLetterSpacing) removeAllStructs(joinResult.style, LetterSpacing(0.0)) else joinResult.style
 			)
 		),


### PR DESCRIPTION
https://trello.com/c/8vqgULMZ/942-styles-are-not-applied-to-leading-spaces-in-tropicwigify