### PR TITLE
Fixed idle eventlistener

### DIFF
--- a/platforms/js/Native.hx
+++ b/platforms/js/Native.hx
@@ -3425,6 +3425,7 @@ Native.memoryLeakReset();
 					}
 				};
 
+				mouseMoveIdleFn();
 				Browser.window.addEventListener("pointermove", mouseMoveIdleFn);
 				Browser.window.addEventListener("videoplaying", mouseMoveIdleFn);
 				Browser.window.addEventListener("focus", mouseMoveIdleFn);


### PR DESCRIPTION
If user wasn't active - idle event won't be fired.