### PR TITLE
Fix width inspector for EmptyLineElement

### DIFF
--- a/lib/tropic/tropic_paragraph.flow
+++ b/lib/tropic/tropic_paragraph.flow
@@ -862,6 +862,7 @@ commonWordConstructor(
 
 	ghostView = switch(w) {
 		GeneralSpace(__, __, __): TVisible(fnot(inspector.detached), inspectFn(tr));
+		EmptyLineElement(): tr;
 		default: inspectFn(tr);
 	}
 	if (!isUrlParameterFalse("wigi921") && isSome(inspectorM) && getValue(inspector.size) == zeroWH) {


### PR DESCRIPTION
https://trello.com/c/gIclS0xo/22982-letters-on-a-slide-are-being-cut-off-when-simulating