### PR TITLE
Fix crop start position for RTL content.

### DIFF
--- a/lib/form/paragraph3.flow
+++ b/lib/form/paragraph3.flow
@@ -1380,9 +1380,19 @@ renderParaLines(
 		}
 	);
 
-	Baseline(const(a.baseline), Size2(const(WidthHeight(if (tightWidth) a.maxLineWidth else max(availableWidth, lines.maxLineWidth), a.y)),
-		Group(list2array(a.lines))
-	))
+	croppedContent = if (rtl) {
+		Crop(
+			const(if (tightWidth) max(availableWidth - lines.maxLineWidth, 0.0) else 0.0),
+			const(0.0),
+			const(if (tightWidth) a.maxLineWidth else max(availableWidth, lines.maxLineWidth)),
+			const(a.y),
+			Group(list2array(a.lines))
+		);
+	} else {
+		Size2(const(WidthHeight(if (tightWidth) a.maxLineWidth else max(availableWidth, lines.maxLineWidth), a.y)), Group(list2array(a.lines)));
+	};
+
+	Baseline(const(a.baseline), croppedContent);
 }
 
 getOptimizedLine(words : [ParaWord], alignment : ParaLineAlignment, availableWidth : double, indent : double, lastLine : bool, ignoreLetterSpacing : bool, rtl : bool) -> [OptimizedLineElement]{


### PR DESCRIPTION
https://trello.com/c/ud75ryBA/28813-regression-review-mode-losing-translations-upon-approving-suggestions

<img width="1867" height="686" alt="image" src="https://github.com/user-attachments/assets/6d2b3849-a36e-4d8f-a5ec-86412d05fcc8" />
