### PR TITLE
Fallback for the 'downloadFileBinary' function

### DIFF
--- a/lib/net/http.flow
+++ b/lib/net/http.flow
@@ -3,6 +3,7 @@
 import fs/filesystem;
 import net/http_types;
 import ds/arrayutils;
+import sys/system;
 
 export {
 	// Example simple call disregarding errors:
@@ -540,8 +541,22 @@ downloadFileBinary(
 	onDone : () -> void,
 	onError : (string) -> void,
 ) {
-	// NOP
 	// Fallback for non-C++ targets
+	httpCustomRequestStyled(
+		url,
+		GET(),
+		\status, responseData, __ -> {
+			if (status == 200) {
+				setFileContentBinary(pathToSave, responseData);
+				onDone()
+			} else {
+				onError("downloadFileBinary: couldn't load '" + url + "'")
+			}
+		},
+		[
+			RequestEncoding(ResponseEncodingByte()),
+		]
+	)
 }
 
 deleteAppCookies() {


### PR DESCRIPTION
This function doesn't work in QtByteRunner for Windows