### PR TITLE
[splitByNumber] Use tail recursion to avoid out of memory error

### DIFF
--- a/lib/ds/array.flow
+++ b/lib/ds/array.flow
@@ -614,16 +614,18 @@ splitByNumber(a : [?], n : int) -> [[?]]{
 	if (length(a) <= n || n <= 0) {
 		[a];
 	} else {
-		// Use tail recursion to avoid memory leaks (e.g. with 2M elements in a splitted by 1k)
-		splitByNumber1(subrange(a, n, length(a)-n), n, [subrange(a, 0, n)]);
+		// Use tail recursion to avoid out of memory error (e.g. with 2M elements in a splitted by 1k)
+		splitByNumber1(a, 0, n, []);
 	}
 }
 
-splitByNumber1(a : [?], n : int, acc : [[?]]) -> [[?]]{
+splitByNumber1(a : [?], i : int, n : int, acc : [[?]]) -> [[?]]{
 	if (length(a) <= n || n <= 0) { 
 		concat(acc, [a]);
+	} else if (length(a) <= i) {
+		acc;
 	} else {
-		splitByNumber1(subrange(a, n, length(a)-n), n, concat(acc, [subrange(a, 0, n)]))
+		splitByNumber1(a, i + n, n, concat(acc, [subrange(a, i, n)]))
 	}
 }
 

--- a/lib/ds/array.flow
+++ b/lib/ds/array.flow
@@ -611,11 +611,19 @@ split(a : [?], f : (?) -> bool) {
 }
 
 splitByNumber(a : [?], n : int) -> [[?]]{
-	l = length(a);
-	if (l <= n || n <= 0) {
+	if (length(a) <= n || n <= 0) {
 		[a];
 	} else {
-		concat([subrange(a, 0, n)], splitByNumber(subrange(a, n, l-n), n))
+		// Use tail recursion to avoid memory leaks (e.g. with 2M elements in a splitted by 1k)
+		splitByNumber1(subrange(a, n, length(a)-n), n, [subrange(a, 0, n)]);
+	}
+}
+
+splitByNumber1(a : [?], n : int, acc : [[?]]) -> [[?]]{
+	if (length(a) <= n || n <= 0) { 
+		concat(acc, [a]);
+	} else {
+		splitByNumber1(subrange(a, n, length(a)-n), n, concat(acc, [subrange(a, 0, n)]))
 	}
 }
 

--- a/lib/ds/array.flow
+++ b/lib/ds/array.flow
@@ -620,12 +620,10 @@ splitByNumber(a : [?], n : int) -> [[?]]{
 }
 
 splitByNumber1(a : [?], i : int, n : int, acc : [[?]]) -> [[?]]{
-	if (length(a) <= n || n <= 0) { 
-		concat(acc, [a]);
-	} else if (length(a) <= i) {
+	if (length(a) <= i) {
 		acc;
 	} else {
-		splitByNumber1(a, i + n, n, concat(acc, [subrange(a, i, n)]))
+		splitByNumber1(a, i + n, n, arrayPush(acc, subrange(a, i, n)));
 	}
 }
 


### PR DESCRIPTION
During the test with Bridge's fixup for creator, we see that browser crash if there are 2M of contents ids that should be slitted in group of 1k ids.
The cause is the recursion in splitByNumber, so I modify it to use tail recursion