### PR TITLE
Rework `values2arrayTree` using List;

### DIFF
--- a/lib/ds/tree.flow
+++ b/lib/ds/tree.flow
@@ -749,7 +749,11 @@ values2treeMerge(xs : [?], getKey : (?) -> ??, defValue : ???, mergeFn : (???, ?
 }
 
 values2arrayTree(xs : [?], getKey : (?) -> ??) -> Tree<??, [?]> {
-	fold(xs, makeTree(), \t, d -> treePushToArrayValue(t, getKey(d), d));
+	treeLists = fold(xs, makeTree(), \acc, x -> {
+		key = getKey(x);
+		setTree(acc, key, Cons(x, lookupTreeDef(acc, key, EmptyList())));
+	});
+	mapTree(treeLists, list2array);
 }
 
 tree2list(tree : Tree<?, ??>) -> List<Pair<?, ??>> {

--- a/tests/valuest2array_tree_speed.flow
+++ b/tests/valuest2array_tree_speed.flow
@@ -43,15 +43,40 @@ testSpeed2(arrLength : int, avgTreeValueLength : int) -> void {
 	testSpeed(arrLength, avgTreeValueLength);
 }
 
+testForShortArray(arrayLength : int, repeatCount : int, oneKey : bool) -> void {
+	arr = generate(0, arrayLength, \i -> random());
+	getKey = if (oneKey) \__ -> 0.0 else idfn;
+	if (oneKey) {
+		println("Speed test for " + i2s(arrayLength) + " element array. All elements has the same key. " + i2s(repeatCount) + " repetitions.");
+		\__ -> 0.0;
+	} else {
+		println("Speed test for " + i2s(arrayLength) + " element array. All elements has different keys. " + i2s(repeatCount) + " repetitions.");
+		idfn;
+	}
+
+	tm1 = timestamp();
+	fori(1, repeatCount, \__ -> ignore(values2arrayTree(arr, getKey)));
+	println("New function: " + i2s(trunc(timestamp() - tm1)) + " ms");
+
+	tm2 = timestamp();
+	fori(1, repeatCount, \__ -> ignore(values2arrayTreeOld(arr, getKey)));
+	println("Old function: " + i2s(trunc(timestamp() - tm2)) + " ms");
+}
+
 main() {
+	// Tests for long arrays
 	arrLength = 100000;
 
 	iter(
-		[1, 2, 4, 8, 16, 32, 64, 100, 128, 1000, 10000],
+		[1, 2, 4, 128, 256, 512, 1000, 10000],
 		\avgTreeValueLength -> testSpeed2(arrLength, avgTreeValueLength)
 	);
 
 	testSpeed2(arrLength * 10, 10000);
+
+	// Tests for short arrays
+	testForShortArray(50, 10000, true);
+	testForShortArray(50, 10000, false);
 
 	quit(0);
 }

--- a/tests/valuest2array_tree_speed.flow
+++ b/tests/valuest2array_tree_speed.flow
@@ -1,0 +1,57 @@
+import math/math;
+import ds/tree;
+
+values2arrayTreeOld(xs : [?], getKey : (?) -> ??) -> Tree<??, [?]> {
+	fold(xs, makeTree(), \t, d -> treePushToArrayValue(t, getKey(d), d));
+}
+
+testSpeed(arrLength : int, avgTreeValueLength : int) -> void {
+	keysCount = arrLength / avgTreeValueLength;
+
+	println(formatString(
+		"Compare values2arrayTree speed on array of %1 elements, splitting this array into ~%2 parts by ~%3 elements",
+		[i2s(arrLength), i2s(keysCount), i2s(avgTreeValueLength)]
+	));
+
+	arr = generate(0, arrLength, \i -> random());
+	getKey = \v -> trunc(v * i2d(keysCount));
+
+	tm1 = timestamp();
+	t1 = values2arrayTree(arr, getKey);
+	dt1 = timestamp() - tm1;
+
+	tm2 = timestamp();
+	t2 = values2arrayTreeOld(arr, getKey);
+	dt2 = timestamp() - tm2;
+
+	f1 = if (dt1 < dt2) "*" else "";
+	f2 = if (dt2 < dt1) "*" else "";
+
+	println(f1 + "New function: " + i2s(trunc(dt1)) + " ms");
+	println(f2 + "Old function: " + i2s(trunc(dt2)) + " ms");
+
+	if (t1 == t2) {
+		println("Trees are exactly the same. Tree size: " + i2s(sizeTree(t1)) + "\n");
+	} else {
+		fail("Trees are different!");
+	}
+}
+
+testSpeed2(arrLength : int, avgTreeValueLength : int) -> void {
+	println("----------");
+	testSpeed(arrLength, avgTreeValueLength);
+	testSpeed(arrLength, avgTreeValueLength);
+}
+
+main() {
+	arrLength = 100000;
+
+	iter(
+		[1, 2, 4, 8, 16, 32, 64, 100, 128, 1000, 10000],
+		\avgTreeValueLength -> testSpeed2(arrLength, avgTreeValueLength)
+	);
+
+	testSpeed2(arrLength * 10, 10000);
+
+	quit(0);
+}


### PR DESCRIPTION
New implementation is slightly slower if values of the resulting tree are shorter then about 300 elements,
but it is much faster if this tree has values with more than a thousand elements.

Speed test
```
Compare values2arrayTree speed on array of 100000 elements, splitting this array into ~100000 parts by ~1 elements
*New function: 292 ms
Old function: 301 ms
Trees are exactly the same. Tree size: 63355

Compare values2arrayTree speed on array of 100000 elements, splitting this array into ~100000 parts by ~1 elements
*New function: 262 ms
Old function: 303 ms
Trees are exactly the same. Tree size: 63237

----------
Compare values2arrayTree speed on array of 100000 elements, splitting this array into ~50000 parts by ~2 elements
New function: 281 ms
*Old function: 264 ms
Trees are exactly the same. Tree size: 43270

Compare values2arrayTree speed on array of 100000 elements, splitting this array into ~50000 parts by ~2 elements
New function: 253 ms
*Old function: 236 ms
Trees are exactly the same. Tree size: 43221

----------
Compare values2arrayTree speed on array of 100000 elements, splitting this array into ~25000 parts by ~4 elements
New function: 228 ms
*Old function: 216 ms
Trees are exactly the same. Tree size: 24541

Compare values2arrayTree speed on array of 100000 elements, splitting this array into ~25000 parts by ~4 elements
New function: 231 ms
*Old function: 219 ms
Trees are exactly the same. Tree size: 24546

----------
Compare values2arrayTree speed on array of 100000 elements, splitting this array into ~781 parts by ~128 elements
New function: 161 ms
*Old function: 142 ms
Trees are exactly the same. Tree size: 781

Compare values2arrayTree speed on array of 100000 elements, splitting this array into ~781 parts by ~128 elements
New function: 183 ms
*Old function: 174 ms
Trees are exactly the same. Tree size: 781

----------
Compare values2arrayTree speed on array of 100000 elements, splitting this array into ~390 parts by ~256 elements
New function: 152 ms
*Old function: 134 ms
Trees are exactly the same. Tree size: 390

Compare values2arrayTree speed on array of 100000 elements, splitting this array into ~390 parts by ~256 elements
New function: 134 ms
*Old function: 130 ms
Trees are exactly the same. Tree size: 390

----------
Compare values2arrayTree speed on array of 100000 elements, splitting this array into ~195 parts by ~512 elements
*New function: 119 ms
Old function: 190 ms
Trees are exactly the same. Tree size: 195

Compare values2arrayTree speed on array of 100000 elements, splitting this array into ~195 parts by ~512 elements
*New function: 119 ms
Old function: 130 ms
Trees are exactly the same. Tree size: 195

----------
Compare values2arrayTree speed on array of 100000 elements, splitting this array into ~100 parts by ~1000 elements
*New function: 104 ms
Old function: 132 ms
Trees are exactly the same. Tree size: 100

Compare values2arrayTree speed on array of 100000 elements, splitting this array into ~100 parts by ~1000 elements
*New function: 104 ms
Old function: 214 ms
Trees are exactly the same. Tree size: 100

----------
Compare values2arrayTree speed on array of 100000 elements, splitting this array into ~10 parts by ~10000 elements
*New function: 66 ms
Old function: 1228 ms
Trees are exactly the same. Tree size: 10

Compare values2arrayTree speed on array of 100000 elements, splitting this array into ~10 parts by ~10000 elements
*New function: 74 ms
Old function: 1246 ms
Trees are exactly the same. Tree size: 10

----------
Compare values2arrayTree speed on array of 1000000 elements, splitting this array into ~100 parts by ~10000 elements
*New function: 1250 ms
Old function: 14669 ms
Trees are exactly the same. Tree size: 100

Compare values2arrayTree speed on array of 1000000 elements, splitting this array into ~100 parts by ~10000 elements
*New function: 1300 ms
Old function: 15457 ms
Trees are exactly the same. Tree size: 100
```