### PR TITLE
parseCssTrace use parsic2

### DIFF
--- a/lib/formats/css/parse_css.flow
+++ b/lib/formats/css/parse_css.flow
@@ -20,7 +20,7 @@ parseCss(css : string) -> Stylesheet {
 
 parseCssTrace(css : string, addWarning : (string) -> void) -> Stylesheet {
 	// TODO add @font-face support
-	result = parsic(pegOps4Css, css, defaultPegActions);
+	result = parsic2(pegOps4Css, css, defaultPegActions);
 	if (result == "PARSING FAILED") {
 			addWarning(toString(result));
 			Stylesheet(makeTree());


### PR DESCRIPTION
we have addWarning inside parseCssTrace. but parsic prints errors. -> suggestion - use parsic2 to hide errors if we are not interested in them 
(issue : huge import -> a lot of prints -> slower)