### PR TITLE
Flowc callgraph include vars

### DIFF
--- a/tools/flowc/callgraph.flow
+++ b/tools/flowc/callgraph.flow
@@ -104,7 +104,12 @@ symbolUses(prog : FiProgram) -> Tree<string, Set<string>> {
 				setTree(a, free, insertSet(lookupTreeDef(a, free, makeSet()), fn.name))
 			)
 		);
-		fold(module.natives, acc1, \ac, nat ->
+		acc2 = fold(module.globalVars, acc1, \ac, var ->
+			foldSet(fifreevars(var.value), ac, \a, free ->
+				setTree(a, free, insertSet(lookupTreeDef(a, free, makeSet()), var.name))
+			)
+		);
+		fold(module.natives, acc2, \ac, nat ->
 			switch (nat.fallbackLambda) {
 				FiLambda(__, __, __, __): {
 					foldSet(fifreevars(nat.fallbackLambda), ac, \a, free ->
@@ -184,13 +189,32 @@ pathInCallGraph(func_from : string, func_to : string, max_num : int, exclude : S
 	uses = foldTree(symbolUses(prog), makeTree(), \id, uses, acc ->
 		if (containsSet(exclude, id)) acc else setTree(acc, id, differenceSets(uses, exclude))
 	);
-	paths = findAllPathsToMain(mapTree(uses, set2array), [[func_from]], [], func_to, max_num);
-	fcPrintln(
-		"Call paths from '" + func_from + "' to '" + func_to + "':\n" + 
-		concatStrings(map(paths, \path -> "\t" + strGlue(path, " -> ") + "\n")) +
-		(if (length(paths) > max_num) "\n  ... \n" else ""), 
-		prog.config.threadId
-	);
+	goals = if (func_to != "") [func_to] else {
+		list2array(foldTree(prog.names.toplevel, makeList1("main"), \name, decl, acc -> switch (decl) {
+			FiGlobalVar(__,__,__,__,__): Cons(name, acc);
+			default: acc;
+		}));
+	}
+	found_paths = filtermap(goals, \goal -> {
+		paths = findAllPathsToMain(mapTree(uses, set2array), [[func_from]], [], goal, max_num);
+		if (paths == []) None() else Some(Pair(goal, paths));
+	});
+	wrap_str = \s -> "'" + s + "'";
+	if (found_paths == []) {
+		goals_str = if (length(goals) == 1) wrap_str(goals[0]) else {
+			"[" + superglue(goals, \goal -> wrap_str(goal), ", ") + "]";
+		}
+		fcPrintln("No paths from " + func_from + " to " + goals_str + " are found", prog.config.threadId);
+	} else {
+		iter(found_paths, \p ->
+			fcPrintln(
+				"Call paths from " + wrap_str(func_from) + " to " + wrap_str(p.first) + "':\n" +
+				concatStrings(map(p.second, \path -> "\t" + strGlue(path, " -> ") + "\n")) +
+				(if (length(p.second) > max_num) "\n  ... \n" else ""),
+				prog.config.threadId
+			)
+		);
+	}
 }
 
 findAllPathsToMain(uses : Tree<string, [string]>, paths : [[string]], acc : [[string]], func_to : string, max_num : int) -> [[string]] {

--- a/tools/flowc/flowc_local.flow
+++ b/tools/flowc/flowc_local.flow
@@ -134,7 +134,7 @@ doFiProgramAnalysis(env : FcTypeEnvGlobal, prog : FiProgram, onError : (FcError)
 
 	callpathFuncFrom = getConfigParameter(config, "callpath-from");
 	if (callpathFuncFrom != "") {
-		callpathFuncTo = getConfigParameterDef(config, "callpath-to", "main");
+		callpathFuncTo = getConfigParameterDef(config, "callpath-to", "");
 		callpathMaxNum = s2i(getConfigParameterDef(config, "callpath-num", "32"));
 		callpathFuncExclude = buildSet(strSplit(getConfigParameterDef(config, "callpath-exclude", ""), ","));
 		pathInCallGraph(callpathFuncFrom, callpathFuncTo, callpathMaxNum, callpathFuncExclude, prog);

--- a/tools/flowc/flowc_usage.flow
+++ b/tools/flowc/flowc_usage.flow
@@ -180,10 +180,10 @@ printUsage(config) {
 	prih(help,"");
 	prih(help,"      callgraph=<file>          Prints call graph to a file");
 	prih(help,"      callgraph-fullpath=1      Print full path for imported modules in call graph");
-	prih(help,"      callpath-from=<func>      Prints all paths in callgraph from a given function to a function, specified by 'callpath-to' option");
-	prih(help,"      callpath-to=<func>        Additional option to 'callpath-from'. By default is 'main'.");
+	prih(help,"      callpath-from=<func>      Prints all paths in callgraph from a given function/variable to a function/variable, specified by 'callpath-to' option");
+	prih(help,"      callpath-to=<func>        Additional option to 'callpath-from'. When skipped, 'main' and all global variables are used.");
 	prih(help,"      callpath-num=<int>        Limit on the number of paths, which are found by 'callpath-from' option. Default value is 32.");
-	prih(help,"      callpath-exclude=<f1>,<f2>,...,<fn> Exclude the paths with the mentioned functions from the output. Used to reduce the result of callpath-from");
+	prih(help,"      callpath-exclude=<f1>,<f2>,...,<fn> Exclude the paths with the mentioned functions/variables from the output. Used to reduce the result of callpath-from");
 	prih(help,"      importgraph=1             Saves import graph in a 1.dot file. Useful for imports' loop debug, can be explored in graphviz");
 	prih(help,"         simplify=1             Simplifies the import graph in the .dot through transitive reduction");
 	prih(help,"      optimize-imports=1        Print dead imports");

--- a/tools/flowc/flowc_version.flow
+++ b/tools/flowc/flowc_version.flow
@@ -2,5 +2,5 @@
 // Edit 'build-flowc' instead.
 export {
 	flowc_version = "3.0";
-	flowc_git_revision = "fd01c6fbf";
+	flowc_git_revision = "33c7e0e26";
 }


### PR DESCRIPTION
Call paths to global variables are also considered:

`Flow compiler (3rd generation)

Call paths from 'make3DBoxGeometry' to 'prime3DSceneGUIStyle'':
	make3DBoxGeometry -> makeM3DEditor -> makePrimeLyceum3DEditor -> showPrime3DSceneEditDialog -> prime3DSceneGUIStyle
	make3DBoxGeometry -> renderF3DGeometry -> render3dform -> F3DStage -> T3DStage -> makeM3DEditor -> makePrimeLyceum3DEditor -> showPrime3DSceneEditDialog -> prime3DSceneGUIStyle

done in 53.6s`