### PR TITLE
Allow to disable the 'zoom by click on image' feature

### DIFF
--- a/lib/formats/html/html2form.flow
+++ b/lib/formats/html/html2form.flow
@@ -70,6 +70,21 @@ export {
 		virtualScreenInfoM : Maybe<VirtualScreenInfo>
 	) -> Pair<Form, (Form) -> Form>;
 
+	getHtmlPictureMagnifyCustomExt(
+		fullForm : Form,
+		scaledForm : Form,
+		maxw : Maybe<double>,
+		scale : Maybe<double>,
+		backgroundColor : Maybe<Color>,
+		zoomBtnFormFn : (() -> void) -> Form,
+		zoomBtnAlign : Corner,
+		zoomCustomUIFnM : Maybe<() -> void>,
+		closeBtnFormFn : (() -> void) -> Form,
+		closeBtnAlign : int,
+		virtualScreenInfoM : Maybe<VirtualScreenInfo>,
+		zoomByClickOnImage : bool
+	) -> Pair<Form, (Form) -> Form>;
+
 	parseCssStyles(cs : HTMLStyle, cssStyles : string) -> HTMLStyle;
 }
 
@@ -703,6 +718,36 @@ getHtmlPictureMagnifyCustom(
 	closeBtnAlign : int,
 	virtualScreenInfoM : Maybe<VirtualScreenInfo>
 ) -> Pair<Form, (Form) -> Form> {
+	getHtmlPictureMagnifyCustomExt(
+		fullForm,
+		scaledForm,
+		maxw,
+		scale,
+		backgroundColor,
+		zoomBtnFormFn,
+		zoomBtnAlign,
+		zoomCustomUIFnM,
+		closeBtnFormFn,
+		closeBtnAlign,
+		virtualScreenInfoM,
+		true
+	)
+}
+
+getHtmlPictureMagnifyCustomExt(
+	fullForm : Form,
+	scaledForm : Form,
+	maxw : Maybe<double>,
+	scale : Maybe<double>,
+	backgroundColor : Maybe<Color>,
+	zoomBtnFormFn : (() -> void) -> Form,
+	zoomBtnAlign : Corner,
+	zoomCustomUIFnM : Maybe<() -> void>,
+	closeBtnFormFn : (() -> void) -> Form,
+	closeBtnAlign : int,
+	virtualScreenInfoM : Maybe<VirtualScreenInfo>,
+	zoomByClickOnImage : bool
+) -> Pair<Form, (Form) -> Form> {
 	closeMagnifyWindow = ref nop;
 	magnifyWindowVisible = make(false);
 	closeMagnify = \ -> {
@@ -749,8 +794,14 @@ getHtmlPictureMagnifyCustom(
 
 	postCropTransfrom = \f -> {
 		formSize = makeWH();
+		inspectedForm = Inspect([ISize(formSize)], f);
+		 {}
 		Group([
-			Inspect([ISize(formSize)], f) |> makeZoomClick,
+			if (zoomByClickOnImage) {
+				inspectedForm |> makeZoomClick
+			} else {
+				inspectedForm
+			},
 			Available2(
 				formSize,
 				alignCorner(zoomBtnAlign, zoomBtnFormFn(onClick) |> makeZoomClick)

--- a/lib/ui/imagedecorated.flow
+++ b/lib/ui/imagedecorated.flow
@@ -77,6 +77,15 @@ export {
 		virtualScreenInfoM : Maybe<VirtualScreenInfo>,
 		backcolor : Maybe<Color>
 	) -> ((Form) -> Form) -> (Form) -> Pair<Form, (Form) -> Form>;
+	// the same as makeZoomAdder2, but it allows to disable 'Zoom by click on image' feature
+	makeZoomAdder4(
+		zoom: ZoomDescription,
+		fn: (Form) -> Form,
+		virtualScreenInfoM : Maybe<VirtualScreenInfo>,
+		backcolor : Maybe<Color>,
+		zoomByClickOnImage : bool,
+	) -> ((Form) -> Form) -> (Form) -> Pair<Form, (Form) -> Form>;
+
 
 	makeDimmerShape(
 		type : ImageDimmerType,
@@ -625,6 +634,16 @@ makeZoomAdder2(
 	fn: (Form) -> Form,
 	virtualScreenInfoM : Maybe<VirtualScreenInfo>,
 	backcolor : Maybe<Color>
+) -> ((Form) -> Form) -> (Form) -> Pair<Form, (Form) -> Form> {
+	makeZoomAdder4(zoom, fn, virtualScreenInfoM, backcolor, true)
+}
+
+makeZoomAdder4(
+	zoom: ZoomDescription,
+	fn: (Form) -> Form,
+	virtualScreenInfoM : Maybe<VirtualScreenInfo>,
+	backcolor : Maybe<Color>,
+	zoomByClickOnImage : bool,
 ) -> ((Form) -> Form) -> (Form) -> Pair<Form, (Form) -> Form>
 {
 	if (zoom.mouseZoom) {
@@ -635,7 +654,7 @@ makeZoomAdder2(
 			validSize = zoom.realSize.width > 0.0 && zoom.realSize.height > 0.0;
 
 			magnifier = eitherFn(zoom.zoomButtonM,
-				\zoomBtn -> getHtmlPictureMagnifyCustom(
+				\zoomBtn -> getHtmlPictureMagnifyCustomExt(
 					decoratedForm,
 					embedded,
 					zoom.toWidth,
@@ -646,7 +665,8 @@ makeZoomAdder2(
 					zoom.zoomCustomUIFnM,
 					zoom.closeButtonFn,
 					zoom.closeButtonAlign,
-					virtualScreenInfoM
+					virtualScreenInfoM,
+					zoomByClickOnImage
 				),
 				\ -> getHtmlPictureMagnifyWithCloseButton(
 					decoratedForm,


### PR DESCRIPTION
Task https://trello.com/c/gCvynpWQ/25311-when-zoom-is-enabled-allow-zoom-when-clicking-on-image-not-only-clicking-on-the-small-icon