### PR TITLE
remove "aria-label" if we have "aria-labelledby"

### DIFF
--- a/lib/material/internal/material_textinput_state.flow
+++ b/lib/material/internal/material_textinput_state.flow
@@ -2585,7 +2585,13 @@ makeNativeEditorView(manager : MaterialManager, parent : MFocusGroup, state : [M
 		else fOr(inputState.mfocus.focused, fand(const(inputState.multiline), inputState.mfocus.focusEnabled));
 
 	inputAriaLabel =
-		if (strlen(inputState.label) > 0) const(inputState.label)
+		if (
+			exists(
+				extractStructMany(state, FAccessAttribute("", const(""))),
+				\attr -> attr.name == "aria-labelledby"
+			)
+		) const("")
+		else if (strlen(inputState.label) > 0) const(inputState.label)
 		else fselect(inputState.mfocus.title, FLift(\title -> if (title == "") "Input" else title));
 
 	textInput = \ ->


### PR DESCRIPTION
https://trello.com/c/Zd72xlPi/28641-missing-accessible-name-of-input-in-bummer-dialog