### PR TITLE
Optimize time2stamp/date2stamp: replace string round-trip with direct arithmetic

### DIFF
--- a/lib/date.flow
+++ b/lib/date.flow
@@ -443,16 +443,16 @@ getTimeString(time : Time, dayOfWeekEnabled : bool, monthLong : bool, yearEnable
 // not be so in other TZ.
 // Also storing UTC in database seems like a sane thing to do.
 date2stamp(d : Date) -> double {
-	date2epochMs(d);
+	date2epochMs(d.year, d.month, d.day);
 }
 
 //without utc2local
-date2stamp2(d: Date) -> double {
-	local2utc(date2epochMs(d));
+date2stamp2(d : Date) -> double {
+	local2utc(date2stamp(d));
 }
 
 // converts local time to UTC timestamp
-time2stamp2(t: Time) -> double {
+time2stamp2(t : Time) -> double {
 	if (t == nullTime) nullTimestamp else local2utc(time2epochMs(t));
 }
 
@@ -461,11 +461,13 @@ time2stamp(t : Time) -> double {
 }
 
 // Compute milliseconds since Unix epoch from Date (midnight UTC).
-date2epochMs(d : Date) -> double {
-	// Days from year 1 to the start of the given year
-	y = d.year;
-	m = d.month;
-	day = d.day;
+// Replicates the behavior of string2time(dateString2ValidDb(date2string(d)))
+// including JS Date constructor quirks for invalid inputs:
+// - Years 0-99: JS new Date() maps year to 1900+year
+// The March-based algorithm naturally normalizes out-of-range month/day values.
+date2epochMs(year : int, m : int, day: int) -> double {
+	// JS new Date() maps years 0-99 to 1900+year
+	y = if (year <= 99) year + 1900 else year;
 	// Adjust so March is month 0 (simplifies leap year handling)
 	adjM = if (m > 2) m - 3 else m + 9;
 	adjY = if (m > 2) y else y - 1;
@@ -480,10 +482,10 @@ date2epochMs(d : Date) -> double {
 
 // Compute milliseconds since Unix epoch from Time (UTC).
 time2epochMs(t : Time) -> double {
-	date2epochMs(Date(t.year, t.month, t.day))
-		+ i2d(t.hour) * 3600000.0
-		+ i2d(t.min) * 60000.0
-		+ i2d(t.sec) * 1000.0;
+	date2epochMs(t.year, t.month, t.day)
+		+ i2d(t.hour * 3600000
+		+ t.min * 60000
+		+ t.sec * 1000);
 }
 
 stamp2date(stamp : double) -> Date {

--- a/lib/date.flow
+++ b/lib/date.flow
@@ -451,8 +451,9 @@ date2stamp2(d: Date) -> double {
 	local2utc(date2epochMs(d));
 }
 
+// converts local time to UTC timestamp
 time2stamp2(t: Time) -> double {
-	if (t == nullTime) nullTimestamp else local2utc(time2epochMs(t)); // converts local time to UTC timestamp
+	if (t == nullTime) nullTimestamp else local2utc(time2epochMs(t));
 }
 
 time2stamp(t : Time) -> double {

--- a/lib/date.flow
+++ b/lib/date.flow
@@ -443,21 +443,46 @@ getTimeString(time : Time, dayOfWeekEnabled : bool, monthLong : bool, yearEnable
 // not be so in other TZ.
 // Also storing UTC in database seems like a sane thing to do.
 date2stamp(d : Date) -> double {
-	// string2time on some platforms expects yyyy-mm-dd HH:MM:SS
-	string2timeUtc(dateString2ValidDb(date2string(d)));
+	date2epochMs(d);
 }
 
 //without utc2local
 date2stamp2(d: Date) -> double {
-	string2time(dateString2ValidDb(date2string(d)));
+	local2utc(date2epochMs(d));
 }
 
 time2stamp2(t: Time) -> double {
-	if (t == nullTime) nullTimestamp else string2time(time2db(t));
+	if (t == nullTime) nullTimestamp else local2utc(time2epochMs(t)); // converts local time to UTC timestamp
 }
 
 time2stamp(t : Time) -> double {
-	if (t == nullTime) nullTimestamp else string2timeUtc(time2db(t)); //utc2local
+	if (t == nullTime) nullTimestamp else time2epochMs(t);
+}
+
+// Compute milliseconds since Unix epoch from Date (midnight UTC).
+date2epochMs(d : Date) -> double {
+	// Days from year 1 to the start of the given year
+	y = d.year;
+	m = d.month;
+	day = d.day;
+	// Adjust so March is month 0 (simplifies leap year handling)
+	adjM = if (m > 2) m - 3 else m + 9;
+	adjY = if (m > 2) y else y - 1;
+	// Days from epoch 1970-01-01
+	daysSinceEpoch =
+		365 * adjY + adjY / 4 - adjY / 100 + adjY / 400
+		+ (adjM * 306 + 5) / 10
+		+ day - 1
+		- 719468;  // offset to align with 1970-01-01
+	i2d(daysSinceEpoch) * msInDay;
+}
+
+// Compute milliseconds since Unix epoch from Time (UTC).
+time2epochMs(t : Time) -> double {
+	date2epochMs(Date(t.year, t.month, t.day))
+		+ i2d(t.hour) * 3600000.0
+		+ i2d(t.min) * 60000.0
+		+ i2d(t.sec) * 1000.0;
 }
 
 stamp2date(stamp : double) -> Date {


### PR DESCRIPTION
### Benchmark results

### JavaScript

=== Benchmark: time2stamp (100000 iterations) ===
OLD time2stamp : 621 ms (100000 iterations), checksum=535256104499307700
NEW time2stamp : 32 ms (100000 iterations), checksum=535256104499307700
Speedup: 19.40625x

=== Benchmark: time2stamp2 (100000 iterations) ===
OLD time2stamp2: 584 ms (100000 iterations), checksum=535253944499307700
NEW time2stamp2: 102 ms (100000 iterations), checksum=535253944499307700
Speedup: 5.7254901960784315x

=== Benchmark: date2stamp (100000 iterations) ===
OLD date2stamp : 516 ms (100000 iterations), checksum=535239360000000000
NEW date2stamp : 7 ms (100000 iterations), checksum=535239360000000000
Speedup: 73.71428571428571x

=== Benchmark: date2stamp2 (100000 iterations) ===
OLD date2stamp2: 462 ms (100000 iterations), checksum=535237200000000000
NEW date2stamp2: 83 ms (100000 iterations), checksum=535237200000000000
Speedup: 5.566265060240964x

### Java

=== Benchmark: time2stamp (100000 iterations) ===
OLD time2stamp : 786 ms (100000 iterations), checksum=535256104499307710
NEW time2stamp : 22 ms (100000 iterations), checksum=535256104499307710
Speedup: 35.72727272727273x

=== Benchmark: time2stamp2 (100000 iterations) ===
OLD time2stamp2: 409 ms (100000 iterations), checksum=535253944499307710
NEW time2stamp2: 22 ms (100000 iterations), checksum=535253944499307710
Speedup: 18.59090909090909x

=== Benchmark: date2stamp (100000 iterations) ===
OLD date2stamp : 390 ms (100000 iterations), checksum=535239360000000000
NEW date2stamp : 9 ms (100000 iterations), checksum=535239360000000000
Speedup: 43.333333333333336x

=== Benchmark: date2stamp2 (100000 iterations) ===
OLD date2stamp2: 432 ms (100000 iterations), checksum=535237200000000000
NEW date2stamp2: 45 ms (100000 iterations), checksum=535237200000000000
Speedup: 9.6x

### C++
=== Benchmark: time2stamp (100000 iterations) ===
OLD time2stamp : 1491.76416015625 ms (100000 iterations), checksum=5.35256104499308e+17
NEW time2stamp : 100.684814453125 ms (100000 iterations), checksum=5.35256104499308e+17
Speedup: 14.8161782713595x

=== Benchmark: time2stamp2 (100000 iterations) ===
OLD time2stamp2: 1414.2021484375 ms (100000 iterations), checksum=5.35253944499308e+17
NEW time2stamp2: 155.36572265625 ms (100000 iterations), checksum=5.35253944499308e+17
Speedup: 9.10240768851217x

=== Benchmark: date2stamp (100000 iterations) ===
OLD date2stamp : 1177.32592773438 ms (100000 iterations), checksum=5.3523936e+17
NEW date2stamp : 42.052001953125 ms (100000 iterations), checksum=5.3523936e+17
Speedup: 27.9969055705536x

=== Benchmark: date2stamp2 (100000 iterations) ===
OLD date2stamp2: 1121.42797851562 ms (100000 iterations), checksum=5.352372e+17
NEW date2stamp2: 116.670166015625 ms (100000 iterations), checksum=5.352372e+17
Speedup: 9.61195151094101x