### PR TITLE
TextFragments. Support context lang.

### DIFF
--- a/lib/form/paragraph.flow
+++ b/lib/form/paragraph.flow
@@ -45,11 +45,12 @@ export {
 		wordDecorator : (Form) -> Form,
 		customParagraphStyle : [ParagraphStyle]
 	) -> TextFragments;
-		TextFragmentStyle ::= TextFragmentMoreLineBreaks, TextFragmentLastChild, TextFragmentFirstChild, TextFragmentAllowAnySoftBreak;
+		TextFragmentStyle ::= TextFragmentMoreLineBreaks, TextFragmentLastChild, TextFragmentFirstChild, TextFragmentAllowAnySoftBreak, TextFragmentContextLang;
 			TextFragmentMoreLineBreaks();
 			TextFragmentLastChild();
 			TextFragmentFirstChild();
 			TextFragmentAllowAnySoftBreak();
+			TextFragmentContextLang(lang : string);
 
 	replaceDoubleNL(s : string) -> string {
 		if (strIndexOf(s, "\n\n") >= 0)
@@ -75,7 +76,8 @@ export {
 		isFirstChild : bool,
 		disableBreaksAfterHyphen : bool,
 		emulateLetterspacing : bool,
-		allowAnySoftBreak : bool
+		allowAnySoftBreak : bool,
+		contextLang : Maybe<string>
 	) -> GeneralTextFragments;
 	// it uses breakTextFragment inside and count resulting list of fragments
 	countTextFragments(text : string) -> int;
@@ -317,7 +319,11 @@ TextFragmentWithDecorator(
 		containsStruct(style, TextFragmentFirstChild()),
 		false,
 		containsStruct(customParagraphStyle, IgnoreLetterspacingOnReflow()),
-		containsStruct(style, TextFragmentAllowAnySoftBreak())
+		containsStruct(style, TextFragmentAllowAnySoftBreak()),
+		maybeMap(
+			tryExtractStruct(style, TextFragmentContextLang("")),
+			\lang -> lang.lang
+		)
 	);
 	TextFragments(
 		mapList(
@@ -594,7 +600,8 @@ countTextFragments(text : string) -> int {
 		false,
 		false,
 		false,
-		false
+		false,
+		None()
 	).elements |> countList;
 }
 
@@ -610,10 +617,10 @@ breakTextFragment(
 	disableBreaksAfterHyphen : bool,
 	emulateLetterspacing : bool,
 	allowAnySoftBreak : bool,
+	contextLang : Maybe<string>
 ) -> GeneralTextFragments {
 	textLen = strlen(text);
-
-	lang = getLang();
+	lang = either(contextLang, getLang());
 
 	elements = breakTextFragmentIntoElements(
 		0,
@@ -877,7 +884,8 @@ breakTextFragmentIntoElements(
 						newHhyphenPos,
 						newChrCatPos,
 						lang,
-						detectAlphabet(word), bidiEnabled,
+						detectAlphabet(word),
+						bidiEnabled,
 						allowAnySoftBreak,
 						debug
 					)

--- a/lib/text/localization.flow
+++ b/lib/text/localization.flow
@@ -170,7 +170,7 @@ findBreakAfterAllowPos2(
 			};
 
 			charAction = {
-				if (isCJKLang()) {
+				if (isCJK(lang)) {
 					notBeg = {
 						if (lang == "ja" || isChinese(lang)) jpNotBeg
 						else if (lang == "ko") krNotBeg

--- a/lib/ui/fontmapping.flow
+++ b/lib/ui/fontmapping.flow
@@ -43,6 +43,7 @@ export {
 	createWithLang(lang : string, fn : () -> ?) -> ?;
 
 	isCJKLang() -> bool; // is current lang chinese/japanese/korean?
+	isCJK(lang : string) -> bool;
 	isChinese(lang : string) -> bool;  // returns true for "zh", "zz" langs
 
 	// Main function for font names mapping. Used by renderForm.


### PR DESCRIPTION
Break texts, based on context lang, not a current one.

https://trello.com/c/Uy45dApm/28608-book-linebreaks-for-japanese-do-not-work-automatically