### PR TITLE
uploadNativeFile: return error description instead of just code

### DIFF
--- a/platforms/js/HttpSupport.hx
+++ b/platforms/js/HttpSupport.hx
@@ -1059,7 +1059,7 @@ class HttpSupport {
 		onOpenFn();
 
 		xhr.onload = xhr.onerror = function() {
-			if(xhr.status != 200) { onErrorFn("" + xhr.status); } else { onDataFn(xhr.responseText); }
+			if(xhr.status != 200) { onErrorFn(xhr.status + ": " + xhr.responseText); } else { onDataFn(xhr.responseText); }
 		};
 
 		xhr.upload.onprogress = function(event) {


### PR DESCRIPTION
Task https://trello.com/c/mJNZrFk8/27510-there-is-no-information-why-the-file-could-not-be-upload