### PR TITLE
Flowc make runtime value type not native

### DIFF
--- a/lib/dynamic.flow
+++ b/lib/dynamic.flow
@@ -125,7 +125,7 @@ runtimeValueType(value : flow) -> string {
 	if (tag == double_data_tag) "double" else
 	if (tag == string_data_tag) "string" else
 	if (tag == array_data_tag) "array" else
-	if (tag == struct_data_tag) "struct" else
+	if (tag == struct_data_tag) extractStructName(value) else
 	if (tag == reference_data_tag) "ref" else
 	if (tag == native_data_tag) "native" else
 	if (tag == function_data_tag) "function" else

--- a/lib/dynamic.flow
+++ b/lib/dynamic.flow
@@ -19,7 +19,7 @@ export {
 
 	// Returns the type of a value, like 'int', 'bool', 'Some', etc.
 	// Currently is implemented in: java backend.
-	native runtimeValueType : (flow) -> string = Native.runtimeValueType;
+	runtimeValueType(flow) -> string;
 
 	// Check, if a struct is known to the runtime.
 	// Currently is implemented in: java backend.

--- a/platforms/java/com/area9innovation/flow/Native.java
+++ b/platforms/java/com/area9innovation/flow/Native.java
@@ -2601,30 +2601,6 @@ public class Native extends NativeHost {
 		}
 	}
 
-	public static final String runtimeValueType(Object value) {
-		if (value == null) {
-			return "void";
-		} else if (value instanceof Integer) {
-			return "int";
-		} else if (value instanceof Double) {
-			return "double";
-		} else if (value instanceof Boolean) {
-			return "bool";
-		} else if (value instanceof String) {
-			return "string";
-		} else if (value instanceof Struct) {
-			return ((Struct)value).getTypeName();
-		} else if (value instanceof Function) {
-			return "function";
-		} else if (value instanceof Object[]) {
-			return "array";
-		} else if (value instanceof Reference) {
-			return "ref";
-		} else {
-			return "undef";
-		}
-	}
-
 	public static final String toStringForJson(String value) {
 		String sv = value;
 		// Make room for some escape

--- a/tools/flowc/flowc_version.flow
+++ b/tools/flowc/flowc_version.flow
@@ -2,5 +2,5 @@
 // Edit 'build-flowc' instead.
 export {
 	flowc_version = "3.0";
-	flowc_git_revision = "266097d98";
+	flowc_git_revision = "952b6b8da";
 }

--- a/tools/flowc/flowc_version.flow
+++ b/tools/flowc/flowc_version.flow
@@ -2,5 +2,5 @@
 // Edit 'build-flowc' instead.
 export {
 	flowc_version = "3.0";
-	flowc_git_revision = "952b6b8da";
+	flowc_git_revision = "61ff0ec98";
 }


### PR DESCRIPTION
No need to have extra native `runtimeValueType`, when we already have `getDataTagForValue` native.