### PR TITLE
Wigi Text. Respect RTL when inspect static Tropic metrics.

### DIFF
--- a/lib/form/formmetrics.flow
+++ b/lib/form/formmetrics.flow
@@ -72,7 +72,6 @@ getStaticFormSizeReal(form : Form, getExactTopPoint : bool, langAttribute : Mayb
 				textField = switch (lookupTree(^familyTextFields, family_lang)) {
 					None(): {
 						tf = makeTextfield(family);
-						setTextDirection(tf, if (getDefaultRtl()) "rtl" else "ltr");
 						maybeApply(langAttribute, \la ->
 							setAccessAttributes(tf, [["lang", la]])
 						);
@@ -84,6 +83,8 @@ getStaticFormSizeReal(form : Form, getExactTopPoint : bool, langAttribute : Mayb
 				}
 				defineTextStyle(textField, locaLizedT, s);
 				setTextPreventCheckTextNodeWidth(textField, contains(s, PreventTextNodeWidthCalculation()));
+				rtl = extractStruct(s, SetRTL(getDefaultRtl())).rtl;
+				setTextDirection(textField, if (rtl) "rtl" else "ltr");
 				metrics = getTextMetrics(textField);
 
 				// For now, we ignore descent and leading in metrics[1] and metrics[2]

--- a/lib/tropic/tropic_paragraph.flow
+++ b/lib/tropic/tropic_paragraph.flow
@@ -929,7 +929,14 @@ commonWordConstructor(
 	// then the inspector.size would be not measured after inspectFn call
 	// and we have to estimate it using artificially created TText
 	if (!isStatic && isSome(inspectorM) && getValue(inspector.size) == zeroWH) {
-		inspectText = \txt -> inspectFn(TText(txt, applyAlphabetStyles(detectAlphabet(txt), style))) |> ignore;
+		inspectText = \txt -> inspectFn(
+			TText(txt,
+				replaceStruct(
+					applyAlphabetStyles(detectAlphabet(txt), style),
+					SetRTL(getValue(rtl))
+				)
+			)
+		) |> ignore;
 		inspectSpace = \txt, alBef, alAft -> inspectFn(TText(txt, apply2AlphabetsScaling(alBef, alAft, style))) |> ignore;
 		switch (w) {
 			GeneralText(txt): inspectText(txt);


### PR DESCRIPTION
https://trello.com/c/ZnfhB18J/28270-incorrect-words-width