### PR TITLE
add fontWrapperT subscriptions for

### DIFF
--- a/lib/material/internal/material_textinput_state.flow
+++ b/lib/material/internal/material_textinput_state.flow
@@ -2549,6 +2549,8 @@ makeNativeEditorView(manager : MaterialManager, parent : MFocusGroup, state : [M
 			)
 		);
 
+	fontWrapperT = either(parent.theme.fontWrapper, const(MFontWrapper(\font, __, __ -> font)));
+
 	inputSize =
 		TGroup2(
 			if (inputState.width == 0.)
@@ -2569,7 +2571,10 @@ makeNativeEditorView(manager : MaterialManager, parent : MFocusGroup, state : [M
 					);
 				}
 			} else {
-				THeight(TSelect(inputState.textStyle, \ts -> TText("m", MTextStyle2CharacterStyle(inputState.parent, ts))))
+				THeight(TSelect2(
+					inputState.textStyle, fontWrapperT,
+					\ts, __ -> TText("m", MTextStyle2CharacterStyle(inputState.parent, ts))
+				))
 			}
 		);
 
@@ -2640,7 +2645,10 @@ makeNativeEditorView(manager : MaterialManager, parent : MFocusGroup, state : [M
 
 									filterKey;
 								}),
-								FCharacterStyle(fselect(inputState.textStyle, FLift(\ts : [MTextStyle] -> MTextStyle2CharacterStyle(parent, ts)))),
+								FCharacterStyle(fselect2(
+									inputState.textStyle, fontWrapperT,
+									FLift2(\ts : [MTextStyle], __ -> MTextStyle2CharacterStyle(parent, ts))
+								)),
 								SetRTL(parent.rtl),
 								FPreventFromXSS(extractStruct(state, MInputPreventFromXSS(enablePreventXSSDef)).enable)
 							],


### PR DESCRIPTION
https://trello.com/c/8VZKddPA/27918-letters-m-and-w-look-cropped-in-crossword-probes-under-the-hachette-skin