### PR TITLE
Fix words grouping for space in the end of group.

### DIFF
--- a/lib/tropic/tropic_paragraph.flow
+++ b/lib/tropic/tropic_paragraph.flow
@@ -770,7 +770,11 @@ appendOrJoinWord(
 			// There are no words yet.
 			if (isSpace(wordString)) {
 				JoinTextAcc(acc with
-					currentOffset = wordOffset
+					currentOffset = wordOffset,
+					currentSpaces = wordString + acc.currentSpaces,
+					lineNumber = lineNumber,
+					style = makeWordStyle(),
+					rtlM = Some(getValue(word.rtl))
 				)
 			} else {
 				JoinTextAcc(


### PR DESCRIPTION
https://trello.com/c/8vqgULMZ/942-styles-are-not-applied-to-leading-spaces-in-tropicwigify


![image](https://github.com/area9innovation/flow9/assets/19254090/fe17b63a-a603-48a4-992a-15b12e314f5a)
