### PR TITLE
MTextStyle: Add BackgroundFill

### DIFF
--- a/lib/fform/fform.flow
+++ b/lib/fform/fform.flow
@@ -227,7 +227,7 @@ export {
 			FAutoAlign, FFocus, FPosition, FSelection, FScrollInfo,
 			FCursorColor, FCursorOpacity, FCursorWidth, FNumericStep, ViewBounds, FAccessProperty,
 			FCharacterStyle, InterlineSpacing, SetRTL, FInputEventFilter, FPreventContextMenu, FPositionSelection,
-			FInputOnSelect, FInputOnSelectAll, FInputOnCopy, FInputOnCompositionEnd;
+			FInputOnSelect, FInputOnSelectAll, FInputOnCopy, FInputOnCompositionEnd, AutofillBackgroundFill;
 
 			FWordWrap(wrap : Transform<bool>);
 			FMultiline(multiline : Transform<bool>);
@@ -267,6 +267,9 @@ export {
 			FInputOnCompositionEnd(fn : () -> void);
 
 			dummyFInputEventFilter = FInputEventFilter(\s, __ -> s);
+
+			// Background color used for autofill suggestions
+			AutofillBackgroundFill : (color : int);
 
 	// Draws content with 'canvas' renderer
 	// Works only in js with 'html' renderer, for other targets identical to regular clip

--- a/lib/fform/renderfform.flow
+++ b/lib/fform/renderfform.flow
@@ -1650,6 +1650,7 @@ renderFForm(rform : FForm, zorder : Transform<[int]>) -> FRenderResult {
 			multiline = extractStruct(style, FMultiline(const(false))).multiline;
 			readOnly = extractStruct(style, FReadOnly(const(false))).readOnly;
 			maxChars = extractStruct(style, FMaxChars(const(-1))).maxChars;
+			autofillBackgroundFill = tryExtractStruct(style, AutofillBackgroundFill(0));
 			numericStep = tryExtractStruct(style, FNumericStep(const(1.)));
 			filterFn = tryExtractStruct(style, FInputFilter(idfn));
 			eventFilterFn = tryExtractStruct(style, dummyFInputEventFilter);
@@ -1667,6 +1668,7 @@ renderFForm(rform : FForm, zorder : Transform<[int]>) -> FRenderResult {
 			// changing multiline leads to recreating on native element so we have to set is first
 			setMultiline(textfield, fgetValue(multiline));
 			defineTextStyle(textfield, getValue(content), fgetValue(characterStyle));
+			maybeApply(autofillBackgroundFill, \afbf -> setAutofillBackgroundColor(textfield, afbf.color));
 
 			disp =
 				concatA([

--- a/lib/fform/sfform.flow
+++ b/lib/fform/sfform.flow
@@ -88,7 +88,7 @@ export {
 	SFTextInput(content : string, wh : WidthHeight, style : [SFTextInputStyle]);
 		SFTextInputStyle ::= CharacterStyle, SWordWrap, SMultiline, SInputType, SReadOnly, SMaxChars, SAutoAlign,
 			SNumericStep, SFocus, SPosition, SSelection, SScrollInfo, SCursorColor, SCursorOpacity, SCursorWidth, SCharacterStyle,
-			SFAccessProperty;
+			SFAccessProperty, AutofillBackgroundFill;
 
 			SWordWrap(wrap : bool);
 			SMultiline(multiline : bool);
@@ -382,6 +382,7 @@ FTextInputStyle2SFTextInputStyle(style : [FTextInputStyle]) -> [SFTextInputStyle
 
 				FCharacterStyle(cs) : Some(SCharacterStyle(fgetValue(cs))); // TODO:
 				SetRTL(__) : None();
+				AutofillBackgroundFill(__): Some(s);
 			}
 		),
 		FAccessProperty2SFAccessProperty(style |> extractFAccessProperties)
@@ -565,6 +566,7 @@ SFTextInputStyle2FTextInputStyle(style : [SFTextInputStyle]) -> [FTextInputStyle
 				FillOpacity(__) : Some(s);
 				FontFamily(__) : Some(s);
 				BackgroundFillOpacity(__) : Some(s);
+				AutofillBackgroundFill(__) : Some(s);
 				default : None();
 			}
 		),

--- a/lib/material/internal/material_textinput_state.flow
+++ b/lib/material/internal/material_textinput_state.flow
@@ -56,6 +56,7 @@ export {
 		selection : DynamicBehaviour<int>,
 		cursorShape : DynamicBehaviour<CursorShape>,
 		textStyle : Transform<[MTextStyle]>,
+		autofillBackgroundFill : Maybe<AutofillBackgroundFill>,
 		tTextMetrics : Transform<FormMetrics>,
 		smallEdit : bool,
 		label : string,
@@ -379,6 +380,7 @@ makeMInputState(manager : MaterialManager, style : [MAutoCompleteStyle], state :
 
 	textStyle = fconcat(extractStruct(style, MDynamicTextStyle(const(mTextStyle))).style, const([LocalizationEnabled(false)]));
 	liftFn : FLift<[MTextStyle], FormMetrics> = FLift(\ts : [MTextStyle] -> getTWordMetrics(TText(" ", MTextStyle2CharacterStyle(parent, ts)), makeTree()));
+	autofillBackgroundFill = tryExtractStruct(style, AutofillBackgroundFill(0));
 	tTextMetrics = fselect(textStyle, liftFn);
 
 	prev = ref getValue(content);
@@ -1238,6 +1240,7 @@ makeMInputState(manager : MaterialManager, style : [MAutoCompleteStyle], state :
 		selection,
 		textInputCursorShape,
 		textStyle,
+		autofillBackgroundFill,
 		tTextMetrics,
 		smallEdit,
 		label,
@@ -2595,6 +2598,12 @@ makeNativeEditorView(manager : MaterialManager, parent : MFocusGroup, state : [M
 								FCharacterStyle(fselect(inputState.textStyle, FLift(\ts : [MTextStyle] -> MTextStyle2CharacterStyle(parent, ts)))),
 								SetRTL(parent.rtl)
 							],
+							eitherMap(
+								inputState.autofillBackgroundFill,
+								\afbf ->
+									[afbf],
+								[]
+							),
 							eitherMap(
 								inputState.autoCompleteType,
 								\ac ->

--- a/lib/material/internal/material_textinput_state.flow
+++ b/lib/material/internal/material_textinput_state.flow
@@ -371,7 +371,8 @@ makeMInputState(manager : MaterialManager, style : [MAutoCompleteStyle], state :
 			extractStructMany(customTextStyle, LetterSpacing(0.0)),
 			extractStructMany(customTextStyle, EscapeHTML(true)),
 			extractStructMany(customTextStyle, MDynamicColor(const(MBlack()))),
-			extractStructMany(customTextStyle, BackgroundFill(0))
+			extractStructMany(customTextStyle, BackgroundFill(0)),
+			extractStructMany(customTextStyle, BackgroundFillOpacity(0.))
 		]);
 
 	textStyle = fconcat(extractStruct(style, MDynamicTextStyle(const(mTextStyle))).style, const([LocalizationEnabled(false)]));

--- a/lib/material/internal/material_textinput_state.flow
+++ b/lib/material/internal/material_textinput_state.flow
@@ -370,7 +370,8 @@ makeMInputState(manager : MaterialManager, style : [MAutoCompleteStyle], state :
 			),
 			extractStructMany(customTextStyle, LetterSpacing(0.0)),
 			extractStructMany(customTextStyle, EscapeHTML(true)),
-			extractStructMany(customTextStyle, MDynamicColor(const(MBlack())))
+			extractStructMany(customTextStyle, MDynamicColor(const(MBlack()))),
+			extractStructMany(customTextStyle, BackgroundFill(0))
 		]);
 
 	textStyle = fconcat(extractStruct(style, MDynamicTextStyle(const(mTextStyle))).style, const([LocalizationEnabled(false)]));

--- a/lib/material/internal/material_theme.flow
+++ b/lib/material/internal/material_theme.flow
@@ -49,6 +49,8 @@ export {
 	MThemedStroke(parent : MaterialManagerOrFocus, color : MThemeColor) -> Stroke { MThemeStroke(parent, color) };
 	MThemeBackgroundFill(parent : MaterialManagerOrFocus, color : MThemeColor) -> BackgroundFill;
 	MThemedBackgroundFill(parent : MaterialManagerOrFocus, color : MThemeColor) -> BackgroundFill { MThemeBackgroundFill(parent, color) };
+	MThemeAutofillBackgroundFill(parent : MaterialManagerOrFocus, color : MThemeColor) -> AutofillBackgroundFill;
+	MThemedAutofillBackgroundFill(parent : MaterialManagerOrFocus, color : MThemeColor) -> AutofillBackgroundFill { MThemeAutofillBackgroundFill(parent, color) };
 
 	FMaterialShape(parent : MFocusGroup, style : [GraphicsStyle], component : string) -> (WidthHeight) -> FForm;
 	MShape(manager : MFocusGroup, style : [TGraphicsStyle], size : Tropic, component : string) -> Tropic;
@@ -710,6 +712,10 @@ MThemeStroke(parent : MaterialManagerOrFocus, color : MThemeColor) -> Stroke {
 
 MThemeBackgroundFill(parent : MaterialManagerOrFocus, color : MThemeColor) -> BackgroundFill {
 	BackgroundFill(MThemeColor2int(parent, color))
+}
+
+MThemeAutofillBackgroundFill(parent : MaterialManagerOrFocus, color : MThemeColor) -> AutofillBackgroundFill {
+	AutofillBackgroundFill(MThemeColor2int(parent, color))
 }
 
 FMaterialShape(parent : MFocusGroup, style : [GraphicsStyle], component : string) -> (WidthHeight) -> FForm {

--- a/lib/material/internal/material_theme.flow
+++ b/lib/material/internal/material_theme.flow
@@ -47,6 +47,8 @@ export {
 	MThemedFill(parent : MaterialManagerOrFocus, color : MThemeColor) -> Fill { MThemeFill(parent, color) };
 	MThemeStroke(parent : MaterialManagerOrFocus, color : MThemeColor) -> Stroke;
 	MThemedStroke(parent : MaterialManagerOrFocus, color : MThemeColor) -> Stroke { MThemeStroke(parent, color) };
+	MThemeBackgroundFill(parent : MaterialManagerOrFocus, color : MThemeColor) -> BackgroundFill;
+	MThemedBackgroundFill(parent : MaterialManagerOrFocus, color : MThemeColor) -> BackgroundFill { MThemeBackgroundFill(parent, color) };
 
 	FMaterialShape(parent : MFocusGroup, style : [GraphicsStyle], component : string) -> (WidthHeight) -> FForm;
 	MShape(manager : MFocusGroup, style : [TGraphicsStyle], size : Tropic, component : string) -> Tropic;
@@ -704,6 +706,10 @@ MThemeFill(parent : MaterialManagerOrFocus, color : MThemeColor) -> Fill {
 
 MThemeStroke(parent : MaterialManagerOrFocus, color : MThemeColor) -> Stroke {
 	Stroke(MThemeColor2int(parent, color))
+}
+
+MThemeBackgroundFill(parent : MaterialManagerOrFocus, color : MThemeColor) -> BackgroundFill {
+	BackgroundFill(MThemeColor2int(parent, color))
 }
 
 FMaterialShape(parent : MFocusGroup, style : [GraphicsStyle], component : string) -> (WidthHeight) -> FForm {

--- a/lib/material/internal/material_typography.flow
+++ b/lib/material/internal/material_typography.flow
@@ -188,30 +188,34 @@ MTextStyle2CharacterStyleDef(parent : MFocusGroup, style : [MParagraphStyle], de
 		intColor = MThemeColor2int(parent, bundle.color);
 		font = MFontStyle2MFont(parent, bundle.fontStyle);
 		backgroundFill = tryExtractStruct(style, BackgroundFill(0));
+		backgroundFillOpacity = tryExtractStruct(style, BackgroundFillOpacity(0.));
 		wrappedFont = eitherMap(
 			parent.theme.fontWrapper,
 			\wrapper -> fgetValue(wrapper).wrapper(font, intColor, bundle.enabled),
 			font
 		);
 		arrayPushMaybe(
-			arrayPush(
-				MFont2CharacterStyle(wrappedFont, intColor == black)
-				|> (\characterStyle ->
-					if (bundle.enabled)
-						arrayPushMaybe(characterStyle, tryExtractStruct(style, FillOpacity(1.0)))
-					else
-						replaceStruct(characterStyle, extractStruct(style, FillOpacity(getDisabledTextOpacity(intColor == black))))
+			arrayPushMaybe(
+				arrayPush(
+					MFont2CharacterStyle(wrappedFont, intColor == black)
+					|> (\characterStyle ->
+						if (bundle.enabled)
+							arrayPushMaybe(characterStyle, tryExtractStruct(style, FillOpacity(1.0)))
+						else
+							replaceStruct(characterStyle, extractStruct(style, FillOpacity(getDisabledTextOpacity(intColor == black))))
+					),
+					Fill(
+						if (bundle.enabled)
+							intColor
+						else if (rgb2cielab(int2rgb(intColor)).l < 50.)
+							black
+						else
+							white
+					)
 				),
-				Fill(
-					if (bundle.enabled)
-						intColor
-					else if (rgb2cielab(int2rgb(intColor)).l < 50.)
-						black
-					else
-						white
-				)
+				backgroundFill
 			),
-			backgroundFill
+			backgroundFillOpacity
 		)
 	})
 	|> (\characterStyle ->
@@ -260,6 +264,7 @@ MCharacterStyle2MTextStyle(style : [CharacterStyle]) -> [MTextStyle] {
 	fill = ref black;
 	fillOpacity = ref primaryTextOpacityDark;
 	backgroundFill = ref None();
+	backgroundFillOpacity = ref None();
 
 	iter(style, \s ->
 		switch (s) {
@@ -267,6 +272,7 @@ MCharacterStyle2MTextStyle(style : [CharacterStyle]) -> [MTextStyle] {
 			FontSize(size) : fontSize := size;
 			Fill(col) : fill := col;
 			BackgroundFill(col) : backgroundFill := Some(BackgroundFill(col));
+			BackgroundFillOpacity(op) : backgroundFill := Some(BackgroundFillOpacity(op));
 			FillOpacity(op) : fillOpacity := op;
 			default : {}
 		}

--- a/lib/material/internal/material_typography.flow
+++ b/lib/material/internal/material_typography.flow
@@ -187,27 +187,31 @@ MTextStyle2CharacterStyleDef(parent : MFocusGroup, style : [MParagraphStyle], de
 	|> (\bundle : MFontStyleBundle -> {
 		intColor = MThemeColor2int(parent, bundle.color);
 		font = MFontStyle2MFont(parent, bundle.fontStyle);
+		backgroundFill = tryExtractStruct(style, BackgroundFill(0));
 		wrappedFont = eitherMap(
 			parent.theme.fontWrapper,
 			\wrapper -> fgetValue(wrapper).wrapper(font, intColor, bundle.enabled),
 			font
 		);
-		arrayPush(
-			MFont2CharacterStyle(wrappedFont, intColor == black)
-			|> (\characterStyle ->
-				if (bundle.enabled)
-					arrayPushMaybe(characterStyle, tryExtractStruct(style, FillOpacity(1.0)))
-				else
-					replaceStruct(characterStyle, extractStruct(style, FillOpacity(getDisabledTextOpacity(intColor == black))))
+		arrayPushMaybe(
+			arrayPush(
+				MFont2CharacterStyle(wrappedFont, intColor == black)
+				|> (\characterStyle ->
+					if (bundle.enabled)
+						arrayPushMaybe(characterStyle, tryExtractStruct(style, FillOpacity(1.0)))
+					else
+						replaceStruct(characterStyle, extractStruct(style, FillOpacity(getDisabledTextOpacity(intColor == black))))
+				),
+				Fill(
+					if (bundle.enabled)
+						intColor
+					else if (rgb2cielab(int2rgb(intColor)).l < 50.)
+						black
+					else
+						white
+				)
 			),
-			Fill(
-				if (bundle.enabled)
-					intColor
-				else if (rgb2cielab(int2rgb(intColor)).l < 50.)
-					black
-				else
-					white
-			)
+			backgroundFill
 		)
 	})
 	|> (\characterStyle ->
@@ -255,18 +259,23 @@ MCharacterStyle2MTextStyle(style : [CharacterStyle]) -> [MTextStyle] {
 	fontSize = ref 14.0;
 	fill = ref black;
 	fillOpacity = ref primaryTextOpacityDark;
+	backgroundFill = ref None();
 
 	iter(style, \s ->
 		switch (s) {
 			FontFamily(name) : fontFamily := name;
 			FontSize(size) : fontSize := size;
 			Fill(col) : fill := col;
+			BackgroundFill(col) : backgroundFill := Some(BackgroundFill(col));
 			FillOpacity(op) : fillOpacity := op;
 			default : {}
 		}
 	);
 
-	[MCustomColor(^fill), MCustomFont(^fontSize, ^fontFamily, ^fillOpacity)]
+	arrayPushMaybe(
+		[MCustomColor(^fill), MCustomFont(^fontSize, ^fontFamily, ^fillOpacity)],
+		^backgroundFill
+	)
 }
 
 MFontStyle2MFont(parent : MFocusGroup, style : MFontStyle) -> MFont {

--- a/lib/material/material.flow
+++ b/lib/material/material.flow
@@ -190,7 +190,7 @@ export {
 		//
 		MText(text : string, style : [MTextStyle]);
 			MTextStyle ::= MFontStyle, MThemeColor, MDynamicColor, MTextDisabled, Underlined, EscapeHTML, NeedBaseline,
-				LetterSpacing, WordSpacing, LineHeightPercent, TagName, LangAttribute, LocalizationEnabled, FillOpacity, SetRTL, BackgroundFill;
+				LetterSpacing, WordSpacing, LineHeightPercent, TagName, LangAttribute, LocalizationEnabled, FillOpacity, SetRTL, BackgroundFill, BackgroundFillOpacity;
 
 				MTextDisabled();
 				MDynamicColor(color : Transform<MThemeColor>); // Overrides MColor/MThemeColor

--- a/lib/material/material.flow
+++ b/lib/material/material.flow
@@ -520,7 +520,7 @@ export {
 
 				// Text input spec with stroke outline.
 				// https://material.io/design/components/text-fields.html#outlined-text-field
-				MOutlined, MOutlineOpacity, MFullHeight, MInactiveOpacity;
+				MOutlined, MOutlineOpacity, MFullHeight, MInactiveOpacity, AutofillBackgroundFill;
 
 					// Move the label above the input on focus
 					MFloatingLabel();

--- a/lib/material/material.flow
+++ b/lib/material/material.flow
@@ -190,7 +190,7 @@ export {
 		//
 		MText(text : string, style : [MTextStyle]);
 			MTextStyle ::= MFontStyle, MThemeColor, MDynamicColor, MTextDisabled, Underlined, EscapeHTML, NeedBaseline,
-				LetterSpacing, WordSpacing, LineHeightPercent, TagName, LangAttribute, LocalizationEnabled, FillOpacity, SetRTL;
+				LetterSpacing, WordSpacing, LineHeightPercent, TagName, LangAttribute, LocalizationEnabled, FillOpacity, SetRTL, BackgroundFill;
 
 				MTextDisabled();
 				MDynamicColor(color : Transform<MThemeColor>); // Overrides MColor/MThemeColor

--- a/lib/material/material_color.flow
+++ b/lib/material/material_color.flow
@@ -131,6 +131,7 @@ export {
 	// Fill and Stroke with MaterialColor
 	MFill(mcolor : MColor) -> Fill;
 	MStroke(mcolor : MColor) -> Stroke;
+	MBackgroundFill(mcolor : MColor) -> BackgroundFill;
 
 	// Available MColor int values
 	mColorPaletteValues : [int];
@@ -413,6 +414,10 @@ MFill(mcolor : MColor) -> Fill {
 
 MStroke(mcolor : MColor) -> Stroke {
 	Stroke(MColor2int(mcolor))
+}
+
+MBackgroundFill(mcolor : MColor) -> BackgroundFill {
+	BackgroundFill(MColor2int(mcolor))
 }
 
 mColorName2s(color : MColor) -> string {

--- a/lib/rendersupport.flow
+++ b/lib/rendersupport.flow
@@ -202,6 +202,7 @@ export {
 	native setFocus : io (native, bool) -> void = RenderSupport.setFocus;
 	native setReadOnly : io (native, bool) -> void = RenderSupport.setReadOnly;
 	native setMaxChars : io (native, int) -> void = RenderSupport.setMaxChars;
+	native setAutofillBackgroundColor : io (native, int) -> void = RenderSupport.setAutofillBackgroundColor;
 	native setCursor : io (string) -> void = RenderSupport.setCursor;
 	native getCursor : io () -> string = RenderSupport.getCursor;
 	// makeWebClip(url, domain, updateCachedContent, reloadBlock, flowCallback, onDone, shrink2fit);
@@ -533,6 +534,7 @@ setTextWordSpacing(textfield, spacing) {}
 setContentRect(clip, width, height) {}
 listenScrollRect(clip, cb) { nop; }
 setApplicationLanguage(lang) { }
+setAutofillBackgroundColor(textfield, color) {}
 
 getSafeArea() { [0.0, 0.0, 0.0, 0.0]; }
 

--- a/platforms/js/RenderSupport.hx
+++ b/platforms/js/RenderSupport.hx
@@ -2521,6 +2521,10 @@ class RenderSupport {
 		clip.setMaxChars(maxChars);
 	}
 
+	public static function setAutofillBackgroundColor(clip : TextClip, autofillBackgroundColor : Int) : Void {
+		clip.setAutofillBackgroundColor(autofillBackgroundColor);
+	}
+
 	public static function addTextInputFilter(clip : TextClip, filter : String -> String) : Void -> Void {
 		return clip.addTextInputFilter(filter);
 	}

--- a/platforms/js/RenderSupportNodeJs.hx
+++ b/platforms/js/RenderSupportNodeJs.hx
@@ -149,6 +149,8 @@ class RenderSupport {
 
 	public static function setMaxChars(textfield : Dynamic, maxChars : Int) : Void {}
 
+	public static function setAutofillBackgroundColor(textfield : Dynamic, autofillBackgroundColor : Int) : Void {}
+
 	// native addChild : (parent : native, child : native) -> void
 	public static function addChild(parent : Dynamic, child : Dynamic) : Void {}
 

--- a/platforms/js/TextClip.hx
+++ b/platforms/js/TextClip.hx
@@ -449,6 +449,8 @@ class TextClip extends NativeWidgetClip {
 		super.updateNativeWidgetStyle();
 		var alpha = this.getNativeWidgetAlpha();
 
+		var bg = !this.isHTMLRenderer() || backgroundOpacity > 0 ? RenderSupport.makeCSSColor(backgroundColor, backgroundOpacity) : null;
+
 		if (isInput) {
 			nativeWidget.setAttribute("inputMode", type == 'number' ? 'numeric' : type);
 			if (!multiline) {
@@ -485,8 +487,9 @@ class TextClip extends NativeWidgetClip {
 				default : null;
 			}
 
+			var slicedColor : Array<String> = style.fill.split(",");
+
 			if (Platform.isEdge || Platform.isIE) {
-				var slicedColor : Array<String> = style.fill.split(",");
 				var newColor = slicedColor.slice(0, 3).join(",") + "," + Std.parseFloat(slicedColor[3]) * (isFocused ? alpha : 0) + ")";
 
 				nativeWidget.style.color = newColor;
@@ -495,11 +498,11 @@ class TextClip extends NativeWidgetClip {
 				nativeWidget.style.color = style.fill;
 			}
 
-			var bg = !this.isHTMLRenderer() || backgroundOpacity > 0 ? RenderSupport.makeCSSColor(backgroundColor, backgroundOpacity) : null;
-			if (bg && nativeWidget) {
+			if (bg) {
+				var colorWithOpacity = slicedColor.slice(0, 3).join(",") + "," + Std.parseFloat(slicedColor[3]) * alpha + ")";
 				// These variables are used in the flowjspixi.css file for input:-webkit-autofill workaround
 				nativeWidget.style.setProperty('--background-color', bg);
-				nativeWidget.style.setProperty('--text-color', nativeWidget.style.color);
+				nativeWidget.style.setProperty('--text-color', colorWithOpacity);
 			}
 		} else {
 			if (escapeHTML) {
@@ -550,7 +553,6 @@ class TextClip extends NativeWidgetClip {
 		nativeWidget.style.fontWeight = !this.isHTMLRenderer() || style.fontWeight != 400 ? style.fontWeight : null;
 		nativeWidget.style.fontStyle = !this.isHTMLRenderer() || style.fontStyle != 'normal' ? style.fontStyle : null;
 		nativeWidget.style.fontSize = '${style.fontSize}px';
-		var bg = !this.isHTMLRenderer() || backgroundOpacity > 0 ? RenderSupport.makeCSSColor(backgroundColor, backgroundOpacity) : null;
 		if (textBackgroundWidget != null) {
 			textBackgroundWidget.style.background = bg;
 		} else {

--- a/platforms/js/TextClip.hx
+++ b/platforms/js/TextClip.hx
@@ -494,6 +494,13 @@ class TextClip extends NativeWidgetClip {
 				nativeWidget.style.opacity = (RenderSupport.RendererType != "canvas" || isFocused) ? alpha : 0;
 				nativeWidget.style.color = style.fill;
 			}
+
+			var bg = !this.isHTMLRenderer() || backgroundOpacity > 0 ? RenderSupport.makeCSSColor(backgroundColor, backgroundOpacity) : null;
+			if (bg && nativeWidget) {
+				// These variables are used in the flowjspixi.css file for input:-webkit-autofill workaround
+				nativeWidget.style.setProperty('--background-color', bg);
+				nativeWidget.style.setProperty('--text-color', nativeWidget.style.color);
+			}
 		} else {
 			if (escapeHTML) {
 				if (Platform.isIE && isMaterialIconFont()) {

--- a/platforms/js/TextClip.hx
+++ b/platforms/js/TextClip.hx
@@ -134,6 +134,7 @@ class TextClip extends NativeWidgetClip {
 	private var contentGlyphsDirection : String = '';
 	public var charIdx : Int = 0;
 	private var backgroundColor : Int = 0;
+	private var autofillBackgroundColor : Int = null;
 	private var backgroundOpacity : Float = 0.0;
 	private var cursorColor : Int = -1;
 	private var cursorOpacity : Float = -1.0;
@@ -449,8 +450,6 @@ class TextClip extends NativeWidgetClip {
 		super.updateNativeWidgetStyle();
 		var alpha = this.getNativeWidgetAlpha();
 
-		var bg = !this.isHTMLRenderer() || backgroundOpacity > 0 ? RenderSupport.makeCSSColor(backgroundColor, backgroundOpacity) : null;
-
 		if (isInput) {
 			nativeWidget.setAttribute("inputMode", type == 'number' ? 'numeric' : type);
 			if (!multiline) {
@@ -498,10 +497,10 @@ class TextClip extends NativeWidgetClip {
 				nativeWidget.style.color = style.fill;
 			}
 
-			if (bg) {
+			if (autofillBackgroundColor != null) {
 				var colorWithOpacity = slicedColor.slice(0, 3).join(",") + "," + Std.parseFloat(slicedColor[3]) * alpha + ")";
 				// These variables are used in the flowjspixi.css file for input:-webkit-autofill workaround
-				nativeWidget.style.setProperty('--background-color', bg);
+				nativeWidget.style.setProperty('--background-color', RenderSupport.makeCSSColor(autofillBackgroundColor, 1));
 				nativeWidget.style.setProperty('--text-color', colorWithOpacity);
 			}
 		} else {
@@ -553,6 +552,7 @@ class TextClip extends NativeWidgetClip {
 		nativeWidget.style.fontWeight = !this.isHTMLRenderer() || style.fontWeight != 400 ? style.fontWeight : null;
 		nativeWidget.style.fontStyle = !this.isHTMLRenderer() || style.fontStyle != 'normal' ? style.fontStyle : null;
 		nativeWidget.style.fontSize = '${style.fontSize}px';
+		var bg = !this.isHTMLRenderer() || backgroundOpacity > 0 ? RenderSupport.makeCSSColor(backgroundColor, backgroundOpacity) : null;
 		if (textBackgroundWidget != null) {
 			textBackgroundWidget.style.background = bg;
 		} else {
@@ -1146,6 +1146,14 @@ class TextClip extends NativeWidgetClip {
 	public function setMaxChars(maxChars : Int) {
 		if (this.maxChars != maxChars) {
 			this.maxChars = maxChars;
+
+			invalidateStyle();
+		}
+	}
+
+	public function setAutofillBackgroundColor(autofillBackgroundColor : Int) {
+		if (this.autofillBackgroundColor != autofillBackgroundColor) {
+			this.autofillBackgroundColor = autofillBackgroundColor;
 
 			invalidateStyle();
 		}

--- a/www/flowjspixi.css
+++ b/www/flowjspixi.css
@@ -245,3 +245,16 @@ input.no_numeric_arrows::-webkit-outer-spin-button {
 .textBackgroundLayer {
 	z-index: -3;
 }
+
+input:root {
+	--text-color: unset;
+	--background-color: unset;
+}
+
+/* Workaround for Chrome autofill color */
+input:-webkit-autofill,
+input:-webkit-autofill:hover,
+input:-webkit-autofill:focus {
+	-webkit-text-fill-color: var(--text-color) !important;
+	box-shadow: 0 0 0px 1000px var(--background-color) inset;
+}


### PR DESCRIPTION
This PR adds BackgroundFill to MTextStyle and implements a workaround for autofill inputs in chrome to enforce background color.
Related PRs: https://trello.com/c/VhbGwsyZ/568-use-dark-background-for-login-text-inputs