### PR TITLE
fix(js): getTimezoneOffset should use the same utcTimestamp for local…

### DIFF
--- a/platforms/js/Native.hx
+++ b/platforms/js/Native.hx
@@ -841,7 +841,7 @@ class Native {
 			return 0;
 		}
 
-		var localOffset = new js.lib.Date().getTimezoneOffset();
+		var localOffset = new js.lib.Date(utcStamp).getTimezoneOffset();
 		return Math.round(Math.round((stamp - utcStamp) / 600) / 100 - localOffset) * 60 * 1000;
 	}
 	#end


### PR DESCRIPTION
…Offset as utcTimestamp in desired timezone

If we would use current timestamp - getTimezoneOffset might be wrong. For example if in the past our current timezone used Winter/Summer time and now it is not.

For example: timezoneId: America/Anchorage, my local timezoneId: Asia/Krasnoyarsk

getTimezoneOffset(1112367600000, "America/Anchorage") should return -32400000(-9 hrs) getTimezoneOffset(1112886000000, "America/Anchorage") should return -28800000(-8 hrs)

1112367600000 - 02 April 2005 - Winter time in Alaska 1112886000000 - 07 April 2005 - Summer time in Alaska

Without this fix it would return -32400000 both times. Because Winter/Summer time is no longer a thing in my local timezoneId Asia/Krasnoyarsk. But this timezone had it in 2005. So, computations are different.

@NikitaFil and @stanislavpodolia are on vacations, so I can't ask them to review this one. And I need to merge this PR this week.