### PR TITLE
Flowc cpp3 backend fixes

### DIFF
--- a/tools/flowc/backends/cpp3/fi2cpp3_build.flow
+++ b/tools/flowc/backends/cpp3/fi2cpp3_build.flow
@@ -87,8 +87,8 @@ fi2cpp3Build(cfg: FiCpp3Config, sources: [string], deps: [Cpp3Dependency], callb
 		"qt_module_libs", if (use_qt) "target_link_libraries(" + target + " " + superglue(qt_modules, \m -> "Qt5::" + m, " ") + " )" else "",
 		"sources", superglue(cpp_sorces, \src -> fileNameOnly(src), "\n"),
 		"headers", superglue(cpp_headers, \src -> fileNameOnly(src), "\n"),
-		"mimalloc_package", if (use_mimalloc) "find_package(mimalloc 2.1 REQUIRED)" else "",
-		"mimalloc_lib", if (use_mimalloc) "target_link_libraries(" + target + " mimalloc-static)" else "",
+		"mimalloc_package", if (use_mimalloc) "find_package(mimalloc REQUIRED)" else "",
+		"mimalloc_lib", if (use_mimalloc) "target_link_libraries(" + target + " mimalloc)" else "",
 		"std_libs", if (std_libs == []) "" else "target_link_libraries(" + target + " " + strGlue(std_libs, " ") + ")",
 	]);
 	gen_dir = pathCombine(cfg.outputdir, "cpp3gen");
