### PR TITLE
Introduced `FLiftExpensive` to avoid calling expansive functions again

### DIFF
--- a/lib/fusion.flow
+++ b/lib/fusion.flow
@@ -220,11 +220,18 @@ export {
 	transform2string(s : Transform<?>) -> string;
 
 	// Builtin functions - use the functions above instead
-	FFn<?, ??> ::= FLift<?, ??>, FCompose<?, ??>, FIdentity, FNegate,
+	FFn<?, ??> ::= FLift<?, ??>, FLiftExpensive<?, ??>, FCompose<?, ??>, FIdentity, FNegate,
 			FAddConst, FMulConst, FMaxConst<??>, FMinConst<??>, FEqual<?>, FIf<??>;
 
-		// This is for using any other transform function
+		// This is for using any other transform function. If fn is an expansive (e.g. slow) function, use FLiftExpensive instead.
 		FLift(fn : (?) -> ??);
+		// Use this instead of FLift if fn can be slow, can consume a lot of memory etc.
+		// FLift.fn can be called several times even if all behaviors have not changed.
+		// It happens because of an optimization in fselect2, that avoids creating intermadiate bahaviors and
+		// creates a new function from arguments of fselect2.
+		// An example of such behaviour is in tests/flift_expensive_test.flow
+		// FLiftExpensive.fn is not called twice in this situation.
+		FLiftExpensive(fn : (?) -> ??);
 
 		// f1 o f2 == f1(f2(x))
 		FCompose(f1 : FFn<flow, ??>, f2 : FFn<?, flow>);
@@ -292,45 +299,16 @@ fselect(b : Transform<??>, fn : FFn<??, ?>) -> Transform<?> {
 }
 
 fselect2(b1 : Transform<??>, b2 : Transform<???>, fn : FFn2<??, ???, ?>) -> Transform<?> {
-	switch (b1 : Transform<??>) {
-		ConstBehaviour(v1): {
-			ifn = instantiateFn2(fn);
-
-			switch (b2 : Transform<???>) {
-				ConstBehaviour(v2): ConstBehaviour(ifn(v1, v2));
-				default: fselect(b2, FLift(\v -> ifn(v1, v)));
+	def1 = \ -> {
+		switch (b2 : Transform<???>) {
+			ConstBehaviour(v2): {
+				ifn = instantiateFn2(fn);
+				fselect(b1, FLift(\v -> ifn(v, v2)));
 			}
-		}
-		FSelect(nb1, nf1, __): {
-			ifn = instantiateFn2(fn);
-
-			switch (b2 : Transform<???>) {
-				FSelect(nb2, nf2, __): {
-					ifn1 = instantiateFn(nf1);
-					ifn2 = instantiateFn(nf2);
-					if (nb1 == nb2) {
-						FSelect(nb1, FLift(\f -> ifn(ifn1(f), ifn2(f))), FDestroyed());
-					} else {
-						FSelect2(nb1, nb2, FLift2(\f, s -> ifn(ifn1(f), ifn2(s))), FDestroyed());
-					}
-				}
-				default: {
-					ifn1 = instantiateFn(nf1);
-					if (nb1 == b2) {
-						FSelect(nb1, FLift(\f -> ifn(ifn1(f), f)), FDestroyed());
-					} else {
-						FSelect2(nb1, b2, FLift2(\f, s -> ifn(ifn1(f), s)), FDestroyed());
-					}
-				}
-			}
-		}
-		default: {
-			switch (b2 : Transform<???>) {
-				ConstBehaviour(v2): {
-					ifn = instantiateFn2(fn);
-					fselect(b1, FLift(\v -> ifn(v, v2)));
-				}
-				FSelect(nb, nf2, __): {
+			FSelect(nb, nf2, __): {
+				if (isExpensiveFFn(nf2)) {
+					FSelect2(b1, b2, fn, FDestroyed());
+				} else {
 					ifn2 = instantiateFn(nf2);
 					if (supportsLazy(fn)) {
 						ifn = instantiateFn2Lazy(fn);
@@ -348,18 +326,64 @@ fselect2(b1 : Transform<??>, b2 : Transform<???>, fn : FFn2<??, ???, ?>) -> Tran
 						}
 					}
 				}
-				default: {
-					FSelect2(b1, b2, fn, FDestroyed());
+			}
+			default: {
+				FSelect2(b1, b2, fn, FDestroyed());
+			}
+		}
+	}
+	switch (b1 : Transform<??>) {
+		ConstBehaviour(v1): {
+			ifn = instantiateFn2(fn);
+
+			switch (b2 : Transform<???>) {
+				ConstBehaviour(v2): ConstBehaviour(ifn(v1, v2));
+				default: fselect(b2, FLift(\v -> ifn(v1, v)));
+			}
+		}
+		FSelect(nb1, nf1, __): {
+			if (isExpensiveFFn(nf1)) {
+				def1();
+			} else {
+				ifn1 = instantiateFn(nf1);
+				ifn = instantiateFn2(fn);
+				def2 = \ -> {
+					if (nb1 == b2) {
+						FSelect(nb1, FLift(\f -> ifn(ifn1(f), f)), FDestroyed());
+					} else {
+						FSelect2(nb1, b2, FLift2(\f, s -> ifn(ifn1(f), s)), FDestroyed());
+					}
+				}
+				switch (b2 : Transform<???>) {
+					FSelect(nb2, nf2, __): {
+						if (isExpensiveFFn(nf2)) {
+							def2();
+						} else {
+							ifn2 = instantiateFn(nf2);
+							if (nb1 == nb2) {
+								FSelect(nb1, FLift(\f -> ifn(ifn1(f), ifn2(f))), FDestroyed());
+							} else {
+								FSelect2(nb1, nb2, FLift2(\f, s -> ifn(ifn1(f), ifn2(s))), FDestroyed());
+							}
+						}
+					}
+					default: def2();
 				}
 			}
 		}
+		default: def1();
 	}
 }
 
 fsubselect(b : Transform<??>, fn : FFn<??, Transform<?>>) -> Transform<?> {
 	switch (b) {
 		ConstBehaviour(v): {
-			instantiateFn(fn)(v);
+			// Do not run expensive function in constructor, it will be evaluated in fgetValue or on subscribe if needed.
+			if (isExpensiveFFn(fn)) {
+				FSubSelect(b, fn, FDestroyed());
+			} else {
+				instantiateFn(fn)(v);
+			}
 		}
 		FSelect(a, f2, __): {
 			c = fcompose(fn, f2);
@@ -1242,6 +1266,7 @@ transform2string(s : Transform<?>) -> string {
 	}
 }
 
+//Dead code
 transformLength(s : Transform<?>) -> int {
 	switch (s : Transform<?>) {
 		ConstBehaviour(v): {
@@ -2112,10 +2137,18 @@ supportsLazy(fn : FFn2<?, ??, ???>) -> bool {
 	}
 }
 
+isExpensiveFFn(fn : FFn<?, ??>) -> bool {
+	switch (fn) {
+		FLiftExpensive(__): true;
+		default: false;
+	}
+}
+
 instantiateFn(fn : FFn<?, ??>) -> (?) -> ?? {
 	// println(ffn2string(fn));
 	switch (fn : FFn<?, ??>) {
 		FLift(f): f;
+		FLiftExpensive(f): f;
 		FCompose(f1, f2): {
 			// TODO: If f1 or f2 are lifted, we can do better
 			//lf1 : (???) -> ?? = instantiateFn(f1);
@@ -2179,6 +2212,7 @@ instantiateFn2Lazy(fn : FFn2<?, ??, ???>) -> (?, () -> ??) -> ??? {
 ffn2string(fn : FFn<?, ??>) -> string {
 	switch (fn) {
 		FLift(fl): trim2(takeAfter(safeToString(fn), ": ", safeToString(fn)), ")>");
+		FLiftExpensive(fl): "ex#" + trim2(takeAfter(safeToString(fn), ": ", safeToString(fn)), ")>");
 		FCompose(f1, f2): "(" + ffn2string(f1) + ")o(" + ffn2string(f2) + ")";
 		FIdentity(): "id";
 		FNegate(): "~";
@@ -2212,7 +2246,7 @@ safeToString(t : flow) -> string {
 	if (isSameStructType(t, t)) {
 		// OK, it is a struct
 		sname = t.structname;
-		if (sname == "FLift" || sname == "FLift2") {
+		if (sname == "FLift" || sname == "FLiftExpensive" || sname == "FLift2") {
 			toString(extractStructArguments(t)[0])
 		} else if (isSameStructType(t, zero)) {
 			ct : ConstBehaviour<flow> = cast(t : flow -> ConstBehaviour<flow>);

--- a/tests/flift_expensive_test.flow
+++ b/tests/flift_expensive_test.flow
@@ -1,0 +1,123 @@
+import fusion_utils;
+
+printTransformsState(transforms : [Transform]) -> void {
+	println("\nState:");
+	iteri(transforms, \i, trans -> {
+		println("trans" + i2s(i + 1) + ": " + trans2state(trans));
+	});
+}
+
+trans2state(trans : Transform) -> string {
+	switch (trans) {
+		FSelect(__, __, fBeh): fBeh2state(fBeh);
+		FSelect2(__, __, __, fBeh): fBeh2state(fBeh);
+		FSubSelect(__, __, fBeh): fBeh2state(fBeh);
+		FConstructable(__, __, fBeh): fBeh2state(fBeh);
+		default: "None";
+	}
+}
+
+fBeh2state(fBeh : FBehaviour<?>) -> string {
+	switch (fBeh) {
+		FDestroyed(): "Destroyed";
+		FInitialized(__, __, __): "Initialized";
+	}
+}
+
+createTransforms(useFLiftExpensive : bool) -> [Transform] {
+	createFLift = \fn : (int) -> flow -> if (useFLiftExpensive) FLiftExpensive(fn) else FLift(fn);
+
+	beh1 = make(1);
+	beh2 = make(2);
+
+	trans1 = fselect(beh1, createFLift(\v -> {
+		println("  call fn1");
+		v;
+	}));
+	trans2 = fselect(trans1, createFLift(\v -> {
+		println("  call fn2");
+		v;
+	}));
+	trans3 = fselect(beh2, createFLift(\v -> {
+		println("  call fn3");
+		v;
+	}));
+	trans4 = fselect2Lift(trans2, trans3, \v1, v2 -> {
+		println("  call fn4");
+		v1 + v2;
+	});
+	trans5 = fselect2Lift(trans4, trans3, \v1, v2 -> {
+		println("  call fn5");
+		v1 + v2;
+	});
+	trans6 = fselect2Lift(trans5, const(9), \v1, v2 -> {
+		println("  call fn6");
+		v1 + v2;
+	});
+	trans7 = fsubselect(trans6, createFLift(\__ -> {
+		println("  call fn7");
+		trans6;
+	}));
+	trans8 = fsubselect(const(9), createFLift(\__ -> {
+		println("  call fn8");
+		trans7;
+	}));
+	trans9 = fselect(trans8, createFLift(\v -> {
+		println("  call fn9");
+		v;
+	}));
+	trans10 = fselect2Lift(trans8, trans9, \v1, v2 -> {
+		println("  call fn10");
+		v1 + v2;
+	});
+	[trans1, trans2, trans3, trans4, trans5, trans6, trans7, trans8, trans9, trans10];
+}
+
+test(useFLiftExpensive : bool, reversSubscribe : bool) -> void {
+	println("Creating transforms");
+	transforms = createTransforms(useFLiftExpensive);
+	count = length(transforms);
+
+	subscribeTransformIfNotInitialized = \idx -> {
+		name = i2s(idx + 1);
+		trans = transforms[idx];
+		if (trans2state(trans) == "Initialized") {
+			println("Transform " + name + " is already initialized");
+			makeList();
+		} else {
+			println("Subscribing transform " + name);
+			fsubscribe(trans, \__ -> {
+				println("  Transform " + name + " calculated");
+			});
+		}
+	}
+
+	uns = if (reversSubscribe) {
+		println("Subscribing transforms from last to first");
+		generate(0, count, \i -> {
+			subscribeTransformIfNotInitialized(count - 1 - i);
+		});
+	} else {
+		println("Subscribing transforms from first to last");
+		mapi(transforms, \i, __ -> subscribeTransformIfNotInitialized(i));
+	}
+
+	println("Getting values");
+	println(map(transforms, \trans -> fgetValue(trans)));
+
+	iter(uns, \u -> applyList(u, apply0));
+	println("Done");
+}
+
+main() {
+	reversSubscribe = true;
+
+	println("=== Using FLift");
+	test(false, reversSubscribe);
+
+	println("");
+	println("=== Using FLiftExpensive");
+	test(true, reversSubscribe);
+
+	quit(0);
+}


### PR DESCRIPTION
We use Transform a lot. But sometimes Transform behaves unclear.

For example we can use transforms to create trees.
```
classId2learnersT = fselectLift(learnersB, \learners -> valuesToArrayTree(learners, \learner -> learner.classId);
```
We do not expect to recalculate this expensive tree until learnersB changes.
But it happens if we use `classId2learnersT` in `fselect2`, because `fselect2` creates new function from our expansive function.
We do not want to change this behavior, because as @NikitaFil says, it may increase the number of DynamicBehaviours and memory consumption.

So we need `FLiftExpensive` to mark expensive functions and avoid unwanted recalculations.

Here is a test example https://github.com/area9innovation/flow9/compare/FLiftExpensive?expand=1#diff-97db1eea617660e99c205157e61ab96a911c7206daa6b1261e5149885ca19524
Output:
```
=== Using FLift
Creating transforms
  call fn8
Subscribing transforms from last to first
Subscribing transform 10
  call fn1
  call fn2
  call fn3
  call fn4
  call fn3
  call fn5
  call fn6
  call fn7
  call fn9
  call fn10
  Transform 10 calculated
Subscribing transform 9
  call fn9
  Transform 9 calculated
Transform 8 is already initialized
Transform 7 is already initialized
Transform 6 is already initialized
Transform 5 is already initialized
Transform 4 is already initialized
Subscribing transform 3
  call fn3
  Transform 3 calculated
Subscribing transform 2
  call fn2
  Transform 2 calculated
Transform 1 is already initialized
Getting values
[1, 1, 2, 3, 5, 14, 14, 14, 14, 28]
Done

=== Using FLiftExpensive
Creating transforms
Subscribing transforms from last to first
Subscribing transform 10
  call fn8
  call fn1
  call fn2
  call fn3
  call fn4
  call fn5
  call fn6
  call fn7
  call fn9
  call fn10
  Transform 10 calculated
Transform 9 is already initialized
Transform 8 is already initialized
Transform 7 is already initialized
Transform 6 is already initialized
Transform 5 is already initialized
Transform 4 is already initialized
Transform 3 is already initialized
Transform 2 is already initialized
Transform 1 is already initialized
Getting values
[1, 1, 2, 3, 5, 14, 14, 14, 14, 28]
Done
```
As you can see from the example above, an additional benefit of `FLiftExpensive` is that initializing a transform also initializes the influencing transforms with `FLiftExpensive`, even if they are behind `fselect2`.
