### PR TITLE
Native java function for getting the JAR time stamp

### DIFF
--- a/lib/sys/self_timestamp.flow
+++ b/lib/sys/self_timestamp.flow
@@ -1,0 +1,25 @@
+import maybe;
+
+export {
+	// Return the ISO time stamp of the jar file. It returns none if it is not Java or not a jar file. 
+	// e.g., "2025-06-20T10:44:06Z"
+	selfTimestampM() -> Maybe<string>;
+}
+
+selfTimestampM() -> Maybe<string>
+{
+	r: string = selfTimestamp();
+	if (r == "") {
+		None();
+	} else {
+		Some(r);
+	}
+}
+
+// Returns a empty string on errors.
+native selfTimestamp: () -> string = FlowSelfTimestamp.selfTimestamp;
+
+// Fallback is to always fail
+selfTimestamp() -> string {
+	"";
+}

--- a/platforms/java/com/area9innovation/flow/FlowSelfTimestamp.java
+++ b/platforms/java/com/area9innovation/flow/FlowSelfTimestamp.java
@@ -1,0 +1,37 @@
+package com.area9innovation.flow;
+
+import java.io.File;
+import java.net.URL;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+
+public class FlowSelfTimestamp extends NativeHost {
+
+	/**
+	 * Returns the UTC timestamp of the Jar file as an ISO 8601 string.
+	 * Assumes the class is running from a JAR file.
+	 *
+	 * @return ISO timestamp string (e.g., "2025-06-20T10:44:06Z")
+	 */
+	public static String selfTimestamp() {
+		try {
+			URL resource = FlowSelfTimestamp.class.getResource(
+				FlowSelfTimestamp.class.getSimpleName() + ".class"
+			);
+
+			String jarPath = resource.getPath();
+			String jarFilePath = jarPath.substring(5, jarPath.indexOf("!"));
+			File jarFile = new File(jarFilePath);
+
+			long millis = jarFile.lastModified();
+			long seconds = millis / 1000; // Truncate to seconds
+			LocalDateTime dateTime = LocalDateTime.ofEpochSecond(seconds, 0, ZoneOffset.UTC);
+			return dateTime.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME) + "Z";
+
+		} catch (Exception e) {
+			System.out.println("selfTimestamp exception: " + e.getMessage());
+			return ""; 
+		}
+	}
+}

--- a/platforms/js/FlowSelfTimestamp.hx
+++ b/platforms/js/FlowSelfTimestamp.hx
@@ -1,0 +1,2 @@
+class FlowSelfTimestamp {
+}


### PR DESCRIPTION
The compiled timestamp of tools can be quite use full, but including the build date via "#include build_date.txt" can make builds slow. 

This will use the timestamp of the jar file. This is not the same but for tools deployed via a build server, it can be good enough. 