### PR TITLE
TextClip: Disable useCheck if escapeHTML is true

### DIFF
--- a/lib/material/tests/escape_html_test.flow
+++ b/lib/material/tests/escape_html_test.flow
@@ -1,0 +1,9 @@
+import material/material_ui;
+
+main() {
+	setRendererType("html");
+	manager = makeMaterialManager([]);
+	text = MParagraph(_("Be <span style=\"font-family:Roboto\">clear</span> and <span style=\"font-family:Roboto\">precise</span>, clearly communicating the <span style=\"font-family:Roboto\">course content</span>."), [EscapeHTML(false)])
+	|> MDebugMetricsBlue;
+	mrender(manager, true, text) |> ignore;
+}

--- a/lib/material/tests/escape_html_test.flow
+++ b/lib/material/tests/escape_html_test.flow
@@ -5,5 +5,5 @@ main() {
 	manager = makeMaterialManager([]);
 	text = MParagraph(_("Be <span style=\"font-family:Roboto\">clear</span> and <span style=\"font-family:Roboto\">precise</span>, clearly communicating the <span style=\"font-family:Roboto\">course content</span>."), [EscapeHTML(false)])
 	|> MDebugMetricsBlue;
-	mrender(manager, true, text) |> ignore;
+	timer(1000, \ -> mrender(manager, true, text) |> ignore);
 }

--- a/platforms/js/TextClip.hx
+++ b/platforms/js/TextClip.hx
@@ -1823,7 +1823,7 @@ class TextClip extends NativeWidgetClip {
 	private function updateTextWidth() : Void {
 		if (nativeWidget != null && metrics != null) {
 			var wordWrap = style.wordWrapWidth != null && style.wordWrap && style.wordWrapWidth > 0;
-			var useCheck = checkTextNodeWidth && !preventCheckTextNodeWidth && !wordWrap;
+			var useCheck = checkTextNodeWidth && !preventCheckTextNodeWidth && !wordWrap && escapeHTML;
 			var textNodeMetrics = getTextNodeMetrics(nativeWidget, useCheck, untyped this.transform);
 			var textNodeWidth0 = textNodeMetrics.width;
 			var textNodeHeight = textNodeMetrics.height;
@@ -1928,7 +1928,7 @@ class TextClip extends NativeWidgetClip {
 		var wordWrap = style.wordWrapWidth != null && style.wordWrap && style.wordWrapWidth > 0;
 		var parentNode : Dynamic = nativeWidget.parentNode;
 		var nextSibling : Dynamic = nativeWidget.nextSibling;
-		var useCheck = checkTextNodeWidth && !preventCheckTextNodeWidth;
+		var useCheck = checkTextNodeWidth && !preventCheckTextNodeWidth && escapeHTML;
 
 		updateNativeWidgetStyle();
 		var tempDisplay = nativeWidget.style.display;

--- a/platforms/js/TextClip.hx
+++ b/platforms/js/TextClip.hx
@@ -1737,7 +1737,7 @@ class TextClip extends NativeWidgetClip {
 				var contentGlyphsModified = untyped __js__("this.contentGlyphs.modified.replace(/<\\/?[^>]+(>|$)/g, '')");
 				metrics = TextMetrics.measureText(contentGlyphsModified, style);
 				if (this.isHTMLRenderer()) {
-					measureHTMLWidthAndHeight();
+					measureHTMLWidth();
 				}
 			} else {
 				metrics = TextMetrics.measureText(this.contentGlyphs.modified, style);
@@ -1823,7 +1823,7 @@ class TextClip extends NativeWidgetClip {
 	private function updateTextWidth() : Void {
 		if (nativeWidget != null && metrics != null) {
 			var wordWrap = style.wordWrapWidth != null && style.wordWrap && style.wordWrapWidth > 0;
-			var useCheck = checkTextNodeWidth && !preventCheckTextNodeWidth && !wordWrap && escapeHTML;
+			var useCheck = checkTextNodeWidth && !preventCheckTextNodeWidth && !wordWrap;
 			var textNodeMetrics = getTextNodeMetrics(nativeWidget, useCheck, untyped this.transform);
 			var textNodeWidth0 = textNodeMetrics.width;
 			var textNodeHeight = textNodeMetrics.height;
@@ -1928,7 +1928,7 @@ class TextClip extends NativeWidgetClip {
 		var wordWrap = style.wordWrapWidth != null && style.wordWrap && style.wordWrapWidth > 0;
 		var parentNode : Dynamic = nativeWidget.parentNode;
 		var nextSibling : Dynamic = nativeWidget.nextSibling;
-		var useCheck = checkTextNodeWidth && !preventCheckTextNodeWidth && escapeHTML;
+		var useCheck = checkTextNodeWidth && !preventCheckTextNodeWidth;
 
 		updateNativeWidgetStyle();
 		var tempDisplay = nativeWidget.style.display;


### PR DESCRIPTION
This PR disables useCheck for TextClip in case escapeHTML is true. Attached a test to reproduce the problem:
`lib/material/tests/escape_html_test.flow`
Before fix:
<img width="645" alt="image" src="https://github.com/area9innovation/flow9/assets/14890073/76c2f992-a9ec-40b3-b84b-c6757bb591e8">
After fix:
<img width="679" alt="image" src="https://github.com/area9innovation/flow9/assets/14890073/f13c7fc0-4d25-4d06-827a-fec5e8f35cb9">