### PR TITLE
JS. TextClip. Added native font properties measurement.

### DIFF
--- a/platforms/js/PixiWorkarounds.hx
+++ b/platforms/js/PixiWorkarounds.hx
@@ -613,13 +613,13 @@ class PixiWorkarounds {
 				nativeSetProperty.call(this, propertyName, value, priority);
 			}
 
-			PIXI.TextMetrics.measureText = function(text, style, wordWrap, canvas)
+			PIXI.TextMetrics.measureText = function(text, style, wordWrap, canvas, useNativeMetrics)
 			{
 				canvas = typeof canvas !== 'undefined' ? canvas : PIXI.TextMetrics._canvas;
 
 				wordWrap = (wordWrap === undefined || wordWrap === null) ? style.wordWrap : wordWrap;
 				const font = style.toFontString();
-				const fontProperties = PIXI.TextMetrics.measureFont(font);
+				const fontProperties = PIXI.TextMetrics.measureFont(font, useNativeMetrics);
 
 				// fallback in case UA disallow canvas data extraction
 				// (toDataURI, getImageData functions)
@@ -711,7 +711,7 @@ class PixiWorkarounds {
 				);
 			}
 
-			PIXI.TextMetrics.measureFont = function(font, fontSize)
+			PIXI.TextMetrics.measureFont = function(font, fontSize, useNativeMetrics)
 			{
 				// as this method is used for preparing assets, don't recalculate things if we don't need to
 				if (PIXI.TextMetrics._fonts[font])
@@ -727,7 +727,8 @@ class PixiWorkarounds {
 				context.font = font;
 
 				const metricsString = PIXI.TextMetrics.METRICS_STRING + PIXI.TextMetrics.BASELINE_SYMBOL;
-				const width = Math.ceil(context.measureText(metricsString).width);
+				const textMeasurement = context.measureText(metricsString);
+				const width = Math.ceil(textMeasurement.width);
 				var baseline = Math.ceil(context.measureText(PIXI.TextMetrics.BASELINE_SYMBOL).width) * 2;
 				const height = 2 * baseline;
 
@@ -778,7 +779,11 @@ class PixiWorkarounds {
 					}
 				}
 
-				properties.ascent = baseline - i;
+				if (useNativeMetrics) {
+					properties.ascent = textMeasurement.actualBoundingBoxAscent;
+				} else {
+					properties.ascent = baseline - i;
+				}
 
 				idx = pixels - line;
 				stop = false;
@@ -805,7 +810,13 @@ class PixiWorkarounds {
 					}
 				}
 
-				properties.descent = i - baseline;
+
+				if (useNativeMetrics) {
+					properties.descent = textMeasurement.actualBoundingBoxDescent;
+				} else {
+					properties.descent = i - baseline;
+				}
+
 				properties.fontSize = properties.ascent + properties.descent;
 
 				PIXI.TextMetrics._fonts[font] = properties;

--- a/platforms/js/PixiWorkarounds.hx
+++ b/platforms/js/PixiWorkarounds.hx
@@ -819,6 +819,8 @@ class PixiWorkarounds {
 
 				properties.fontSize = properties.ascent + properties.descent;
 
+				console.log('Font metrics for ' + font + ' - ascent: ' + properties.ascent + ', descent: ' + properties.descent + ', fontSize: ' + properties.fontSize);
+
 				PIXI.TextMetrics._fonts[font] = properties;
 
 				return properties;

--- a/platforms/js/TextClip.hx
+++ b/platforms/js/TextClip.hx
@@ -630,7 +630,11 @@ class TextClip extends NativeWidgetClip {
 			// Looks like a browser bug, so we need this workaround
 			if (amiriItalicWorkaroundWidget == null) {
 				var txt = 't';
-				var charMetrics = TextMetrics.measureText(txt, style);
+				var useNativeMetrics = Util.getParameter("use_native_measurement") == "1";
+				var charMetrics : Dynamic = null;
+				untyped __js__(
+					"charMetrics = PIXI.TextMetrics.measureText(txt, style, null, null, useNativeMetrics);"
+				);
 				amiriItalicWorkaroundWidget = Browser.document.createElement('span');
 				amiriItalicWorkaroundWidget.classList.add('amiriItalicWorkaroundWidget');
 				amiriItalicWorkaroundWidget.style.position = 'relative';
@@ -877,7 +881,8 @@ class TextClip extends NativeWidgetClip {
 	}
 
 	private function measureFont() : Void {
-		untyped __js__("this.style.fontProperties = PIXI.TextMetrics.measureFont(this.style.toFontString(), this.style.fontSize);");
+		var useNativeMetrics = Util.getParameter("use_native_measurement") == "1";
+		untyped __js__("this.style.fontProperties = PIXI.TextMetrics.measureFont(this.style.toFontString(), this.style.fontSize, useNativeMetrics);");
 	}
 
 	private function layoutText() : Void {
@@ -1822,14 +1827,21 @@ class TextClip extends NativeWidgetClip {
 
 	private function updateTextMetrics() : Void {
 		if (metrics == null && untyped text != "" && style.fontSize > 1.0) {
+			var useNativeMetrics = Util.getParameter("use_native_measurement") == "1";
 			if (!escapeHTML) {
 				var contentGlyphsModified = untyped __js__("this.contentGlyphs.modified.replace(/<\\/?[^>]+(>|$)/g, '')");
-				metrics = TextMetrics.measureText(contentGlyphsModified, style);
+				// metrics = untyped TextMetrics.measureText(contentGlyphsModified, style, null, null, useNativeMetrics);
+				untyped __js__(
+					"this.metrics = PIXI.TextMetrics.measureText(contentGlyphsModified, this.style, undefined, undefined, useNativeMetrics);"
+				);
 				if (this.isHTMLRenderer()) {
 					measureHTMLWidth();
 				}
 			} else {
-				metrics = TextMetrics.measureText(this.contentGlyphs.modified, style);
+				// metrics = untyped TextMetrics.measureText(this.contentGlyphs.modified, style, null, null, useNativeMetrics);
+				untyped __js__(
+					"this.metrics = PIXI.TextMetrics.measureText(this.contentGlyphs.modified, this.style, undefined, undefined, useNativeMetrics);"
+				);
 				if (this.isHTMLRenderer()) {
 					if (useHTMLMeasurementJapaneseFont(style)) {
 						measureHTMLSize();


### PR DESCRIPTION
- under "use_native_measurement=1"
https://trello.com/c/JzDzVWJW/28115-pgs-can-look-different-on-different-computers