### PR TITLE
remove arrow navigation in menu in the case if there is only one item

### DIFF
--- a/lib/material/internal/material_menu.flow
+++ b/lib/material/internal/material_menu.flow
@@ -2104,7 +2104,6 @@ MMenuLines2MPopup(
 			RMScaleAnimation(),
 			MRippleShape("MMenu"),
 			MFocusHorizontal(false),
-			MFocusVertical(true),
 			MActive(make(true)),
 			AccessRole(popupRole),
 			FAccessAttribute(
@@ -2169,7 +2168,8 @@ MMenuLines2MPopup(
 		|> (\f -> ifArrayPush(f, expandingAnimation, RMExpandingAnimation()))
 		|> (\f -> ifArrayPush(f, elevation == 8., RMClickOutToClose()))
 		|> (\f -> ifArrayPush(f, contains(style0, MMenuNoSnapSize()), RMNoSnapSize()))
-		|> (\f -> concat(f, extractStructMany(style0, MBlockClicks())));
+		|> (\f -> concat(f, extractStructMany(style0, MBlockClicks())))
+		|> (\arr -> ifArrayPush(arr, itemsLen > 1, MFocusVertical(true)));
 
 	MPopup(
 		newItems,


### PR DESCRIPTION
https://trello.com/c/pagm9qUt/23486-its-impossible-to-operate-with-keyboard-in-match-drag-and-drop-mode