### PR TITLE
RenderSupport: Add preventStuckModifierKeys to onpointerdown

### DIFF
--- a/platforms/js/RenderSupport.hx
+++ b/platforms/js/RenderSupport.hx
@@ -1385,7 +1385,9 @@ class RenderSupport {
 
 	private static function preventStuckModifierKeys(e : Dynamic, stage : FlowContainer) : Void {
 		try {
-			if (keysPending.keys().hasNext()) {
+			if (keysPending.keys().hasNext() && e.ctrlKey != null && e.altKey != null && e.metaKey != null && e.shiftKey != null) {
+				// Parsing pointer event as key event to check for active modifier keys
+				// parseKeyEvent is used to correctly detect modifiers state and swap ctrl with meta in case it's Mac
 				var ke = parseKeyEvent(e);
 				for (key in keysPending) {
 					if ((key.key == "ctrl" && !ke.ctrl) || (key.key == "alt" && !ke.alt) || (key.key == "meta" && !ke.meta) || (key.key == "shift" && !ke.shift)) {


### PR DESCRIPTION
In some cases modifier keys get stuck when browser loses focus but "blur" event is not fired, in particular when "Mission control" is triggered on mac. This pr adds preventStuckModifierKeys to onpointerdown to check stuck modifiers to fix the issue in this card: https://trello.com/c/HgWoJyV2/410-multiselection-is-often-the-default-on-mac