### PR TITLE
Always encode spaces in the url

### DIFF
--- a/lib/formats/uri3/uri3.flow
+++ b/lib/formats/uri3/uri3.flow
@@ -335,7 +335,7 @@ uri3GlueSearchParameters(params: [KeyValue], encode : (string) -> string) -> str
 
 uri3GetSearch(u: Uri3) -> string { uri3GlueSearchParameters(u.search, urlEncode2); }
 
-uri3GetHash(u: Uri3) -> string { uri3GlueSearchParameters(u.hash, idfn); }
+uri3GetHash(u: Uri3) -> string { uri3GlueSearchParameters(u.hash, \str -> strReplace(str, " ", "%20")); }
 
 uri3MakeTree(params: [KeyValue]) -> Tree<string, string> {
 	fold(params, makeTree(), \acc: Tree<string, string>, kv: KeyValue -> {


### PR DESCRIPTION
https://trello.com/c/DGomPo92/26091-command-shift-k-adding-spaces-in-url