### PR TITLE
TextClip: Ignore transform if useCheck is true

### DIFF
--- a/lib/material/tests/test_text_metrics_with_scale.flow
+++ b/lib/material/tests/test_text_metrics_with_scale.flow
@@ -1,0 +1,8 @@
+import material/material_ui;
+
+main() {
+	setRendererType("html");
+	manager = makeMaterialManager([]);
+	text = MText("TEST", [MFont(MDisplay3() with size = 164.0)]) |> MAlignEnd |> (\f -> MScale(const(Factor(0.75, 0.75)), f));
+	mrender(manager, true, text) |> ignore;
+}

--- a/platforms/js/TextClip.hx
+++ b/platforms/js/TextClip.hx
@@ -1778,7 +1778,7 @@ class TextClip extends NativeWidgetClip {
 			if (textNodeWidth0 != null && textNodeWidth0 > 0 && textNodeHeight != null && textNodeHeight > 0) {
 				var textNodeWidth = useLetterSpacingFix ? (textNodeWidth0 - style.letterSpacing) : textNodeWidth0;
 				var textWidth =
-					untyped this.transform
+					untyped this.transform && !useCheck
 						? (
 							(textNodeWidth * (1 - Math.pow(untyped this.transform.worldTransform.c, 2)) / untyped this.transform.worldTransform.a)
 							+ Math.abs(textNodeHeight * untyped this.transform.worldTransform.c)

--- a/platforms/js/TextClip.hx
+++ b/platforms/js/TextClip.hx
@@ -1772,18 +1772,11 @@ class TextClip extends NativeWidgetClip {
 		if (nativeWidget != null && metrics != null) {
 			var wordWrap = style.wordWrapWidth != null && style.wordWrap && style.wordWrapWidth > 0;
 			var useCheck = checkTextNodeWidth && !preventCheckTextNodeWidth && !wordWrap;
-			var textNodeMetrics = getTextNodeMetrics(nativeWidget, useCheck);
+			var textNodeMetrics = getTextNodeMetrics(nativeWidget, useCheck, untyped this.transform);
 			var textNodeWidth0 = textNodeMetrics.width;
 			var textNodeHeight = textNodeMetrics.height;
 			if (textNodeWidth0 != null && textNodeWidth0 > 0 && textNodeHeight != null && textNodeHeight > 0) {
-				var textNodeWidth = useLetterSpacingFix ? (textNodeWidth0 - style.letterSpacing) : textNodeWidth0;
-				var textWidth =
-					untyped this.transform && !useCheck
-						? (
-							(textNodeWidth * (1 - Math.pow(untyped this.transform.worldTransform.c, 2)) / untyped this.transform.worldTransform.a)
-							+ Math.abs(textNodeHeight * untyped this.transform.worldTransform.c)
-						)
-						: textNodeWidth;
+				var textWidth = useLetterSpacingFix ? (textNodeWidth0 - style.letterSpacing) : textNodeWidth0;
 				if (textWidth > 0 && textWidth != metrics.width) {
 					metrics.width = textWidth;
 					this.emitEvent('textwidthchanged', textWidth);
@@ -1937,7 +1930,7 @@ class TextClip extends NativeWidgetClip {
 		}
 	}
 
-	private static function getTextNodeMetrics(nativeWidget, useCheck) : Dynamic {
+	private static function getTextNodeMetrics(nativeWidget, useCheck, ?transform = null) : Dynamic {
 		var textNodeMetrics : Dynamic = {};
 		if (nativeWidget == null || nativeWidget.lastChild == null) {
 			textNodeMetrics.width = 0;
@@ -1948,7 +1941,7 @@ class TextClip extends NativeWidgetClip {
 			if (useCheck) {
 				updateTextNodesWidth(untyped nativeWidget.childNodes, textNodeMetrics);
 			}
-			updateTextNodeHeight(textNode, textNodeMetrics, useCheck);
+			updateTextNodeHeight(textNode, textNodeMetrics, useCheck, transform);
 		}
 		return textNodeMetrics;
 	}
@@ -1996,7 +1989,7 @@ class TextClip extends NativeWidgetClip {
 		}
 	}
 
-	private static function updateTextNodeHeight(textNode, textNodeMetrics, useCheck) {
+	private static function updateTextNodeHeight(textNode, textNodeMetrics, useCheck, transform) {
 		if (Browser.document.createRange != null) {
 			var range = Browser.document.createRange();
 			range.selectNodeContents(textNode);
@@ -2004,12 +1997,20 @@ class TextClip extends NativeWidgetClip {
 				var rect = range.getBoundingClientRect();
 				if (rect != null) {
 					var viewportScale = RenderSupport.getViewportScale();
+					textNodeMetrics.height = (rect.bottom - rect.top) * viewportScale;
 					if (!useCheck) {
 						var computedStyle = Browser.window.getComputedStyle(untyped textNode);
 						var letSp = Std.parseFloat(computedStyle.letterSpacing);
-						textNodeMetrics.width = (rect.right - rect.left - (Math.isNaN(letSp) ? 0 : letSp)) * viewportScale;
+						var wd0 = rect.right - rect.left;
+						var wd1 = untyped transform && transform.worldTransform
+							? (
+								(wd0 * (1 - Math.pow(untyped transform.worldTransform.c, 2)) / untyped transform.worldTransform.a)
+								+ Math.abs(textNodeMetrics.height * untyped transform.worldTransform.c)
+							)
+							: wd0;
+						var wd2 = (wd1 - (Math.isNaN(letSp) ? 0 : letSp)) * viewportScale;
+						textNodeMetrics.width = wd2;
 					}
-					textNodeMetrics.height = (rect.bottom - rect.top) * viewportScale;
 				}
 			}
 		}


### PR DESCRIPTION
This PR skips applying transform to `textNodeWidth` in `updateTextWidth` if `useCheck=true`. `getTextNodeMetrics` with `useCheck=true` calls `updateTextNodesWidth` which attaches the svg to the body in `updateTextNodeWidth` ignoring transform applied to the text clip. As result we should skip dividing width by this transform as it was never applied. Not sure if this is a correct and only place to ignore transform.
Added a test `lib/material/tests/test_text_metrics_with_scale.flow`
without fix:
<img width="1680" alt="image" src="https://github.com/area9innovation/flow9/assets/14890073/0a889f69-7a59-4f31-8bfc-fad5f8cfe5e7">
with fix:
<img width="1680" alt="image" src="https://github.com/area9innovation/flow9/assets/14890073/3cb2cc80-3f27-4186-9468-67fcb5dd0d73">