### PR TITLE
Subtitles: draw text without extra background

### DIFF
--- a/lib/material/internal/material_player.flow
+++ b/lib/material/internal/material_player.flow
@@ -1181,12 +1181,15 @@ TAnimatedSubtitles(manager : MaterialManager, parent : MFocusGroup, subtitles : 
 		|> (\sz -> TFrameT(const(frame.border), const(frame.radius), backgroundStyle, sz));
 
 	makeSubtitleLine = \sbtl, size, translatePoint, dSize ->
-		MDynamicParagraph2T(parent, const(sbtl.text), concat(MCharacterStyle2MTextStyle(sbtl.style), [
-			MSetRTL(false),
-			extractStruct(sbtl.style, EscapeHTML(true)),
-			CenterAlign(),
-			ParagraphMetrics(\met -> nextDistinct(size, WidthHeight(met.width, met.height + dSize)))
-		]))
+		MDynamicParagraph2T(parent, const(sbtl.text), concat(
+			replaceStruct(MCharacterStyle2MTextStyle(sbtl.style), BackgroundFillOpacity(0.0)),
+			[
+				MSetRTL(false),
+				extractStruct(sbtl.style, EscapeHTML(true)),
+				CenterAlign(),
+				ParagraphMetrics(\met -> nextDistinct(size, WidthHeight(met.width, met.height + dSize)))
+			])
+		)
 		|> TBorderBottom(dSize)
 		|> TBorderTop(frame.border)
 		|> (\t -> TTranslate(translatePoint, t))


### PR DESCRIPTION
Task https://trello.com/c/ObgeYAnO/25564-video-subtitles-have-too-large-black-background-boxes