### PR TITLE
MMultiAudioPlayer: start all fragments muted in Safari

### DIFF
--- a/lib/material/material_ui.flow
+++ b/lib/material/material_ui.flow
@@ -676,7 +676,7 @@ MMultiAudioPlayer(filenames : [string], mStyle : [MMultiAudioPlayerStyle]) -> Ma
 				default : None()
 			}
 		);
-		isSafari = isSafariBrowser() && js;
+		isSafari = isSafariBrowser();
 
 	  	// FVideoStyle properties
 	 	lenEx = extractStruct(fvStyle, FVideoLength(make(0.))).length;

--- a/lib/material/material_ui.flow
+++ b/lib/material/material_ui.flow
@@ -677,6 +677,7 @@ MMultiAudioPlayer(filenames : [string], mStyle : [MMultiAudioPlayerStyle]) -> Ma
 			}
 		);
 		isSafari = isSafariBrowser();
+		allFragmentsInitiated = ref false;
 
 	  	// FVideoStyle properties
 	 	lenEx = extractStruct(fvStyle, FVideoLength(make(0.))).length;
@@ -838,7 +839,10 @@ MMultiAudioPlayer(filenames : [string], mStyle : [MMultiAudioPlayerStyle]) -> Ma
 							synchrocallEx.onStart();
 							if (isSafari) {
 								next(volumeEx, volumeValue);
-								deferUntilRender(\-> changeAudioPlaying(getValue(currIndexB), getValue(playEx)));
+								deferUntilRender(\-> {
+									changeAudioPlaying(getValue(currIndexB), getValue(playEx));
+									allFragmentsInitiated := true;
+								});
 							}
 						}
 					),
@@ -861,8 +865,10 @@ MMultiAudioPlayer(filenames : [string], mStyle : [MMultiAudioPlayerStyle]) -> Ma
 							}
 							changeAudioPlaying(newIndex, getValue(playEx));
 
-							if (isSafari) [] else [
-								fconnect(fdelayUntilNextFrameRendered(states.isPlay[newIndex]), playEx)
+							[
+								fconnectSelect(fdelayUntilNextFrameRendered(states.isPlay[newIndex]), playEx, \isPlay -> {
+									if (!isSafari || ^allFragmentsInitiated) isPlay else getValue(playEx)
+								})
 							]
 						})
 					),

--- a/lib/material/material_ui.flow
+++ b/lib/material/material_ui.flow
@@ -676,6 +676,7 @@ MMultiAudioPlayer(filenames : [string], mStyle : [MMultiAudioPlayerStyle]) -> Ma
 				default : None()
 			}
 		);
+		isSafari = isSafariBrowser() && js;
 
 	  	// FVideoStyle properties
 	 	lenEx = extractStruct(fvStyle, FVideoLength(make(0.))).length;
@@ -687,6 +688,10 @@ MMultiAudioPlayer(filenames : [string], mStyle : [MMultiAudioPlayerStyle]) -> Ma
 		timeranges = extractStruct(mStyle, MMultiAudioTimerange([])).timeranges;
 		hasTimeRanges = exists(timeranges, isSome);
 
+		volumeEx = extractStruct(fvStyle, FVideoVolume(make(1.0))).volume;
+		volumeValue = getValue(volumeEx);
+		if (isSafari) next(volumeEx, 0.01);
+
 	  	// MMultiAudioPlayerStyle properties
 	 	currIndexB = extractStruct(mStyle, IndexInPlaylist(make(0))).index;
 
@@ -696,14 +701,22 @@ MMultiAudioPlayer(filenames : [string], mStyle : [MMultiAudioPlayerStyle]) -> Ma
 			map(filenames, \__ -> make(0.0)),
 			map(filenames, \__ -> make(0.0)),
 			map(filenames, \__ -> make(0.0)),
-			map(filenames, \__ -> make(false)),
+			map(filenames, \__ -> make(isSafari)),
 			map(filenames, \__ -> make(false)),
 	 	);
+		allIsReady = fands(states.isReady, false);
 
-	  	synchrocalls = mapi(filenames, \i, __ ->
-	 		SynchroCalls(
-	 			// set ready
-	 			\-> nextDistinct(states.isReady[i], true),
+		synchrocalls = mapi(filenames, \i, __ ->
+			SynchroCalls(
+				// set ready
+				\-> if (isSafari) {
+					deferUntilRender(\-> {
+						next(states.isPlay[i], false);
+						nextDistinct(states.isReady[i], true);
+					});
+				} else {
+					nextDistinct(states.isReady[i], true)
+				},
 	 			// play next or stop in the end
 	 			\-> {
 	 				// reset position (for js)
@@ -747,6 +760,7 @@ MMultiAudioPlayer(filenames : [string], mStyle : [MMultiAudioPlayerStyle]) -> Ma
 								synchrocalls[i],
 								FAudio(),
 								timerange,
+								FVideoVolume(volumeEx),
 							]
 						)
 					)
@@ -762,6 +776,7 @@ MMultiAudioPlayer(filenames : [string], mStyle : [MMultiAudioPlayerStyle]) -> Ma
 						FVideoPlay(states.isPlay[i]),
 						synchrocalls[i],
 						FAudio(),
+						FVideoVolume(volumeEx),
 					]
 				)
 			)
@@ -818,12 +833,19 @@ MMultiAudioPlayer(filenames : [string], mStyle : [MMultiAudioPlayerStyle]) -> Ma
 				[
 					\-> \-> next(currIndexB, 0),
 					// when all audios ready
-					makeSubscribe(fands(states.isReady, false), \isReady ->
-						if (isReady) synchrocallEx.onStart()
+					makeSubscribe(allIsReady, \isReady ->
+						if (isReady) {
+							synchrocallEx.onStart();
+							if (isSafari) {
+								next(volumeEx, volumeValue);
+								deferUntilRender(\-> changeAudioPlaying(getValue(currIndexB), getValue(playEx)));
+							}
+						}
 					),
 					// sum all audio lengths. but refresh total length only after all data is got (all lengths > 0)
-					\-> fconnectSelect(fmerge(states.length), lenEx, \lens -> {
-							if (hasTimeRanges) calculateAudioLengthWithTimeRanges(lens) 
+					\-> fconnect2Select(fmerge(states.length), allIsReady, lenEx, \lens, ready -> {
+							if (isSafari && !ready) 0.0
+							else if (hasTimeRanges) calculateAudioLengthWithTimeRanges(lens)
 							else if (all(map(lens, \l -> l > 0.0))) dsum(lens)
 							else 0.0
 						}),
@@ -839,7 +861,7 @@ MMultiAudioPlayer(filenames : [string], mStyle : [MMultiAudioPlayerStyle]) -> Ma
 							}
 							changeAudioPlaying(newIndex, getValue(playEx));
 
-							[
+							if (isSafari) [] else [
 								fconnect(fdelayUntilNextFrameRendered(states.isPlay[newIndex]), playEx)
 							]
 						})


### PR DESCRIPTION
Task https://trello.com/c/nBXxF9wN/25622-coach-sometimes-plays-twice-on-top-of-one-another-using-safari

Sometimes Safari on MacOS and iPad launches all fragments at once and they can not be paused by isPlay[i] (because it is false at that moment).
So for Safari I suggest starting all the fragments quietly, pausing them, and then returning the volume to the initial value and starting the whole playlist from the beginning if necessary (if autoplay is on)

@NikitaFil @stanislavpodolia any objections?