### PR TITLE
Implemented `verifyJwtWithPublicKey`;

### DIFF
--- a/lib/jwt.flow
+++ b/lib/jwt.flow
@@ -35,15 +35,10 @@ export {
 	) -> void = FlowJwt.decodeJwt;
 
 /*
-	// Verify JWT's, signed with the public/private key algorithms: RSA or ECDSA
-	// The alg must be one of the "RS256", "RS384", "RS512", "ES256", "ES384" or "ES512"
-	// When the alg is RS (RSA), then the key array must be of length 2, where "p" is key[0], "n" is key[1], the key is the public key modulus and exponent.
-	// When the alg is ES (ECDSA) then the array must be of length 3, where "crv" is key[0], "x" is key[1] and "y" is key[2].
-	// The keys are base64url encoded integers.
-	// See https://datatracker.ietf.org/doc/html/rfc7518 for all the details.
-	// Return "OK" if the JWT is valid.
-	native verifyJwtAlt(jwt: string, alg: string, key: [string]) -> string = FlowJwt.verifyJwtRSA;
+	// Verify JWT's, signed with the public/private key RSA algorithm (RS256).
+	// Return "OK" if the JWT is valid, otherwise an error message.
 */
+	native verifyJwtWithPublicKey : (jwt : string, publicKey : string) -> string = FlowJwt.verifyJwtWithPublicKey;
 }
 
 createJwtClaims(
@@ -96,6 +91,10 @@ createJwt(
 
 verifyJwt(jwt : string, key : string) -> string {
 	""; // Not implemented
+}
+
+verifyJwtWithPublicKey(jwt : string, publicKey : string) -> string {
+	"Not implemented";
 }
 
 decodeJwt(

--- a/platforms/java/com/area9innovation/flow/FlowJwt.java
+++ b/platforms/java/com/area9innovation/flow/FlowJwt.java
@@ -4,6 +4,8 @@ import java.util.*;
 import java.text.*;
 import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
+import java.security.*;
+import java.security.interfaces.*;
 
 import com.auth0.jwt.JWTVerifier.*;
 import com.auth0.jwt.interfaces.*;
@@ -143,5 +145,28 @@ public class FlowJwt extends NativeHost {
 			}
 		}
 		return builder.sign(algorithm);
+	}
+
+	public static RSAPublicKey getPublicKeyFromString(String publicKeyPEM) throws NoSuchAlgorithmException, java.security.spec.InvalidKeySpecException {
+		publicKeyPEM = publicKeyPEM.replace("-----BEGIN PUBLIC KEY-----", "");
+		publicKeyPEM = publicKeyPEM.replace("-----END PUBLIC KEY-----", "");
+		publicKeyPEM = publicKeyPEM.replaceAll("\\s","");
+		byte[] decodedPublicKey = Base64.getDecoder().decode(publicKeyPEM);
+
+		KeyFactory kf = KeyFactory.getInstance("RSA");
+		RSAPublicKey pubKey = (RSAPublicKey) kf.generatePublic(new java.security.spec.X509EncodedKeySpec(decodedPublicKey));
+		return pubKey;
+	}
+
+	public static String verifyJwtWithPublicKey(String jwtStr, String publicKeyStr) {
+		try {
+			RSAPublicKey publicKey = getPublicKeyFromString(publicKeyStr);
+			DecodedJWT jwt = JWT.decode(jwtStr);
+			Algorithm algorithm = Algorithm.RSA256(publicKey, null);
+			algorithm.verify(jwt);
+			return "OK";
+		} catch (Exception e) {
+			return e.getMessage();
+		}
 	}
 }


### PR DESCRIPTION
Test

```flow
import jwt;

main() {
	jwt = "eyJraWQiOiI4NjRmYTU3Mi04M2RjLTRmZjEtYTIzZC1kMDFjZDY5ZDI5ZTEiLCJhbGciOiJSUzI1NiJ9.ew0KICAic3ViIjogIjEyMzQ1Njc4OTAiLA0KICAibmFtZSI6ICJBbmlzaCBOYXRoIiwNCiAgImlhdCI6IDE1MTYyMzkwMjINCn0.ZhUNXCYVkhtbY-mPpyZrckpg0yPzVrp2H7jaSukafrWrAjz4ORVYKYXccDV2uGj8bLep_LEC_FOeA3bbPxlaplaTNJd2MpfuJdQ2VM9zBdzTMeJlqIJqvqsJ0Kaa106ixTwh8bbB9TM_3Av7lgmYRvoDLAKgqs6DBgGGcJn1nzWyfWvp9Bh1GvYSDCawp5_CvfJF538XVn2htaPkjXfnII3yFdrYfsEI8rNEwSw9x6A6wJBcJayQdbIHypbqv1vkNpe-LGc5x818beAT0ZHdHjCgfBzVebOWMz-HufO4WzHWLkrop23lkakqmEimpzud2umnhACqxFGgGxiNInMntQ";
	publicKey = "
		-----BEGIN PUBLIC KEY-----
		MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAsGbDmLfdoja9l7Ea9fKZ
		2/aZd/0hsqYY6yAUK/thgytchXQxmrVW20YizNGN5EhChGVVdYhV0pg4UEaIHy+N
		DSjghyYL35/UxS/F33m8SeUb+8jgdzzS56Gyou2XaTivQwqEQfjGVps8xKVMShLZ
		OR47x3XtKW8xHnh/aqRwVZovb7wiEEhcgZMVRYox25rZo8a7MWGDrwE7rIB2w9O+
		6hSZ1NQFkEahWAmX+aszFVrDTaahPWmc0Ue+JYbqa9R4/Ersk8V0oyQqc3eOQnKu
		Je6MiZyapfPvircqlWVDJGy9z5hCgVzF9pAADzhC9ZnEHLpd3v3h4J0OnH3Hrs2p
		CwIDAQAB
		-----END PUBLIC KEY-----
	";
	println(verifyJwtWithPublicKey(jwt, publicKey));
	quit(0);
}
```

jwt and keys for the test are generated with https://8gwifi.org/jwsgen.jsp