### PR TITLE
Do not use `fold` in `fmaxA`, `fminA`

### DIFF
--- a/lib/fusion.flow
+++ b/lib/fusion.flow
@@ -1843,33 +1843,6 @@ fmerge(a : [Transform<?>]) -> Transform<[?]> {
 		ConstBehaviour([])
 }
 
-fmergeBalanced(a : [Transform<?>]) -> Transform<[?]> {
-	if (length(a) > 0) {
-		foldTreeBinary(
-			pairs2tree(mapi(a, \i : int, v : Transform<?> -> Pair(i, Some(v)))),
-			\__, v : Maybe<Transform<?>>, l : Maybe<Transform<[?]>>, r : Maybe<Transform<[?]>> -> {
-				maybeMap(v, \vv : Transform<?> -> eitherFn(l,
-					\ll -> eitherMap(r,
-						\rr : Transform<[?]> -> {
-							fselect3(ll, vv, rr, \lll, vvv, rrr -> concat3(lll, [vvv], rrr))
-						},
-						fselect2(ll, vv, FLift2(arrayPush))
-					),
-					\ -> eitherMap(r,
-						\rr : Transform<[?]> -> {
-							fselect2(vv, rr, FLift2(\vvv, rrr -> concat([vvv], rrr)))
-						},
-						fselect(vv, FLift(v2a))
-					)
-				))
-			},
-			None()
-		) |> (\f -> either(f, const([])))
-	} else {
-		const([])
-	}
-}
-
 fmergeTree(tree : Tree<??, Transform<?>>) -> Transform<Tree<??, ?>> {
 	if (sizeTree(tree) > 0)
 		fselect(

--- a/lib/fusion.flow
+++ b/lib/fusion.flow
@@ -1530,14 +1530,26 @@ fmin3(b1 : Transform<?>, b2 : Transform<?>, b3 : Transform<?>) -> Transform<?> {
 
 fmaxA(v : [Transform<?>], def : ?) -> Transform<?> {
 	if (length(v) > 0)
-		fselect(fmerge(v), FLift(\arr -> either(maxA(arr), def)))
+		foldTreeBinary(
+			pairs2tree(mapi(v, \k : int, vv : Transform<?> -> Pair(k, vv))),
+			\__ : int, vv : Transform<?>, ll : Transform<?>, rr : Transform<?> -> {
+				fmax3(ll, vv, rr)
+			},
+			ConstBehaviour(def)
+		)
 	else
 		ConstBehaviour(def)
 }
 
 fminA(v : [Transform<?>], def : ?) -> Transform<?> {
 	if (length(v) > 0)
-		fselect(fmerge(v), FLift(\arr -> either(minA(arr), def)))
+		foldTreeBinary(
+			pairs2tree(mapi(v, \k : int, vv : Transform<?> -> Pair(k, vv))),
+			\__ : int, vv : Transform<?>, ll : Transform<?>, rr : Transform<?> -> {
+				fmin3(ll, vv, rr)
+			},
+			ConstBehaviour(def)
+		)
 	else
 		ConstBehaviour(def)
 }

--- a/lib/fusion.flow
+++ b/lib/fusion.flow
@@ -1529,33 +1529,34 @@ fmin3(b1 : Transform<?>, b2 : Transform<?>, b3 : Transform<?>) -> Transform<?> {
 }
 
 fmaxA(v : [Transform<?>], def : ?) -> Transform<?> {
-	if (length(v) > 0)
-		fMaxMin(v, fmax)
+	l = length(v);
+	if (l > 0)
+		fMaxMin(v, 0, l - 1, fmax)
 	else
 		ConstBehaviour(def)
 }
 
 fminA(v : [Transform<?>], def : ?) -> Transform<?> {
-	if (length(v) > 0)
-		fMaxMin(v, fmin)
+	l = length(v);
+	if (l > 0)
+		fMaxMin(v, 0, l - 1, fmin)
 	else
 		ConstBehaviour(def)
 }
 
-fMaxMin(v : [Transform<?>], fn : (Transform<?>, Transform<?>) -> Transform<?>) -> Transform<?> {
-	len = length(v);
-	middle = len / 2;
-	left = if (middle > 1) fMaxMin(subrange(v, 0, middle), fn) else v[0];
-	right = if (len - middle > 1) fMaxMin(subrange(v, middle, len - middle), fn) else v[len - 1];
+fMaxMin(v : [Transform<?>], start : int, end : int, fn : (Transform<?>, Transform<?>) -> Transform<?>) -> Transform<?> {
+	pivot = (start + end) / 2;
+	left = if (pivot > start) fMaxMin(v, start, pivot, fn) else v[start];
+	right = if (end - pivot > 1) fMaxMin(v, pivot + 1, end, fn) else v[end];
 	fn(left, right);
 }
 
 farray(v1 : Transform<?>) -> Transform<[?]> {
-	fselect(v1, FLift(\v -> [v]))
+	fselect(v1, FLift(v2a))
 }
 
 fconcat(v1 : Transform<[?]>, v2 : Transform<[?]>) -> Transform<[?]> {
-	fselect2(v1, v2, concat |> FLift2)
+	fselect2(v1, v2, FLift2(concat))
 }
 
 farrayPush(v1 : Transform<[?]>, v2 : Transform<?>) -> Transform<[?]> {

--- a/lib/fusion.flow
+++ b/lib/fusion.flow
@@ -1531,12 +1531,19 @@ fmin3(b1 : Transform<?>, b2 : Transform<?>, b3 : Transform<?>) -> Transform<?> {
 fmaxA(v : [Transform<?>], def : ?) -> Transform<?> {
 	if (length(v) > 0)
 		foldTreeBinary(
-			pairs2tree(mapi(v, \k : int, vv : Transform<?> -> Pair(k, vv))),
-			\__ : int, vv : Transform<?>, ll : Transform<?>, rr : Transform<?> -> {
-				fmax3(ll, vv, rr)
+			pairs2tree(mapi(v, \k : int, vv : Transform<?> -> Pair(k, Some(vv)))),
+			\__ : int, vv : Maybe<Transform<?>>, ll : Maybe<Transform<?>>, rr : Maybe<Transform<?>> -> {
+				maybeMap(vv, \vvv -> eitherFn(ll,
+					\lll -> {
+						m = fmax(vvv, lll);
+						eitherMap(rr, \rrr -> fmax(m, rrr), m)
+					},
+					\ -> eitherMap(rr, \rrr -> fmax(vvv, rrr), vvv)
+				))
 			},
-			ConstBehaviour(def)
+			None()
 		)
+		|> (\f -> either(f, const(def)))
 	else
 		ConstBehaviour(def)
 }
@@ -1544,12 +1551,19 @@ fmaxA(v : [Transform<?>], def : ?) -> Transform<?> {
 fminA(v : [Transform<?>], def : ?) -> Transform<?> {
 	if (length(v) > 0)
 		foldTreeBinary(
-			pairs2tree(mapi(v, \k : int, vv : Transform<?> -> Pair(k, vv))),
-			\__ : int, vv : Transform<?>, ll : Transform<?>, rr : Transform<?> -> {
-				fmin3(ll, vv, rr)
+			pairs2tree(mapi(v, \k : int, vv : Transform<?> -> Pair(k, Some(vv)))),
+			\__ : int, vv : Maybe<Transform<?>>, ll : Maybe<Transform<?>>, rr : Maybe<Transform<?>> -> {
+				maybeMap(vv, \vvv -> eitherFn(ll,
+					\lll -> {
+						m = fmin(vvv, lll);
+						eitherMap(rr, \rrr -> fmin(m, rrr), m)
+					},
+					\ -> eitherMap(rr, \rrr -> fmin(vvv, rrr), vvv)
+				))
 			},
-			ConstBehaviour(def)
+			None()
 		)
+		|> (\f -> either(f, const(def)))
 	else
 		ConstBehaviour(def)
 }

--- a/lib/fusion.flow
+++ b/lib/fusion.flow
@@ -1861,6 +1861,33 @@ fmerge(a : [Transform<?>]) -> Transform<[?]> {
 		ConstBehaviour([])
 }
 
+fmergeBalanced(a : [Transform<?>]) -> Transform<[?]> {
+	if (length(a) > 0) {
+		foldTreeBinary(
+			pairs2tree(mapi(a, \i : int, v : Transform<?> -> Pair(i, Some(v)))),
+			\__, v : Maybe<Transform<?>>, l : Maybe<Transform<[?]>>, r : Maybe<Transform<[?]>> -> {
+				maybeMap(v, \vv : Transform<?> -> eitherFn(l,
+					\ll -> eitherMap(r,
+						\rr : Transform<[?]> -> {
+							fselect3(ll, vv, rr, \lll, vvv, rrr -> concat3(lll, [vvv], rrr))
+						},
+						fselect2(ll, vv, FLift2(arrayPush))
+					),
+					\ -> eitherMap(r,
+						\rr : Transform<[?]> -> {
+							fselect2(vv, rr, FLift2(\vvv, rrr -> concat([vvv], rrr)))
+						},
+						fselect(vv, FLift(v2a))
+					)
+				))
+			},
+			None()
+		) |> (\f -> either(f, const([])))
+	} else {
+		const([])
+	}
+}
+
 fmergeTree(tree : Tree<??, Transform<?>>) -> Transform<Tree<??, ?>> {
 	if (sizeTree(tree) > 0)
 		fselect(

--- a/lib/fusion.flow
+++ b/lib/fusion.flow
@@ -1530,42 +1530,24 @@ fmin3(b1 : Transform<?>, b2 : Transform<?>, b3 : Transform<?>) -> Transform<?> {
 
 fmaxA(v : [Transform<?>], def : ?) -> Transform<?> {
 	if (length(v) > 0)
-		foldTreeBinary(
-			pairs2tree(mapi(v, \k : int, vv : Transform<?> -> Pair(k, Some(vv)))),
-			\__ : int, vv : Maybe<Transform<?>>, ll : Maybe<Transform<?>>, rr : Maybe<Transform<?>> -> {
-				maybeMap(vv, \vvv -> eitherFn(ll,
-					\lll -> {
-						m = fmax(vvv, lll);
-						eitherMap(rr, \rrr -> fmax(m, rrr), m)
-					},
-					\ -> eitherMap(rr, \rrr -> fmax(vvv, rrr), vvv)
-				))
-			},
-			None()
-		)
-		|> (\f -> either(f, const(def)))
+		fMaxMin(v, fmax)
 	else
 		ConstBehaviour(def)
 }
 
 fminA(v : [Transform<?>], def : ?) -> Transform<?> {
 	if (length(v) > 0)
-		foldTreeBinary(
-			pairs2tree(mapi(v, \k : int, vv : Transform<?> -> Pair(k, Some(vv)))),
-			\__ : int, vv : Maybe<Transform<?>>, ll : Maybe<Transform<?>>, rr : Maybe<Transform<?>> -> {
-				maybeMap(vv, \vvv -> eitherFn(ll,
-					\lll -> {
-						m = fmin(vvv, lll);
-						eitherMap(rr, \rrr -> fmin(m, rrr), m)
-					},
-					\ -> eitherMap(rr, \rrr -> fmin(vvv, rrr), vvv)
-				))
-			},
-			None()
-		)
-		|> (\f -> either(f, const(def)))
+		fMaxMin(v, fmin)
 	else
 		ConstBehaviour(def)
+}
+
+fMaxMin(v : [Transform<?>], fn : (Transform<?>, Transform<?>) -> Transform<?>) -> Transform<?> {
+	len = length(v);
+	middle = len / 2;
+	left = if (middle > 1) fMaxMin(subrange(v, 0, middle), fn) else v[0];
+	right = if (len - middle > 1) fMaxMin(subrange(v, middle, len - middle), fn) else v[len - 1];
+	fn(left, right);
 }
 
 farray(v1 : Transform<?>) -> Transform<[?]> {

--- a/lib/fusion.flow
+++ b/lib/fusion.flow
@@ -1141,7 +1141,7 @@ doFuseDynamic(t : Transform<?>) -> Pair<DynamicBehaviour<?>, () -> void> {
 							};
 							u = subscribe2(b, \v1 -> {
 								if (useFSubSelectFix) ^disconnect();
-								
+
 								bf = doFuse(ifn(v1));
 								u2 = subscribe(firstOfPair(bf), \v2 -> nextDistinct(dyn, v2));
 
@@ -1530,18 +1530,14 @@ fmin3(b1 : Transform<?>, b2 : Transform<?>, b3 : Transform<?>) -> Transform<?> {
 
 fmaxA(v : [Transform<?>], def : ?) -> Transform<?> {
 	if (length(v) > 0)
-		fold(tail(v), v[0], \acc, v1 ->
-			fmax(acc, v1)
-		)
+		fselect(fmerge(v), FLift(\arr -> either(maxA(arr), def)))
 	else
 		ConstBehaviour(def)
 }
 
 fminA(v : [Transform<?>], def : ?) -> Transform<?> {
 	if (length(v) > 0)
-		fold(tail(v), v[0], \acc, v1 ->
-			fmin(acc, v1)
-		)
+		fselect(fmerge(v), FLift(\arr -> either(minA(arr), def)))
 	else
 		ConstBehaviour(def)
 }


### PR DESCRIPTION
Do not use `fold` in `fmaxA`, `fminA` because it causes a crash when the array is longer than 10K.

But maybe we still need to use `fold` with short arrays?


hotfix for lyceum is here https://git.area9lyceum.com/Lyceum/lyceum/commit/ee1ccced0d7b33cb0d2740b75e42adbe143135f2
trello https://trello.com/c/dWCgbsTq/25448-attempting-to-load-a-big-class-over-10k-learners-crashes