### PR TITLE
Introduce isAltIn

### DIFF
--- a/lib/sys/keyboard.flow
+++ b/lib/sys/keyboard.flow
@@ -17,6 +17,7 @@ export {
 	isCtrlKeyIn(key : KeyEvent) -> bool;
 
 	isAltAlone(key : KeyEvent) -> bool;
+	isAltIn(key : KeyEvent) -> bool;
 	// Returns a string representation of KeyEvent
 	shortcut2s(shortcut : Maybe<KeyEvent>) -> string;
 	// Returns a string representation of keyboard combination which produces this KeyEvent
@@ -69,6 +70,10 @@ isCtrlKeyIn(key : KeyEvent) -> bool {
 
 isAltAlone(key : KeyEvent) -> bool {
 	(toLowerCase(key.utf) == "alt" || (key.utf == "" && key.alt));
+}
+
+isAltIn(key : KeyEvent) -> bool {
+	(toLowerCase(key.utf) == "alt" || key.alt || key.keycode ==KEY_ALT);
 }
 
 // Returns a string representation of KeyEvent


### PR DESCRIPTION
https://trello.com/c/iUVQrWGX/27123-keyboard-focus-doesnt-move-out-of-the-text-editor-in-math-and-projects