### PR TITLE
flowc: `getDataTagForValue` for functions returns correct value

### DIFF
--- a/platforms/java/com/area9innovation/flow/Native.java
+++ b/platforms/java/com/area9innovation/flow/Native.java
@@ -1227,7 +1227,7 @@ public class Native extends NativeHost {
 			return 6;
 		} else if (x instanceof Reference) {
 			return 31;
-		} else if (x.getClass().getName().contains("$$Lambda$")) {
+		} else if (x.getClass().getName().contains("$$Lambda")) {
 			return 34;
 		} else {
 			return 32;


### PR DESCRIPTION
The funcion class name pattern looks like:
`tools.flowc.flowc.Module_eval$$Lambda/0x000071317c1ab2e0` thus we need to check for "$$Lambda", not for "$$Lambda$