### PR TITLE
Native `db2time`

### DIFF
--- a/lib/date.flow
+++ b/lib/date.flow
@@ -1,8 +1,4 @@
 // © Copyright 2011 Area9 Technologies.
-
-import math/math;
-import maybe;
-import string;
 import utctime;
 import text/translation;
 import ui/fontmapping;
@@ -103,7 +99,7 @@ export {
 	// considered as NULL in sql. It is necessary because mysql won't accept 0000-00-00 in strict_mode (which is recommended)
 	date2dbValid(dt : Date) -> Maybe<string>;
 
-	db2time(s : string) -> Time;
+	native db2time : (s : string) -> Time = Native.db2time;
 	db2timeDef(s : string, def : Time) -> Time;
 	time2db(dt : Time) -> string;
 	// It converts nullTime to None() then buildKeyValueForPhp won't pass it to php and it will be
@@ -379,7 +375,7 @@ getTimeOnlyString(time : Time, secEnabled: bool, is12hr : bool) -> string {
 		formatString(
 			if (time.hour < 12) _("%1a.m.") else _("%1p.m."),
 			[hours + ":" + minutes + secondsStr + separator12hrFormat]
-		) 
+		)
 	} else {
 		i2s(time.hour) + ":" + minutes + secondsStr
 	}

--- a/platforms/common/haxe/HaxeRuntime.hx
+++ b/platforms/common/haxe/HaxeRuntime.hx
@@ -24,6 +24,7 @@ class HaxeRuntime {
 	static public var _structids_ : haxe.ds.StringMap<Int>;
 	static public var _structtemplates_ : haxe.ds.IntMap<Dynamic>;
 #if (js)
+	static public var _structconstruct_ : haxe.ds.IntMap<Dynamic> = new haxe.ds.IntMap<Dynamic>(); // Structure id to constructor
 	static var regexCharsToReplaceForString : Dynamic = untyped __js__ ("/[\\\\\\\"\\n\\t]/g");
 	static var regexCharsToReplaceForJson : Dynamic = untyped __js__ ("/[\\\\\\\"\\n\\t\\x00-\\x08\\x0B-\\x1F]/g");
 #end
@@ -37,13 +38,15 @@ class HaxeRuntime {
 
 	// Do not use 'eval' directly here: https://esbuild.github.io/content-types/#direct-eval
 	// Using 'new Function('arg', 'code')' instead
+	untyped __js__ ("if(args!=[]){var a='';for(var i=0;i<args.length;i++)a+=(args[i]+':'+args[i]+ ','); a=a.substring(0, a.length -1);var c='c$'+f(id);");
 #if (readable)
-	untyped __js__ ("if(args!=[]){var a='';for(var i=0;i<args.length;i++)a+=(args[i]+':'+args[i]+ ','); a=a.substring(0, a.length -1);(new Function('g', 'g.c$'+f(id) + '=function(' + args.join(',') +'){return {name:\"'+ name+'\",' + a + '};}'))($global)}");
+	untyped __js__ ("(new Function('g', 'g.'+c + '=function(' + args.join(',') +'){return {name:\"'+ name+'\",' + a + '};}'))($global)");
 #elseif (namespace)
-	untyped __js__ ("if(args!=[]){var a='';for(var i=0;i<args.length;i++)a+=(args[i]+':'+args[i]+ ','); a=a.substring(0, a.length -1);(new Function('g', 'g.c$'+f(id) + '=function(' + args.join(',') + '){return {kind:'+id.toString()+',' + a + '};}'))($global)}");
+	untyped __js__ ("(new Function('g', 'g.'+c + '=function(' + args.join(',') + '){return {kind:'+id.toString()+',' + a + '};}'))($global)");
 #else
-	untyped __js__ ("if(args!=[]){var a='';for(var i=0;i<args.length;i++)a+=(args[i]+':'+args[i]+ ','); a=a.substring(0, a.length -1);(new Function('g', 'g.c$'+f(id) + '=function(' + args.join(',') + '){return {_id:'+id.toString()+',' + a + '};}'))($global)}");
+	untyped __js__ ("(new Function('g', 'g.'+c + '=function(' + args.join(',') + '){return {_id:'+id.toString()+',' + a + '};}'))($global)");
 #end
+	untyped __js__ ("HaxeRuntime._structconstruct_.h[id]=$global[c]}");
 #end
 		_structnames_.set(id, name);
 		_structids_.set(name, id);


### PR DESCRIPTION
We have a lot of time fields in db, so the speed of parsing these fields matters.

Card: https://trello.com/c/7KsGgL8m/1696-slow-makessqlupdaterequest

Native function results exactly like flow `db2time` and twice faster in JS:
<img width="248" height="135" alt="image" src="https://github.com/user-attachments/assets/7cd80f59-64da-4fec-bfaf-5d6f42e5caa4" />

Flow function:
<img width="442" height="190" alt="image" src="https://github.com/user-attachments/assets/d7c5bce6-509d-4b34-85b3-d6dc81680b48" />

Native function:
<img width="432" height="154" alt="image" src="https://github.com/user-attachments/assets/8c3e5e60-2a16-4b3e-b513-f612c5643c64" />
