### PR TITLE
tropic_paragraph: metrics cache + dyn metrics fwidth+fthrottle optimization

### DIFF
--- a/lib/tropic/tropic_metrics.flow
+++ b/lib/tropic/tropic_metrics.flow
@@ -25,7 +25,6 @@ export {
 
 		// There can be a word wrap before and after this
 		TZeroWidthSpace(style : [TCharacterStyle]);
-		getTWordMetrics_count = ref 0;
 }
 
 getTropicMetrics(t : Tropic) -> FormMetrics {
@@ -42,7 +41,6 @@ getTWordMetricsWithCache(pt : TWord, env : Tree<string, Tropic>, useCache : bool
 	switch (pt) {
 		TText(txt, styles): {
 			doMeasure = \-> {
-				getTWordMetrics_count := ^getTWordMetrics_count + 1;
 				getStaticFormSizeReal(
 					Text(txt, tcharacterStyle2charStyle(styles)),
 					false,
@@ -54,7 +52,6 @@ getTWordMetricsWithCache(pt : TWord, env : Tree<string, Tropic>, useCache : bool
 				currentTime = timestamp();
 				if (currentTime - ^getStaticFormSizeReal_TextCacheAge > 3000.) {
 					getStaticFormSizeReal_TextCacheAge := currentTime;
-					println("getStaticFormSizeReal_TextCache CLEANUP: " + i2s(sizeTree(^getStaticFormSizeReal_TextCache)));
 					getStaticFormSizeReal_TextCache := makeTree();
 				}
 

--- a/lib/tropic/tropic_paragraph.flow
+++ b/lib/tropic/tropic_paragraph.flow
@@ -57,9 +57,6 @@ export {
 		isLastChild : bool,
 		paragraphRtl : bool
 	) -> Pair<string, FormMetrics>;
-
-	tRenderParagraphCount = ref 0;
-	tRenderParagraphUpdateCount = ref 0;
 }
 
 useWigiTextDynamicMetrics = !isUrlParameterFalse("wigi_text_dynamic_metrics");
@@ -287,8 +284,6 @@ TRenderParagraph(
 	renderedLinesInfoM : Maybe<DynamicBehaviour<[RenderedLinesInfo]>>,
 	renderInfo : WigiRenderParameters
 ) -> Tropic {
-	tRenderParagraphCount := ^tRenderParagraphCount + 1;
-
 	traceApi = makeWigiTrace_Tropic("TRenderParagraph", words);
 	traceApi.trace(\-> "TRenderParagraph "+toString(maybeMap(alignWidthBM, getValue))+", style: "+toString(s));
 	deferredRender = !renderInfo.inline && !isUrlParameterTrue("twigify_render_inline");
@@ -359,7 +354,6 @@ TRenderParagraph(
 	scaledContent = if (fitLongWords) TScale(scaleB, contentGroup) else contentGroup;
 
 	updateFn = \id, wi_raw, alignWidthM, immediate -> {
-		tRenderParagraphUpdateCount := ^tRenderParagraphUpdateCount + 1;
 		oldWH = getValue(paragraphWHB);
 		wi = roundUIMetricsValue(wi_raw);
 		traceApi.traceAndNest(\-> "updateFn [" + id + "] START wi_raw =  " + toString(wi_raw) + ", wi = " + toString(wi) + ", alignWidthM = " + toString(alignWidthM) + ", paragraphWH: " + toString(oldWH)  + ", linesCount: " + toString(getValue(linesCountB)));


### PR DESCRIPTION
https://trello.com/c/JCFkvRqW/971-optimize-twigifytextelement

optimization is enabled under "new"
wigi_word_metrics_cache=0 - disable cahce
wigi_dyn_metrics_width_only=0 - disable fwidth+fthrottle

<img width="1003" height="162" alt="image" src="https://github.com/user-attachments/assets/2f76e8e6-70eb-4289-9f00-e5dede350fde" />

