### PR TITLE
The support for the `code` tag is added

### DIFF
--- a/lib/formats/html/html2md.flow
+++ b/lib/formats/html/html2md.flow
@@ -81,6 +81,12 @@ ruHtmlNode2md(html : HtmlNode, indent : string) -> string {
 				src = fold(attribs, "", \acc, attrib -> if (attrib.key == "src") attrib.val else acc);
 				alt = fold(attribs, "Image", \acc, attrib -> if (attrib.key == "alt") attrib.val else acc);
 				"![" + alt + "](" + src + ")"
+			} else if (tag == "code") {
+				if (strContains(contents, "\n")) {
+					"```\n" + contents + "\n```";
+				} else {
+					"`" + contents + "`";
+				}
 			} else if (tag != "") {
 				println("TODO: Support " + tag + " in ruHtmlNode2md");
 				contents;


### PR DESCRIPTION
The `<code> CODE </code>` is translated to `CODE` or ```CODE```