### PR TITLE
Fixed dimmer in images with custom size less then actual size.

### DIFF
--- a/lib/ui/imagedecorated.flow
+++ b/lib/ui/imagedecorated.flow
@@ -178,7 +178,7 @@ makeImageDecorated2(
 
 	pictureWithZoomableDecorations = Group([
 		Inspect([ISize(wholeImageWH)], pictureWithWarning.picture),
-		Scale(replacedImageScale, replacedImageScale, makeImagePreZoomDecorationsForm(preZoomDecorations, _width, _height))
+		Scale(replacedImageScale, replacedImageScale, Select(wholeImageWH, \wh -> makeImagePreZoomDecorationsForm(preZoomDecorations, wh.width, wh.height)))
 	]);
 
 	addDecorations = \scaleConnector, zoom -> \image -> { //is applied both to full size image and downscaled one


### PR DESCRIPTION
Before:
![Screenshot_20240122_124858](https://github.com/area9innovation/flow9/assets/11317004/a98b7814-5bb7-465b-b127-2faa9de1a855)
After:
![Screenshot_20240122_125839](https://github.com/area9innovation/flow9/assets/11317004/81c2db48-cf04-4ff1-bb3c-eee48652b11c)
