### PR TITLE
Subtitles: fix multiline subtitles

### DIFF
--- a/lib/ui/videoplayer.flow
+++ b/lib/ui/videoplayer.flow
@@ -116,10 +116,10 @@ parseWebVTTContent(content : string, ccsref : ref [ClosedCaption]) -> void {
 				if (textStart > lastCC.begin) {
 					Pair(
 						arrayPush(ccs, ClosedCaption(lastCC with end = textStart - 1)),
-						ClosedCaption(textStart, blockEnd, t.content)
+						ClosedCaption(textStart, blockEnd, trim2(t.content, " \n\t"))
 					)
 				} else {
-					Pair(ccs, ClosedCaption(lastCC with text = lastCC.text + "\n" + t.content))
+					Pair(ccs, ClosedCaption(lastCC with text = trim2(lastCC.text + "\n" + t.content, " \n\t")))
 				}
 			})),
 			\ccs, lastCC -> refConcat(ccsref, ifArrayPush(ccs, lastCC != emptyCC, lastCC))


### PR DESCRIPTION
Task https://trello.com/c/ObgeYAnO/25564-video-subtitles-have-too-large-black-background-boxes