### PR TITLE
Improve `fthrottle2` by using `movableTimer`;

### DIFF
--- a/lib/fusion.flow
+++ b/lib/fusion.flow
@@ -1968,16 +1968,37 @@ fthrottle2(v : Transform<?>, maxDelta : int) -> Transform<?> {
 	switch (v) {
 		ConstBehaviour(__): v;
 		default: {
-			newV = make(fgetValue(v));
-			uns = ref nop;
+			val = fgetValue(v);
+			newV = make(val);
+
+			delta = i2d(maxDelta);
+			execTime = ref 0.0;
+			execVal = ref val;
 
 			fsubselect(v, FLift(\v0 -> {
-				^uns();
-				uns := interruptibleTimer(maxDelta, \ -> {next(newV, v0); ^uns();});
+				noTimer = ^execTime == 0.0;
+				execTime := timestamp() + delta;
+				execVal := v0;
+				if (noTimer) {
+					movableTimer(execTime, \ -> {
+						next(newV, ^execVal);
+						execTime := 0.0;
+					});
+				}
 
 				newV
 			}))
 		}
+	}
+}
+
+// execTime can be moved outside
+movableTimer(execTime : ref double, fn : () -> void) -> void {
+	execDelta = ^execTime - timestamp();
+	if (execDelta <= 0.0) {
+		fn();
+	} else {
+		timer(trunc(execDelta), \ -> movableTimer(execTime, fn));
 	}
 }
 


### PR DESCRIPTION
https://github.com/user-attachments/assets/a1b0933a-b3e1-4a43-8edd-2ce57c993765

I'm not sure if this is really useful, but in the case in the attached video it replaces 4 redraws with 2.

The hover triggers more then 5k calls to interruptibleTimer inside fthrottle2.