### PR TITLE
RtrimWords in lines for Right alignment

### DIFF
--- a/lib/tropic/tropic_paragraph.flow
+++ b/lib/tropic/tropic_paragraph.flow
@@ -985,14 +985,14 @@ reflowTParaWords(
 
 	lines = reflowAndWidth.first.lines;
 
-	text = if (alignment == Justify()) {
+	text = if (alignment == Justify() || alignment == RightAlign()) {
 		mapi(
 			lines,
 			\i : int, line : TParaLine -> if (i == length(lines) - 1) line
 			else TParaLine(line with words = rtrimWords(line.words))
 		)
 	} else {
-		reflowAndWidth.first.lines;
+		lines;
 	}
 
 	paraLines = if (isBiDiEnabled())


### PR DESCRIPTION
https://trello.com/c/S8FpPc9E/25394-prime-graphics-right-alignmented-text-are-not-presented-in-line-after-an-automatically-line-break