### PR TITLE
The `&sol` html escape is added

### DIFF
--- a/lib/formats/html/html.flow
+++ b/lib/formats/html/html.flow
@@ -429,6 +429,7 @@ doUnescapeHtml(acc : string, s : string, numericOnly : bool, onError : (string) 
 				else if (esca == "&lt") "<"
 				else if (esca == "&gt") ">"
 				else if (esca == "&quot") "\""
+				else if (esca == "&sol") "/"
 				else {
 					e = lookupTreeDef(^htmlEntity2string, esca, "");
 					if (e == "") {


### PR DESCRIPTION
The `&sol` means [direct
slash](https://www.toptal.com/designers/htmlarrows/punctuation/slash/).