### PR TITLE
Update around UTF8 encoding

### DIFF
--- a/lib/net/http.flow
+++ b/lib/net/http.flow
@@ -38,12 +38,6 @@ export {
 		onResponse : (responseStatus : int, responseData : string, responseHeaders : [KeyValue]) -> void,
 		async : bool
 	) -> void;
-	// Added `responseEncoding` parameter to return data in the requested encoding.
-	// Compiler or url parameter takes precedence:
-	//  - cpp flag is `use_utf8_js_style`;
-	//  - js flag is `utf8_no_surrogates`.
-	// If there is no such - `responseEncoding` will be used.
-	//
 	// RequestTimeout currently implemented only in java backend.
 	httpCustomRequestStyled(
 		url : string,

--- a/lib/net/http_types.flow
+++ b/lib/net/http_types.flow
@@ -41,13 +41,11 @@ export {
 	method2string(method : RequestMethod) -> string;
 	string2method(method : string) -> RequestMethod; // POST by default
 
-	ResponseEncoding ::= ResponseEncodingAuto, ResponseEncodingUtf8, ResponseEncodingByte;
-		// defined by target (js - ResponseEncodingUtf8(true), cpp - ResponseEncodingUtf8(false);
+	ResponseEncoding ::= ResponseEncodingAuto, ResponseEncodingUtf8, ResponseEncodingWtf8, ResponseEncodingByte;
+		// defined by url flags
 		ResponseEncodingAuto();
-		// UTF8 encoding with two realisations:
-		// 	`withSurrogatePairs=true` -  UTF-8 encoding with surrogate pairs (like it works in js target by default);
-		//  `withSurrogatePairs=false` - original UTF-8 encoding with 1, 2, 3 bytes symbol length (in cpp target is a bug - symbol cropped by two bytes);
-		ResponseEncodingUtf8(withSurrogatePairs : bool);
+		ResponseEncodingUtf8();
+		ResponseEncodingWtf8();	// Old format, for backward compatibility. https://simonsapin.github.io/wtf-8/
 		// Without encoding - each symbol is a one byte length
 		ResponseEncodingByte();
 
@@ -88,21 +86,17 @@ string2method(method : string) -> RequestMethod {
 responseEncoding2string(responseEncoding : ResponseEncoding) -> string {
 	switch(responseEncoding) {
 		ResponseEncodingAuto(): "auto";
-		ResponseEncodingUtf8(withSurrogatePairs): {
-			if (withSurrogatePairs) "utf8_js"
-			else "utf8";
-		}
+		ResponseEncodingUtf8(): "utf8";
+		ResponseEncodingWtf8(): "wtf8"
 		ResponseEncodingByte(): "byte";
 	}
 }
 
 string2responseEncoding(responseEncoding : string) -> ResponseEncoding {
-	if (responseEncoding == "auto") {
-		ResponseEncodingAuto()
-	} else if (responseEncoding == "utf8_js") {
-		ResponseEncodingUtf8(true)
-	} else if (responseEncoding == "utf8") {
-		ResponseEncodingUtf8(false)
+	if (responseEncoding == "utf8") {
+		ResponseEncodingUtf8();
+	} else if (responseEncoding == "wtf8") {
+		ResponseEncodingWtf8();
 	} else if (responseEncoding == "byte") {
 		ResponseEncodingByte()
 	} else {

--- a/platforms/common/cpp/core/STLHelpers.h
+++ b/platforms/common/cpp/core/STLHelpers.h
@@ -221,11 +221,10 @@ public:
 // We store here compiler flag about which logic of utf8 decode we should use:
 //  false - usual way with loss real code for 3 bytes codes,
 //  true - with decoding 3 bytes codes into UTF-16 codes (pairs of 2 bytes codes).
-void setUtf8JsStyleGlobalFlag(const bool flag);
+void setUtf8StyleGlobalFlag(const bool flag);
 
 unicode_string parseUtf8(const std::string &str);
 unicode_string parseUtf8(const char *str, unsigned size);
-unicode_string parseUtf8Base(const char *str, unsigned size, bool js_style);
 
 unicode_string parseUtf8u(const unicode_string &str);
 

--- a/platforms/common/cpp/utils/AbstractHttpSupport.cpp
+++ b/platforms/common/cpp/utils/AbstractHttpSupport.cpp
@@ -231,10 +231,8 @@ void AbstractHttpSupport::deliverResponse(int id, int status, HeadersMap headers
                 switch (rq->response_enc)
                 {
                     case ResponseEncodingUTF8:
-                        data = RUNNER->AllocateString(parseUtf8Base((const char*)pdata, count, false));
-                        break;
-                    case ResponseEncodingUTF8js:
-                        data = RUNNER->AllocateString(parseUtf8Base((const char*)pdata, count, true));
+                    case ResponseEncodingWTF8:
+                        data = RUNNER->AllocateString(parseUtf8((const char*)pdata, count));
                         break;
                     case ResponseEncodingByte:
                         data = RUNNER->AllocateString((unicode_char*)pdata, count/FLOW_CHAR_SIZE+count%FLOW_CHAR_SIZE);
@@ -737,9 +735,9 @@ StackSlot AbstractHttpSupport::deleteAppCookies(RUNNER_ARGS)
 
 ResponseEncoding AbstractHttpSupport::GetResponseEncodingFromString(std::string str)
 {
-    if (str == "utf8_js")
-        return ResponseEncodingUTF8js;
-    else if (str == "utf8") {
+    if (str == "utf8")
+        return ResponseEncodingWTF8;
+    else if (str == "wtf8") {
         return ResponseEncodingUTF8;
     } else if (str == "byte")
         return ResponseEncodingByte;
@@ -762,23 +760,23 @@ StackSlot AbstractHttpSupport::setDefaultResponseEncoding(RUNNER_ARGS)
 
     switch (defaultResponseEncoding) {
         case ResponseEncodingUTF8:
-            setUtf8JsStyleGlobalFlag(false);
-            cout << lookup << "'" << "utf8 without surrogate pairs" << "'." << endl;
+            setUtf8StyleGlobalFlag(true);
+            cout << lookup << "'UTF8'." << endl;
             break;
-        case ResponseEncodingUTF8js:
-            setUtf8JsStyleGlobalFlag(true);
-            cout << lookup << "'" << "utf8 with surrogate pairs" << "'." << endl;
+        case ResponseEncodingWTF8:
+            setUtf8StyleGlobalFlag(false);
+            cout << lookup << "'WTF8'." << endl;
             break;
         case ResponseEncodingByte:
-            setUtf8JsStyleGlobalFlag(false);
-            cout << lookup << "'" << "raw byte" << "'." << endl;
+            setUtf8StyleGlobalFlag(false);
+            cout << lookup << "'raw byte'." << endl;
             break;
         case ResponseEncodingAuto:
-            setUtf8JsStyleGlobalFlag(false);
-            cout << lookup << "'" << "auto" << "'." << endl;
+            setUtf8StyleGlobalFlag(true);
+            cout << lookup << "'auto'." << endl;
             break;
         default:
-            setUtf8JsStyleGlobalFlag(false);
+            setUtf8StyleGlobalFlag(true);
             cout << "Invalid encoding '" << encodeUtf8(RUNNER->GetString(tmp_value)) << "'. Switched to 'auto'." << endl;
     }
 

--- a/platforms/common/cpp/utils/AbstractHttpSupport.h
+++ b/platforms/common/cpp/utils/AbstractHttpSupport.h
@@ -8,7 +8,7 @@
 enum ResponseEncoding {
     ResponseEncodingAuto,
     ResponseEncodingUTF8,
-    ResponseEncodingUTF8js,
+    ResponseEncodingWTF8,
     ResponseEncodingByte
 };
 

--- a/platforms/java/com/area9innovation/flow/HttpSupport.java
+++ b/platforms/java/com/area9innovation/flow/HttpSupport.java
@@ -23,7 +23,7 @@ import java.nio.file.Files;
 
 @SuppressWarnings("unchecked")
 public class HttpSupport extends NativeHost {
-	public static String defaultResponseEncoding = "auto";
+	public static String defaultResponseEncoding = "utf8";
 
 	public static Object httpRequest(
 		String url, boolean post,Object[] headers, Object[] params,
@@ -132,10 +132,10 @@ public class HttpSupport extends NativeHost {
 	}
 
 	private static final String stream2string(InputStream inputStream, String responseEncoding) throws java.io.IOException {
-		if (Native.getUrlParameter("use_utf8_js_style").equals("1")) {
-			responseEncoding = "utf8_js";
-		} else if (Native.getUrlParameter("utf8_no_surrogates").equals("1")) {
+		if (Native.getUrlParameter("use_wtf8").equals("0")) {
 			responseEncoding = "utf8";
+		} else if (Native.getUrlParameter("use_wtf8").equals("1")) {
+			responseEncoding = "wtf8";
 		} else if (responseEncoding.equals("auto")) {
 			responseEncoding = defaultResponseEncoding;
 		}
@@ -145,10 +145,10 @@ public class HttpSupport extends NativeHost {
 		if (Objects.nonNull(inputStream)) {
 			final int bufferSize = 1024;
 
-			if (responseEncoding.equals("utf8")) {
+			if (responseEncoding.equals("wtf8")) {
 				// How much last chars from the previous chain we moved to the beginning of the new one (0 or 1).
 				int additionalChars = 0;
-				// +1 additinal char from the prevoius chain
+				// +1 additional char from the previous chain
 				final char[] buffer = new char[bufferSize + 1];
 
 				int readSize = 0;
@@ -186,7 +186,7 @@ public class HttpSupport extends NativeHost {
 				if (additionalChars > 0) {
 					unpackSurrogatePair(response, buffer[0], buffer[0]);
 				}
-			} else if (responseEncoding.equals("utf8_js")) {
+			} else if (responseEncoding.equals("utf8")) {
 				final char[] buffer = new char[bufferSize];
 				Reader in = new InputStreamReader(inputStream, Charset.forName("UTF-8"));
 				while (true) {
@@ -588,10 +588,10 @@ public class HttpSupport extends NativeHost {
 		String encodingName = "";
 		if (responseEncoding.equals("auto")) {
 			encodingName = "auto";
-		} else if (responseEncoding.equals("utf8_js")) {
-			encodingName = "utf8 with surrogate pairs";
 		} else if (responseEncoding.equals("utf8")) {
-			encodingName = "utf8 without surrogate pairs";
+			encodingName = "utf8";
+		} else if (responseEncoding.equals("wtf8")) {
+			encodingName = "wtf8";
 		} else if (responseEncoding.equals("byte")) {
 			encodingName = "raw byte";
 		} else {

--- a/platforms/js/HttpCustom.hx
+++ b/platforms/js/HttpCustom.hx
@@ -4,8 +4,8 @@ class HttpCustom extends haxe.Http {
 	#if (js && !nwjs)
 	var method : String;
 	var availableMethods = ['GET', 'POST', 'DELETE', 'PATCH', 'PUT'];
-	var arrayBufferEncodings = ['utf8', 'byte'];
-	var defaultEncodings = ['auto', 'utf8_js'];
+	var arrayBufferEncodings = ['wtf8', 'byte'];
+	var defaultEncodings = ['auto', 'utf8'];
 
 	var responseHeaders2 : Array<Array<String>>;
 
@@ -33,11 +33,11 @@ class HttpCustom extends haxe.Http {
 		#end
 		var r = me.req = js.Browser.createXMLHttpRequest();
 
-		var utf8NoSurrogatesFlag = Util.getParameter("utf8_no_surrogates");
+		var wtf8Flag = Util.getParameter("use_wtf8");
 		// Url parameter takes precedence.
-		if (utf8NoSurrogatesFlag != null && utf8NoSurrogatesFlag != "0") {
-			responseEncoding = "utf8";
-		} else if (responseEncoding == "utf8_js") {
+		if (wtf8Flag != null && wtf8Flag != "0") {
+			responseEncoding = "wtf8";
+		} else if (responseEncoding == "utf8") {
 			responseEncoding = "auto";
 		} else if (this.arrayBufferEncodings.indexOf(responseEncoding) == -1 && this.defaultEncodings.indexOf(responseEncoding) == -1) {
 			responseEncoding = "auto";
@@ -73,7 +73,7 @@ class HttpCustom extends haxe.Http {
 				me.onStatus(s);
 			me.req = null;
 
-			if (responseEncoding == "utf8") {
+			if (responseEncoding == "wtf8") {
 				try {
 					encodedResponse = this.parseUtf8Real(
 						new Uint8Array(r.response),

--- a/platforms/qt/bin/windows/QtByteRunner.exe
+++ b/platforms/qt/bin/windows/QtByteRunner.exe
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:01d4d074b8686c66d89d501849466e6850e2fb0de5f88e341fff0ef5da44927b
-size 1637376
+oid sha256:686f29da21d97b16183bdb661366f6fdb16dcf043b814f2ed86a7cc29d599538
+size 1637888

--- a/platforms/qt/main.cpp
+++ b/platforms/qt/main.cpp
@@ -418,8 +418,8 @@ int main(int argc, char *argv[])
         } else if (!strcmp(argv[1], "--min-heap")) {
             MIN_HEAP_SIZE = atoi(argv[2]) * 1048576;
             shift_args(argc, argv, 2);
-        } else if (!strcmp(argv[1], "--use_utf8_js_style")) {
-            setUtf8JsStyleGlobalFlag(true);
+        } else if (!strcmp(argv[1], "--use_wtf8")) {
+            setUtf8StyleGlobalFlag(false);
             shift_args(argc, argv, 1);
         } else if (argv[1][0] == '-') {
             printf("Unknown argument: %s\n", argv[1]);
@@ -771,8 +771,11 @@ int main(int argc, char *argv[])
                     QString key = a.left(equal);
                     QString value = a.mid(equal + 1);
                     FlowRunner.setUrlParameter(key, value);
-
-                    setUtf8JsStyleGlobalFlag(!strcmp(argv[i], "use_utf8_js_style=1"));
+                    if (!strcmp(argv[i], "use_wtf8=1")) {
+                        setUtf8StyleGlobalFlag(false);
+                    } else if (!strcmp(argv[i], "use_wtf8=0")) {
+                        setUtf8StyleGlobalFlag(true);
+                    }
                 } else {
                     FlowRunner.setUrlParameter(a, QString());
                 }
@@ -843,7 +846,7 @@ int main(int argc, char *argv[])
                        "--fallback_font <font> Enables lookup of unknown glyphs in the <font>. <font> example - DejaVuSans.\n"
                        "--transparent          Enables GL transparency.\n"
 #endif
-                       "--use_utf8_js_style    To switch UTF-8 parser to js style (3 bytes or more symbol codes converts into UTF-16).\n"
+                       "--use_wtf8             To switch to WTF-8 instead of UTF-8.\n"
                        "-I dir                 passes -I parameter to flow compiler\n"
                        "Compiler, media-path, and fallback_font options can also be specified in flow.config file in properties format:\n"
                        "    flowcompiler=flowcompiler|nekocompiler|flowc\n"

--- a/tests/test_utf8.flow
+++ b/tests/test_utf8.flow
@@ -1,0 +1,21 @@
+import sys/target;
+
+main() {
+	b1 = "i";	// 1 byte
+	b2 = "я";	// 2 bytes
+	b3 = "❤";	// 3 bytes in UTF8 and 2 bytes in UTF16 '\u2764'
+	b4 = "😀";	// 4 bytes in UTF8 and 4 bytes in UTF16 (a surrogate pair) because unicode is '\U0001F600' -- more than FFFF.
+
+	assert(length(string2utf8(b1)) == 1, "string2utf8 is broken for 1 byte utf8 character");
+	assert(length(string2utf8(b2)) == 2, "string2utf8 is broken for 2 byte utf8 character");
+	assert(length(string2utf8(b3)) == 3, "string2utf8 is broken for 3 byte utf8 character");
+	assert(length(string2utf8(b4)) == 4, "string2utf8 is broken for 4 byte utf8 character");
+
+	assert(strlen(b1) == 1, "strlen is broken for 1 byte utf8 character");
+	assert(strlen(b2) == 1, "strlen is broken for 2 byte utf8 character");
+	assert(strlen(b3) == 1, "strlen is broken for 3 byte utf8 character");
+	assert(strlen(b4) == 2, "strlen is broken for 4 byte utf8 character"); // Not 1 because it uses a surrogate pair
+
+	println("UTF8 tests are OK in " + getTargetName());
+	quit(0);
+}


### PR DESCRIPTION
Removed `--use_utf8_js_style` flowcpp flag, since its behavior is standard UFT8 format, use this by default;

To use outdated format introduced flowcpp flag `--use_wtf8`; Removed "js" suffix from names;

Removed parser dependency on "js_style" in cpp code: we should always create surrogate pairs for big codes when parsing UTF8 into UTF16 (internal flowcpp format), otherwise UTF16 data cannot be correctly restored back to UTF8; After removing the dependency, "base" functions (like "parse_base") was removed as they become the same as normal functions (for example "parse");

Added a simple test case; Added more tests to the bugfour application in the innovation repo;