### PR TITLE
MTabsStyle: Add MListReorderStyle

### DIFF
--- a/lib/material/internal/material_tabs.flow
+++ b/lib/material/internal/material_tabs.flow
@@ -218,11 +218,7 @@ MDynamicTabs2T(manager : MaterialManager, parent : MFocusGroup, m : MDynamicTabs
 									"MTabsButton",
 									concat(focusState, externalState),
 									\focus ->
-										TCopySize(
-											sz,
-											\sz2 -> TShowLazy(fOr(focus.focused, focus.down), \ -> TRectangle([MFill(MGrey(500)), FillOpacity(0.3)], sz2)),
-											true
-										)
+										TGroup2(sz, TShowLazy(fOr(focus.focused, focus.down), \ -> TRectangle([MFill(MGrey(500)), FillOpacity(0.3)], sz)))
 										|> (\t2 -> TConstruct([
 												\ -> fconnect(
 													fmaxA([feq(m.selected, i), focus.down, focus.focused, focus.hover], false),

--- a/lib/material/internal/material_tabs.flow
+++ b/lib/material/internal/material_tabs.flow
@@ -26,6 +26,7 @@ MDynamicTabs2T(manager : MaterialManager, parent : MFocusGroup, m : MDynamicTabs
 	addAction = tryExtractStruct(m.style, MTabsAddAction(\__ -> TEmpty()));
 	elevation = extractStruct(m.style, MElevation(const(if (js) 0. else 2.))).elevation;
 	order = tryExtractStruct(m.style, MListReorder(make([]), const(false)));
+	orderStyle = extractStruct(m.style, MListReorderStyle([MReorderOnDragEnd()])).style;
 	maxHeight = tryExtractStruct(m.style, MMaxHeight(tabsPanelHeight));
 	tabsHeight = make(eitherMap(maxHeight, \mh -> mh.height, tabsPanelHeight));
 	tabsAlign = extractStruct(m.style, MTabsAlign(StartAlign())).direction;
@@ -164,6 +165,7 @@ MDynamicTabs2T(manager : MaterialManager, parent : MFocusGroup, m : MDynamicTabs
 					isIconVisible = make(true);
 					dynArrayPush(iconsVisible, isIconVisible);
 					colorT = fselectLift(fand(const(!isKeepTabColor), feq(m.selected, i)), \selected -> if (selected) Some(indicatorColor) else itemsColor);
+					isActive = make(false);
 
 					(\externalState -> TSelect2(tb.text, colorT, \txt, color ->
 						if (txt != "") {
@@ -197,9 +199,18 @@ MDynamicTabs2T(manager : MaterialManager, parent : MFocusGroup, m : MDynamicTabs
 					))
 					|> TBorderLeftRight(bordersGap / 2.)
 					|> (if (oneLineTitle) TCenterY else TCenter)
+					|> (\f ->
+						if (noDimming)
+							f
+						else
+							TAlpha(
+								fif(isActive, const(1.), const(secondaryTextOpacity)),
+								f
+							)
+					)
+					|> (\f -> eitherMap(addAction, \addAct -> m2t(MCols2A(f, addAct.action(i)), p2), f))
 					|> (\t ->
 						TCopySize2(t, \sz, tr -> {
-							isActive = make(false);
 							TGroup2(
 								MComponent2T(
 									manager,
@@ -208,7 +219,7 @@ MDynamicTabs2T(manager : MaterialManager, parent : MFocusGroup, m : MDynamicTabs
 									concat(focusState, externalState),
 									\focus ->
 										TCopySize(
-											eitherMap(addAction, \addAct -> m2t(MCols2A(sz, addAct.action(i)), p2), sz),
+											sz,
 											\sz2 -> TShowLazy(fOr(focus.focused, focus.down), \ -> TRectangle([MFill(MGrey(500)), FillOpacity(0.3)], sz2)),
 											true
 										)
@@ -220,11 +231,7 @@ MDynamicTabs2T(manager : MaterialManager, parent : MFocusGroup, m : MDynamicTabs
 											], t2)),
 									m2t
 								),
-								if (noDimming) tr
-								else TAlpha(
-									fif(isActive, const(1.), const(secondaryTextOpacity)),
-									tr
-								)
+								tr
 							)
 						})
 					)
@@ -314,7 +321,7 @@ MDynamicTabs2T(manager : MaterialManager, parent : MFocusGroup, m : MDynamicTabs
 								p2,
 								map(t, \tb -> MReorderItem(tb, [])),
 								or.order,
-								concat([MEnabled(or.enabled), MVertical()], grabDelay),
+								concat3([MEnabled(or.enabled), MVertical()], orderStyle, grabDelay),
 								m2t
 							)
 							|> (\t2 -> TAvailableHeight(t2, const(0.))),

--- a/lib/material/material.flow
+++ b/lib/material/material.flow
@@ -902,6 +902,7 @@ export {
 				MListSelectionEnabled(enabled : Transform<[Transform<bool>]>);
 				MOnListClick(enabled : Transform<bool>, onClick : (int) -> void);
 				MListReorder(order : DynamicBehaviour<[int]>, enabled : Transform<bool>);
+				MListReorderStyle(style : [MReorderGridStyle]);
 				// Hide standard "drag_handle" icon which added automatically by MListReorder style
 				MListReorderHideIcon();
 				// Substitutes standard "drag_handle" icon with custom one
@@ -1638,7 +1639,7 @@ export {
 			               MTabsContentBackgroundStyle, MTabsIndicatorColor, MTabsIndicatorHeight, MTabIndicatorOnTop, MLargeView, MThemeColor /* equals to MBackgroundStyle([MFill(color)]) */,
 			               FillOpacity /* equals to MBackgroundStyle([FillOpacity(opacity)]) */, MElevation /* Shadow of the tab (2.0 by default, 0.0 for js) */,
 			               MNoDispose /* Don't dispose tab content after switching to another one */, MPreRender, MTabTitleRescaleEnabled,
-			               MTabWidthLimited, MShowTooltip, MTabsPanelButton, MTabsAddAction, MMaxHeight, MListReorder, MGrabDelay, MNoScroll, MWidth, MScrollStyle /*for content area scroll*/,
+			               MTabWidthLimited, MShowTooltip, MTabsPanelButton, MTabsAddAction, MMaxHeight, MListReorder, MListReorderStyle, MGrabDelay, MNoScroll, MWidth, MScrollStyle /*for content area scroll*/,
 			               MTabsNoDimming, MTabsVerticalSeparators, MTabsHorizontalSeparator, MTabsIconAlign, MTabsAlign, MTabsNoCapitalization,
 			               MTabChangeIndicatorColor, MTabsIconTitleAlign, MTabIconHideable, MTabsPanelShow;
 


### PR DESCRIPTION
This PR adds MListReorderStyle to MTabsStyle and fixes tab header width for MWidthByContent() with MTabsAddAction()
By default MListReorderStyle has MReorderOnDragEnd() because it seems like an expected behavior in most cases
Related PRs: https://git.area9lyceum.com/Lyceum/lyceum/pulls/7814