@@ -111,7 +111,7 @@ fi2cpp3Build(cfg: FiCpp3Config, sources: [string], deps: [Cpp3Dependency], callb
 		["..", debug_or_release]
 	]);
 	if (cfg.verbose > 0) {
-		fcPrintln("cmake invokation: cmake " + strGlue(cmake_args, " "), cfg.config.threadId);
+		fcPrintln("cmake invocation: cmake " + strGlue(cmake_args, " "), cfg.config.threadId);
 	}
 	cmake_exit_code = execSystemProcess("cmake", cmake_args, build_dir,
 		\out -> if (cfg.verbose > 0 && !isSpace(out)) {
@@ -130,7 +130,7 @@ fi2cpp3BuildCxxSupressWarningsFlags() -> [string] {[
 	"-Wno-unused-value", "-Wno-unused-parameter",
 	"-Wno-unused-variable", "-Wno-return-type",
 	"-Wno-unused-but-set-variable", "-Wno-trigraphs",
-	"-Wno-use-after-free"
+	"-Wno-use-after-free", "-Wno-unknown-warning-option"
 ]}
 
 fi2cpp3Make(cfg: FiCpp3Config, builddir: string, callback : (int) -> void) -> void {

--- a/tools/flowc/backends/cpp3/fi2cpp3_source.flow
+++ b/tools/flowc/backends/cpp3/fi2cpp3_source.flow
@@ -8,11 +8,8 @@ export {
 }
 
 fiCompiledModule2cpp3header(module: Cpp3CompiledModule, gctx: Cpp3GlobalContext) -> string {
-	includes = superglue(
-		fiCpp3DependenciesIncludes(map(module.natives, \nat -> nat.dependencies)),
-		\inc -> "#inc" + "lude " + inc,
-		"\n"
-	);
+	dependencies = fiCpp3DependenciesIncludes(map(module.natives, \nat -> nat.dependencies));
+	includes = superglue(dependencies, \inc -> "#inc" + "lude " + inc, "\n");
 	forwards = filtermap(module.decls, \decl -> if (decl.forward == "") None() else Some(decl.forward));
 	traits = filtermap(module.decls, \decl -> if (decl.traits == "") None() else Some(decl.traits));
 	decls = filtermap(module.decls, \decl -> if (decl.declaration == "") None() else Some(decl.declaration));
@@ -88,7 +85,6 @@ fiInitTermModule2cpp3Source(compiled: [Cpp3CompiledModule], runtime_parts: [Cpp3
 	"namespace flow {\n" +
 	"void init_all_modules(){\n" +
 		"\tMemoryPool::init();\n" +
-		"\tThreadPool::init(std::thread::hardware_concurrency());\n" +
 		make_block(map(has_init, \m -> "init_" + m.name + "();")) +
 		make_block(map(runtime_parts, \part -> part.globalInit)) +
 	"}\n\n" +
@@ -97,8 +93,6 @@ fiInitTermModule2cpp3Source(compiled: [Cpp3CompiledModule], runtime_parts: [Cpp3
 		make_block(map(reverseA(has_term), \m ->
 			"term_" + m.name + "();",
 		)) +
-		"\tThreadPool::release();\n" +
-		"\tMemoryPool::release();\n" +
 	"}\n\n" +
 	"void join_all_modules(){\n" +
 		make_block(map(reverseA(runtime_parts), \part -> part.globalJoin)) +

--- a/tools/flowc/backends/cpp3/fi2cpp3_structs.flow
+++ b/tools/flowc/backends/cpp3/fi2cpp3_structs.flow
@@ -83,10 +83,11 @@ fiStruct2cpp3StructDef(struct: FiTypeStruct, gctx: Cpp3GlobalContext) -> string 
 		"\tfail(\"Struct " + s.name + " arity mismatch: expected " + i2s(length(s.args)) + " arguments, " +
 		"got: \" + string2std(int2string(args->size())) + \"  \");\n}";
 		struct_type = FiTypeName(s.name, s.typars);
+		struct_name = fiStructName2cpp3(struct_type, gctx);
 		"[](Vec<Flow*>* args){\n" + strIndent(
 			check_arity + "\n" +
-			"Flow* ret = static_cast<Flow*>(new " +
-			fiStructName2cpp3(struct_type, gctx) + "(\n" +
+			"Flow* ret = static_cast<Flow*>(" +
+			struct_name + "::make<" + struct_name + "*>(\n" +
 				strIndent(strGlue(mapi(s.args, make_arg), ",\n")) +
 			"\n));\n" +
 			"decRc(args);\n" +

--- a/tools/flowc/backends/cpp3/natives/dynamic.nats
+++ b/tools/flowc/backends/cpp3/natives/dynamic.nats
@@ -57,17 +57,23 @@ Cpp3Native("makeStructValue", false,
 }\n", "", [], []),
 
 Cpp3Native("isSameObj", true,
-"template<typename T> Bool $F_1(isSameObj)(T x, T y);\n",
-"template<typename T> inline Bool $F_1(isSameObj)(T x, T y) {
-	Bool ret = false;
-	if constexpr (std::is_same_v<T, String*>) {
-		ret = (x->str() == y->str());
+"template<typename T1, typename T2> Bool $F_1(isSameObj)(T1 x, T2 y);\n",
+"template<typename T1, typename T2> inline Bool $F_1(isSameObj)(T1 x, T2 y) {
+	if constexpr (std::is_same_v<T1, T2>) {
+		Bool ret = false;
+		if constexpr (std::is_same_v<T1, String*>) {
+			ret = (x->str() == y->str());
+		} else {
+			ret = (x == y);
+		}
+		decRc(x);
+		decRc(y);
+		return ret;
 	} else {
-		ret = (x == y);
+		decRc(x);
+		decRc(y);
+		return false;
 	}
-	decRc(x);
-	decRc(y);
-	return ret;
 }
 \n", 
 "", [], []),

--- a/tools/flowc/backends/cpp3/natives/runtime.nats
+++ b/tools/flowc/backends/cpp3/natives/runtime.nats
@@ -195,12 +195,8 @@ Cpp3Native("setFileContent", false,
 }\n", "", [Cpp3Std(["<fstream>"], [])], []),
 
 Cpp3Native("timestamp", false,
-"Double $F_1(timestamp)();\n",
-"Double $F_1(timestamp)() {
-	return std::chrono::duration_cast<std::chrono::milliseconds>(
-		std::chrono::system_clock::now().time_since_epoch()
-	).count();
-}\n", "", [Cpp3Std(["<chrono>", "<ctime>"], [])], []),
+"inline Double $F_1(timestamp)() { return timestamp(); }\n",
+"", "timestamp()", [], []),
 
 Cpp3Native("string2time", false,
 "Double $F_1(string2time)(String* s);\n",
@@ -219,7 +215,7 @@ Cpp3Native("string2time", false,
 	} else {
 		return 0.0;
 	}
-}\n", "", [Cpp3Std(["<chrono>", "<ctime>", "<locale>"], [])], ["date_time_format"]),
+}\n", "", [Cpp3Std(["<ctime>", "<locale>"], [])], ["date_time_format"]),
 
 Cpp3Native("time2string", false,
 "String* $F_1(time2string)(Double t);\n",
@@ -230,7 +226,7 @@ Cpp3Native("time2string", false,
 	std::ostringstream out;
 	time_put.put(out, out, ' ', time, date_time_format.data(), date_time_format.data() + date_time_format.length());
 	return String::make(out.str());
-}\n", "", [Cpp3Std(["<chrono>", "<ctime>"], [])], ["date_time_format"]),
+}\n", "", [Cpp3Std(["<ctime>"], [])], ["date_time_format"]),
 
 Cpp3Native("getApplicationPath", true,
 "inline String* $F_1(getApplicationPath)();\n",

--- a/tools/flowc/backends/cpp3/natives/string.nats
+++ b/tools/flowc/backends/cpp3/natives/string.nats
@@ -335,12 +335,14 @@ Cpp3Native("strSplit", false,
 		} else {
 			Int i = 0;
 			auto sep_it = sep->str().begin();
-			for (char16_t ch : s->str()) {
-				if (ch != *sep_it) {
-					++i;
+			for (auto s_it = s->str().begin(); s_it != s->str().end(); ++ s_it) {
+				if (*s_it != *sep_it) {
 					if (sep_it != sep->str().begin()) {
 						i += (sep_it - sep->str().begin());
 						sep_it = sep->str().begin();
+						--s_it;
+					} else {
+						++i;
 					}
 				} else {
 					++ sep_it;

--- a/tools/flowc/backends/cpp3/natives/sys_concurrent.nats
+++ b/tools/flowc/backends/cpp3/natives/sys_concurrent.nats
@@ -6,61 +6,52 @@ Cpp3Native("availableProcessors", true,
 }\n", "", 
 [], []),
 
-Cpp3Native("setThreadPoolSize", true,
-"inline Void $F_1(setThreadPoolSize)(Int threads);\n",
-"inline Void $F_1(setThreadPoolSize)(Int threads) {
-	//thread_pool = std::make_unique<ThreadPool>(threads);
-	ThreadPool::init(threads);
-	return void_value;
+Cpp3Native("newThreadPool", true,
+"inline Native* $F_1(newThreadPool)(Int threadsCount);\n",
+"inline Native* $F_1(newThreadPool)(Int threadsCount) {
+	ThreadPool* thread_pool = new ThreadPool(threadsCount);
+	return Native::make(thread_pool, [thread_pool]() { delete thread_pool; });
 }\n", "", [], []),
 
 Cpp3Native("getThreadId", true,
 "inline String* $F_1(getThreadId)();\n",
 "inline String* $F_1(getThreadId)() {
-	return String::make(int2string(ThreadPool::currentThread()));
-/*
-	static std::mutex m;
-	static std::unordered_map<std::thread::id, Int> thread_ids;
-	static Int counter = 0;
-	std::lock_guard<std::mutex> l(m);
-	auto p = thread_ids.find(std::this_thread::get_id());
-	if (p == thread_ids.end()) {
-		Int thread_id = counter;
-		thread_ids[std::this_thread::get_id()] = counter++;
-		return String::make(int2string(thread_id));
-	} else {
-		return String::make(int2string(p->second));
-	}*/
+	std::stringstream ss;
+	ss << std::this_thread::get_id();
+	return String::make(ss.str());
 }\n", "", [], []),
 
 Cpp3Native("concurrent", true,
-"template<typename T> Vec<T>* $F_1(concurrent)(Bool fine, Vec<Fun<T>*>* tasks);\n",
-"template<typename T> Vec<T>* $F_1(concurrent)(Bool fine, Vec<Fun<T>*>* tasks) {
+"template<typename T> Vec<T>* $F_1(concurrent)(Native* nat, Vec<Fun<T>*>* tasks);\n",
+"template<typename T> Vec<T>* $F_1(concurrent)(Native* nat, Vec<Fun<T>*>* tasks) {
 	std::size_t size = tasks->size();
 	if (size == 0) {
+		decRc(nat);
 		decRc(tasks);
 		return Vec<T>::make();
 	} else if (size == 1) {
+		decRc(nat);
 		Vec<T>* ret = Vec<T>::make(1);
 		ret->pushBack(tasks->get(0)->callRc1());
 		decRc(tasks);
 		return ret;
 	} else {
-		std::vector<T> ret;
-		ret.resize(size);
-		std::vector<std::future<void>> task_jobs;
-		task_jobs.resize(size);
-		for (std::size_t i = 0; i < size; ++i) {
-			Fun<T>* fn = tasks->get(static_cast<Int>(i));
-			task_jobs[i] = std::move(
-				ThreadPool::push<void>(ThreadPool::Shutdown::Block, [i, fn, &ret]() {
-					ret[i] = fn->callRc1();
+		std::vector<std::future<T>> task_jobs;
+		task_jobs.reserve(size);
+		ThreadPool* thread_pool = nat->get<ThreadPool*>();
+		for (Fun<T>* fn: *tasks) {
+			task_jobs.emplace_back(
+				thread_pool->push<T>(ThreadPool::Shutdown::Block, [fn]() {
+					return fn->callRc1();
 				})
 			);
 		}
-		for (std::size_t i = 0; i < size; ++i) {
-			task_jobs.at(i).get();
+		std::vector<T> ret;
+		ret.reserve(size);
+		for (std::future<T>& job: task_jobs) {
+			ret.push_back(job.get());
 		}
+		decRc(nat);
 		decRc(tasks);
 		return Vec<T>::make(std::move(ret));
 	}
@@ -125,10 +116,22 @@ Cpp3Native("synchronizedTernaryFn", true,
 [], ["concurrent"]),
 
 Cpp3Native("concurrentAsyncCallback", true,
-"template<typename T> Void $F_1(concurrentAsyncCallback)(Fun<Void, String*, Fun<Void, T>*>* task, Fun<Void, T>* on_done, Fun<Void, String*>* onFail);\n",
-"template<typename T> Void $F_1(concurrentAsyncCallback)(Fun<Void, String*, Fun<Void, T>*>* task, Fun<Void, T>* on_done, Fun<Void, String*>* onFail) {
-	ThreadPool::push<void>(ThreadPool::Shutdown::Block, [task, on_done]() {
-		task->callRc1($F_1(getThreadId)(), on_done);
+"template<typename T> Void $F_1(concurrentAsyncCallback)(
+	Native* nat,
+	Fun<Void, Fun<Void, T>*, Fun<Void>*>* task,
+	Fun<Void, T>* on_done,
+	Fun<Void, String*>* on_fail
+);\n",
+"template<typename T> Void $F_1(concurrentAsyncCallback)(
+	Native* nat,
+	Fun<Void, Fun<Void, T>*, Fun<Void>*>* task,
+	Fun<Void, T>* on_done,
+	Fun<Void, String*>* on_fail
+) {
+	ThreadPool* thread_pool = nat->get<ThreadPool*>();
+	decRc(fail); // TODO: use fail
+	thread_pool->push<void>(ThreadPool::Shutdown::Block, [task, on_done]() {
+		task->callRc(on_done, Fun<Void>::make([] { return void_value; }));
 	});
 	return void_value;
 }\n", "", 

--- a/tools/flowc/backends/cpp3/natives/sys_system.nats
+++ b/tools/flowc/backends/cpp3/natives/sys_system.nats
@@ -63,7 +63,7 @@ Cpp3Native("setFileContentBytes", false,
 	decRc(path);
 	// Saves the lower byte of a two-byte char, ignores the upper one.
 	for (char16_t ch: data->str()) {
-		os << static_cast<char>(ch && 0xFF);
+		os << static_cast<char>(ch & 0xFF);
 	}
 	decRc(data);
 	return os.good();

--- a/tools/flowc/backends/cpp3/natives/timer.nats
+++ b/tools/flowc/backends/cpp3/natives/timer.nats
@@ -3,18 +3,22 @@
 Cpp3Native("timer", false,
 "Void $F_1(timer)(Int delay, Fun<Void>* cb);\n",
 "Void $F_1(timer)(Int delay, Fun<Void>* cb) {
-	if (RuntimeState::isReady()) {
-		//ThreadPool::push<void>(ThreadPool::Shutdown::Block, [delay, cb]() {
-		ThreadPool::push<void>(ThreadPool::Shutdown::Skip, [delay, cb]() {
-			std::this_thread::sleep_for(std::chrono::milliseconds(delay));
-			if (RuntimeState::isReady()) {
-				cb->callRc();
-			} else {
-				decRc(cb);
-			}
-		});
-	}
+	decRc(scheduleTimerTask(delay, cb));
 	return void_value;
-}\n", "", [Cpp3Std(["<chrono>", "<thread>"], [])], [])
+}\n", "", [], ["timer"]),
+
+Cpp3Native("setInterval", false,
+"Fun<Void>* $F_1(setInterval)(Int delay, Fun<Void>* cb);\n",
+"Fun<Void>* $F_1(setInterval)(Int delay, Fun<Void>* cb) {
+	return scheduleTimerTask(delay, cb, true);
+}\n", "", [], ["timer"]),
+
+Cpp3Native("scheduleTimerTask", false,
+"Fun<Void>* $F_1(scheduleTimerTask)(Int delay, Fun<Void>* cb, Bool repeat, String* descr);\n",
+"Fun<Void>* $F_1(scheduleTimerTask)(Int delay, Fun<Void>* cb, Bool repeat, String* descr) {
+	Fun<Void>* stopper = scheduleTimerTask(delay, cb, repeat, descr->str());
+	decRc(descr);
+	return stopper;
+}\n", "", [], ["timer"])
 
 ]

--- a/tools/flowc/backends/cpp3/runtime/__flow_runtime_struct.hpp
+++ b/tools/flowc/backends/cpp3/runtime/__flow_runtime_struct.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "__flow_runtime_union.hpp"
+#include "__flow_runtime_string.hpp"
 
 namespace flow {
 

--- a/tools/flowc/backends/cpp3/runtime/__flow_runtime_threads.cpp
+++ b/tools/flowc/backends/cpp3/runtime/__flow_runtime_threads.cpp
@@ -1,7 +1,0 @@
-#include "__flow_runtime_threads.hpp"
-
-namespace flow {
-
-std::unique_ptr<ThreadPool> ThreadPool::instance_;
-
-}

--- a/tools/flowc/backends/cpp3/runtime/__flow_runtime_types.hpp
+++ b/tools/flowc/backends/cpp3/runtime/__flow_runtime_types.hpp
@@ -7,6 +7,7 @@
 #include <type_traits>
 #include <stdexcept>
 #include <thread>
+#include <chrono>
 
 namespace flow {
 
@@ -126,5 +127,11 @@ private:
 	static inline std::vector<string> args_vec_;
 	static inline std::map<string, string> args_map_;
 };
+
+inline Double timestamp() {
+	return std::chrono::duration_cast<std::chrono::milliseconds>(
+		std::chrono::system_clock::now().time_since_epoch()
+	).count();
+}
 
 }

--- a/tools/flowc/backends/cpp3/runtime/timer.runts
+++ b/tools/flowc/backends/cpp3/runtime/timer.runts
@@ -1,0 +1,147 @@
+[
+
+Cpp3RuntimePart("timer",
+"
+void scheduleTimerStart();
+void scheduleTimerStop();
+void scheduleTimerJoin();
+Fun<Void>* scheduleTimerTask(Int delay, Fun<Void>* fn, bool repeat = false, string name = u\"\");",
+"
+namespace {
+	struct Timer {
+		const string name;
+		const Int delay;
+		const bool repeat;
+		Fun<Void>* const fn;
+		Double time;
+	};
+	struct Schedule {
+		void start();
+		void stop();
+		void join();
+		void remove(const string& name);
+		std::vector<Fun<Void>*> ready();
+		Fun<Void>* add(Int delay, Fun<Void>* fn, bool repeat = false, string name = u\"\");
+	private:	
+		bool running = true;
+		std::mutex m;
+		std::map<string, Timer> timers;
+		std::thread thread;
+		Int quantum = 1000;
+	};
+	void Schedule::start() {
+		thread = std::thread([this]{
+			while (running) {
+				std::this_thread::sleep_for(
+					std::chrono::milliseconds(
+						0 < quantum && quantum < 1000 ? quantum : 1000
+					)
+				);
+				if (RuntimeState::isReady()) {
+					m.lock();
+					std::vector<Fun<Void>*> fns = ready();
+					m.unlock();
+					for (Fun<Void>* fn: fns) {
+						fn->callRc1();
+					}
+				}
+			}
+		});
+	}
+	void Schedule::stop() {
+		m.lock();
+		running = false;
+		while (!timers.empty()) {
+			remove(timers.begin()->first);
+		}
+		m.unlock();
+	}
+	void Schedule::join() {
+		thread.join();
+	}
+	void Schedule::remove(const string& name) {
+		if (timers.count(name)) {
+			const Timer& inst = timers.at(name);
+			decRc(inst.fn);
+			timers.erase(name);
+			if (timers.size() == 0) {
+				quantum = 1000;
+				//thread = std::thread();
+			} else {
+				quantum = 0;
+				for (auto& p: timers) {
+					quantum = (quantum == 0) ? p.second.delay : std::gcd(quantum, p.second.delay);
+				}
+			}
+		}
+	}
+	std::vector<Fun<Void>*> Schedule::ready() {
+		std::vector<Fun<Void>*> fns;
+		Double now = timestamp();
+		std::vector<string> to_remove;
+		for (auto& p: timers) {
+			Timer& inst = p.second;
+			if (inst.time <= now) {
+				fns.push_back(inst.fn);
+				if (inst.repeat) {
+					inst.time = now + int2double(inst.delay);
+				} else {
+					to_remove.push_back(inst.name);
+				}
+			}
+		}
+		for (auto& name: to_remove) {
+			remove(name);
+		}
+		return fns;
+	}
+	Fun<Void>* Schedule::add(Int delay, Fun<Void>* fn, bool repeat, string name) {
+		m.lock();
+		if (name.size() == 0) {
+			name = u\"timer_\" + std2string(std::to_string(timers.size()));
+		}
+		quantum = (timers.size() == 0) ? delay : std::gcd(quantum, delay);
+		timers.emplace(name, std::move(Timer{name, delay, repeat, fn, timestamp() + int2double(delay)}));
+		m.unlock();
+		//init();
+		return Fun<Void>::make([this, name]() {
+			m.lock();
+			remove(name);
+			m.unlock();
+			return void_value;
+		});
+	}
+}
+
+Schedule scheduler;
+
+Fun<Void>* scheduleTimerTask(Int delay, Fun<Void>* fn, bool repeat, string name) {
+	if (delay < 0) {
+		fail(\"negative delay for a timer\");
+	}
+	if (delay == 0) {
+		// Instant execution
+		fn->callRc();
+		return Fun<Void>::make([]() { return void_value; });
+	} else {
+		return scheduler.add(delay, fn, repeat, name);
+	}
+}
+void scheduleTimerStart() {
+	scheduler.start();
+}
+void scheduleTimerStop() {
+	scheduler.stop();
+}
+void scheduleTimerJoin() {
+	scheduler.join();
+}
+",
+
+"scheduleTimerStart();",
+"scheduleTimerStop();",
+"scheduleTimerJoin();",
+
+[Cpp3Std(["<numeric>"], [])], false)
+
+]

--- a/tools/flowc/statements/fs_helpers.flow
+++ b/tools/flowc/statements/fs_helpers.flow
@@ -282,6 +282,11 @@ fsEqualExprs(x: FsAll, y: FsAll) -> bool {
 				all(mapi(args1, \i, a1 -> fsEqualExprs(a1, args2[i]))) &&
 				fsEqualExprs(f1, f2);
 			}
+			FsInlineExp(fn2, args2, __,__): {
+				length(args1) == length(args2) &&
+				all(mapi(args1, \i, a1 -> fsEqualExprs(a1, args2[i]))) &&
+				f1.var.name == fn2;
+			}
 			default: false;
 		}
 		FsInlineExp(n1, args1,__,__): switch (y) {
@@ -290,11 +295,34 @@ fsEqualExprs(x: FsAll, y: FsAll) -> bool {
 				length(args1) == length(args2) &&
 				all(mapi(args1, \i, a1 -> fsEqualExprs(a1, args2[i])));
 			}
+			FsCall(f2, args2,__,__): {
+				length(args1) == length(args2) &&
+				all(mapi(args1, \i, a1 -> fsEqualExprs(a1, args2[i]))) &&
+				n1 == f2.var.name;
+			}
 			default: false;
 		}
 		FsCallPrim(op1, es1,__,__): switch (y) {
 			FsCallPrim(op2, es2,__,__): {
-				op1 == op2 &&
+				switch (op1) {
+					FsArrayPrim(__): switch (op2) {
+						FsArrayPrim(__): true;
+						default: false;
+					}
+					FsRefPrim(__): switch (op2) {
+						FsRefPrim(__): true;
+						default: false;
+					}
+					FsStructPrim(struct1,__): switch (op2) {
+						FsStructPrim(struct2,__): struct1 == struct2;
+						default: false;
+					}
+					FsFieldPrim(field1,__): switch (op2) {
+						FsFieldPrim(field2,__): field1 == field2;
+						default: false;
+					}
+					default: op1 == op2;
+				} &&
 				length(es1) == length(es2) &&
 				all(mapi(es1, \i, a1 -> fsEqualExprs(a1, es2[i])));
 			}

--- a/tools/flowc/statements/fs_perceus.flow
+++ b/tools/flowc/statements/fs_perceus.flow
@@ -313,7 +313,7 @@ fsPerceusAddExp2Mem(acc: FsMem, e: FsExp, last: [Set<string>], inline: bool, int
 			}
 			op_intrinsic = switch (op) {
 				FsIntrinsicPrim(name): {
-					if (name == "vecSet") {
+					if (name == "vecSet" || name == "vecPush") {
 						false;
 					} else {
 						true;

--- a/tools/flowc/statements/fs_transform.flow
+++ b/tools/flowc/statements/fs_transform.flow
@@ -204,7 +204,7 @@ fsFold1(s: FsAll, v0: ?, pre: (?, FsAll) -> ?, post: (?, FsAll) -> ?, order: ([F
 fsArgs(s: FsAll) -> [FsAll] {
 	as = switch (s) {
 		FsIf(cond, s1, s2,__,__): [cond, s1, s2];
-		FsSwitch(x,__,cs,__,__):  map(cs, \c -> c.body);
+		FsSwitch(x,__,cs,__,__):  concat([x], map(cs, \c -> c.body));
 		FsLet(__,__,e1, s1,__,__):[e1, s1];
 		FsFor(__,e1,s1,__,__,__): [e1, s1];
 		FsWrapExp(e1,__,__):      [e1];
@@ -233,7 +233,7 @@ fsArgs(s: FsAll) -> [FsAll] {
 fsArgs1(s: FsAll) -> [FsAll] {
 	as = switch (s) {
 		FsIf(cond, s1, s2,__,__): [cond, s1, s2];
-		FsSwitch(x,__,cs,__,__):  map(cs, \c -> c.body);
+		FsSwitch(x,__,cs,__,__):  concat([x], map(cs, \c -> c.body));
 		FsLet(__,__,e1, s1,__,__):[e1, s1];
 		FsFor(__,e1,s1,__,__,__): [e1, s1];
 		FsWrapExp(e1,__,__):      [e1];


### PR DESCRIPTION
The `cpp3` backend is updated and made in-sync with the current state of the standard library. Some bugs are fixed.

Now `flowc` may bootstrap itself on the `cpp3` backend, e.g. by executing following command in the `tools/flowc` directory:
```
flowc1 \
    cpp3=flowc2 \
    cpp-build-jobs=<choose appropriate number of workers> \
    cpp-verbose=1 \
    server=0 \
    cpp-compiler=clang++ \
    cpp-mimalloc=1 \
    dce-types=1 \
    \
    flowc
```
This build command assumes, that `clang++` and `mimalloc` are installed on the system. That's the most fast option, in case you use default c++ compiler and no mimalloc library, just remove appropriate lines from the command.

**NOTE:** The number of workers typically depends on the amount of RAM available: with 16Gb of RAM it's better to set it not more then 4. With 64Gb of RAM onboard you can set the number of logical cores available.
