### PR TITLE
date2formatString: new template '%DTH' for ordinal numbers

### DIFF
--- a/lib/date.flow
+++ b/lib/date.flow
@@ -303,6 +303,7 @@ date2formatString(date: Date, template: string) -> string {
 			"%DDDD", dayOfWeekString(date, true),
 			"%DDD", dayOfWeekString(date, false),
 			"%DD", (if (date.day < 10) "0" else "") + i2s(date.day),
+			"%DTH", i2sTh(date.day),
 			"%D", i2s(date.day),
 			"%MMMMM", strLeft(monthString(date, true), 1),
 			"%MMMM", monthString(date, true),


### PR DESCRIPTION
Task https://trello.com/c/qijVB9Fx/26471-gui-certificates-and-others-date-format-should-be-adjustable-due-to-language-standard