### PR TITLE
MTextInputStyle: Add MFullHeight, MInactiveOpacity

### DIFF
--- a/lib/material/internal/material_textinput_state.flow
+++ b/lib/material/internal/material_textinput_state.flow
@@ -73,6 +73,7 @@ export {
 		width : double,
 		textWidth : DynamicBehaviour<double>,
 		maxHeight : double,
+		fullHeight : bool,
 		align : AutoAlignType,
 		iconSize : double,
 		iconBorders : double,
@@ -344,6 +345,7 @@ makeMInputState(manager : MaterialManager, style : [MAutoCompleteStyle], state :
 	width = extractStruct(style, MWidth(-1.)).width;
 	textWidth = make(0.);
 	maxHeight = extractStruct(style, MMaxHeight(-1.)).height;
+	fullHeight = contains(style, MFullHeight());
 	align = extractStruct(style, AutoAlign(AutoAlignNone())).autoalign;
 	filterAction = iScriptBehaviours.filterAction;
 	smallEdit = contains(style, MEditDialog());
@@ -537,7 +539,7 @@ makeMInputState(manager : MaterialManager, style : [MAutoCompleteStyle], state :
 
 	// Floating Label
 	inactiveColor = contrastingColor(parent);
-	inactiveOpacity = defaultInactiveItemLabelOpacity(MColor2int(color) == black);
+	inactiveOpacity = extractStruct(style, MInactiveOpacity(defaultInactiveItemLabelOpacity(MColor2int(color) == black))).opacity;
 
 	unfocusedUnderline = extractStruct(style, MUnderlineUnfocusedStyle([Fill(inactiveColor), FillOpacity(inactiveOpacity / 4.)])).style;
 
@@ -1251,6 +1253,7 @@ makeMInputState(manager : MaterialManager, style : [MAutoCompleteStyle], state :
 		width,
 		textWidth,
 		maxHeight,
+		fullHeight,
 		align,
 		iconSize,
 		iconBorders,
@@ -1465,7 +1468,7 @@ makeMTextEditorState(inputState : MInputState) -> MTextEditorState {
 		[
 			TScrollbars(
 				invisibleScrollBar,
-				if (multiline && linesCount != 0 && linesCount != -1)
+				if ((multiline && linesCount != 0 && linesCount != -1) || inputState.fullHeight)
 					getMaterialScrollBar().y
 				else
 					invisibleScrollBar
@@ -2442,7 +2445,7 @@ makeMTextEditorView(manager : MaterialManager, inputState : MInputState, m2t : (
 
 		MScroll(
 			f,
-			TFillXHT(boxHeight),
+			if (inputState.fullHeight) TFillXY() else TFillXHT(boxHeight),
 			editorState.scrollStyle
 		)
 		|> (\f2 -> MScroll2T(manager, inputState.parent, f2, m2t))
@@ -2502,7 +2505,9 @@ makeNativeEditorView(manager : MaterialManager, parent : MFocusGroup, state : [M
 				TCols2(TWidth(TGhost("MTextInputText")), TFixed(4., 0.))
 			else
 				TFillX(),
-			if (inputState.multiline) {
+			if (inputState.fullHeight) {
+				TFillY()
+			} else if (inputState.multiline) {
 				if (inputState.linesCount == 0 || inputState.linesCount == -1) {
 					inputFlexibleSize();
 				} else if (inputState.linesCount > 0) {

--- a/lib/material/material.flow
+++ b/lib/material/material.flow
@@ -520,7 +520,7 @@ export {
 
 				// Text input spec with stroke outline.
 				// https://material.io/design/components/text-fields.html#outlined-text-field
-				MOutlined, MOutlineOpacity;
+				MOutlined, MOutlineOpacity, MFullHeight, MInactiveOpacity;
 
 					// Move the label above the input on focus
 					MFloatingLabel();
@@ -600,6 +600,8 @@ export {
 					MTextInputAllowEmojis(allowEmojis : bool);
 					// Deprecated. Do not use.
 					MInputFontPadding(padding : double);
+					// Opacity of inactive input label, underline (divided by 4, use MUnderlineUnfocusedStyle to override) and password icon
+					MInactiveOpacity(opacity : double);
 
 			MAutoCompleteStyle ::=
 				MTextInputStyle, MCompletionFn, TCompletionFn, MSentenceMatcher, MPreparedSentenceMatcher, MDictionaryDynamic,


### PR DESCRIPTION
This PR adds MFullHeight style that allows MTextInput to take full available height and MInactiveOpacity that allows to change opacity for inactive MTextInput elements.