### PR TITLE
Optimize switch code generation: preserve union-level cases from desugar to backends

### DIFF
--- a/tools/flowc/backends/bytecode/fi2bytecode_compile.flow
+++ b/tools/flowc/backends/bytecode/fi2bytecode_compile.flow
@@ -257,7 +257,8 @@ fiBcEncode(cfg : FcBytecodeConfig, ctx : FiBcScopeContext, expr : FiExp, tailcal
 				elsecode
 			], pc);
 		}
-		FiSwitch(e0, switchType, cs, type, i): {
+		FiSwitch(e0, switchType, cs0, type, i): {
+			cs = fiExpandSwitchCases(cs0);
 
 			arg = fiBcEncode(cfg, ctx, e0, false, pc);
 

--- a/tools/flowc/backends/cpp/fc2cpp_compile.flow
+++ b/tools/flowc/backends/cpp/fc2cpp_compile.flow
@@ -8,6 +8,7 @@ import tools/flowc/manipulation/find_last_varrefs;
 import tools/flowc/manipulation/common;
 import tools/flowc/manipulation/freevars;
 import tools/flowc/incremental/fiprogram;
+import tools/flowc/incremental/fi_helpers;
 import ds/set;
 
 export {
@@ -611,7 +612,8 @@ fiCppCompileToExpr(
 			}
 		}
 
-		FiSwitch(e0, e0type, cs, __, __): {
+		FiSwitch(e0, e0type, cs0, __, __): {
+			cs = fiExpandSwitchCases(cs0);
 			aVar = fiCppCompileToExpr(ctx, e0, indent, false, false);
 
 			isUnion = fiIsUnion(program, fiExpType(e0));

--- a/tools/flowc/backends/cpp2/fi2cpp_compile.flow
+++ b/tools/flowc/backends/cpp2/fi2cpp_compile.flow
@@ -865,7 +865,8 @@ cpp2WriterCompileExpression(writer : Cpp2Writer, code : FiExp, ctx : Cpp2Context
 			cpp2ContextWr(ctx, "}");
 			cpp2ContextJoin(ctx, [ctx_if, ctx_else]);
 		}
-		FiSwitch(e0, sw_type, cases, type, __): {
+		FiSwitch(e0, sw_type, cases0, type, __): {
+			cases = fiExpandSwitchCases(cases0);
 			mvexpr = cpp2WriterGetValueRef(writer, e0, ctx, false);
 			vexpr = switch(mvexpr) {
 				Some(ve): ve;

--- a/tools/flowc/backends/cpp3/fi2cpp3_util.flow
+++ b/tools/flowc/backends/cpp3/fi2cpp3_util.flow
@@ -385,8 +385,9 @@ fiExp2stringFull(expr: FiExp) -> string {
 			(if (sl_test(e2_s)) e2_s else "{\n" + strIndent(e2_s) + "\n}") + " else " +
 			(if (sl_test(e3_s)) e3_s else "{\n" + strIndent(e3_s) + "\n}");
 		}
-		FiSwitch(x, __, cases,__, __): {
-			"switch (" + x.name + ") {\n" + 
+		FiSwitch(x, __, cases0,__, __): {
+			cases = fiExpandSwitchCases(cases0);
+			"switch (" + x.name + ") {\n" +
 				strIndent(superglue(cases, \c -> {
 					body_s = fiExp2stringFull(c.body);
 					body_s1 = if (sl_test(body_s)) {

--- a/tools/flowc/backends/d/fi2d_compile.flow
+++ b/tools/flowc/backends/d/fi2d_compile.flow
@@ -2,6 +2,7 @@ import string_utils;
 import tools/flowc/backends/d/fi2d_utils;
 import tools/flowc/backends/d/fi2d_utils2;
 import tools/flowc/backends/d/fi2d_assemble;
+import tools/flowc/incremental/fi_helpers;
 
 export {
 	fiDCompileToplevel(
@@ -426,7 +427,8 @@ fiDCompileToExpr(cfg : FiDConfig, program : FiProgram, expr : FiExp, indent : st
 			p1 = (if (prefix != "") "new " + prefix else "");
 			"/*CAST!"+toString(tFrom)+"*/" + p1 + "(cast(" + tt + ")" + ex + ")";
 		}
-		FiSwitch(e0, e0type, cs, __, __): {
+		FiSwitch(e0, e0type, cs0, __, __): {
+			cs = fiExpandSwitchCases(cs0);
 			aVar = fiDCompileToExpr(cfg, program, e0, indent, isVoid);
 			defCase = filter(cs, \e -> e.struct == "default");
 			dc = if (defCase == []) " else {assert(false, \"" +aVar + "\");}" else {
@@ -526,7 +528,8 @@ fiDCompileToReturn(cfg : FiDConfig, program : FiProgram, expr : FiExp, indent : 
 			subindent + fiDCompileToReturn(cfg, program, falseBranchE, subindent, isVoid, atype) + ";\n"
 			+ indent + "}";
 		}
-		FiSwitch(e0, e0type, cs, __, __): {
+		FiSwitch(e0, e0type, cs0, __, __): {
+			cs = fiExpandSwitchCases(cs0);
 			aVar = fiDCompileToExpr(cfg, program, e0, indent, isVoid);
 			defCase = filter(cs, \e -> e.struct == "default");
 			dc = if (defCase == []) " else {assert(false, \"" +aVar + "\");}" else {

--- a/tools/flowc/backends/inca/cache_function.flow
+++ b/tools/flowc/backends/inca/cache_function.flow
@@ -116,7 +116,8 @@ cacheFiExp(env : IncaEnv, fnname : string, fe : FiExp) -> FiExp {
 			type, 
 			start
 		);
-		FiSwitch(x, switchType, cases, type, start): {
+		FiSwitch(x, switchType, cases0, type, start): {
+			cases = fiExpandSwitchCases(cases0);
 			FiSwitch(x, switchType,
 				map(cases, \c -> {
 					FiCase(c.struct, c.argNames, cacheFiExp(env, fnname, c.body), c.start)

--- a/tools/flowc/backends/inca/change_function.flow
+++ b/tools/flowc/backends/inca/change_function.flow
@@ -156,10 +156,11 @@ bubbleDynUp(dynamicVars : Set<string>, code : FiExp) -> FiExp {
 				FiDyn(ncall)
 			} else ncall
 		}
-		FiSwitch(var, st, cases, t, start): {
+		FiSwitch(var, st, cases0, t, start): {
+			cases = fiExpandSwitchCases(cases0);
 			// If the var is in dynamicVars, it is dynamic!
 			dvar = containsSet(dynamicVars, var.name);
-			caseDyn = map(cases, \c : FiCase -> {
+			caseDyn = map(cases, \c -> {
 				dynB = bubbleDynUp(dynamicVars, c.body);
 				FiCase(c.struct, c.argNames, dynB, c.start);
 			});
@@ -224,9 +225,12 @@ stripFiDyn(code : FiExp) -> FiExp {
 		FiVar(name, type, start): code;
 		FiLet(name, type, e1, e2, type2, start): FiLet(name, type, stripFiDyn(e1), stripFiDyn(e2), type2, start);
 		FiIf(e1, e2, e3, type, start): FiIf(stripFiDyn(e1), stripFiDyn(e2), stripFiDyn(e3), type, start);
-		FiSwitch(x, switchType, cases, type, start): FiSwitch(x, switchType, map(cases, \c -> {
-			FiCase(c.struct, c.argNames, stripFiDyn(c.body), c.start);
-		}), type, start);
+		FiSwitch(x, switchType, cases0, type, start): {
+			cases = fiExpandSwitchCases(cases0);
+			FiSwitch(x, switchType, map(cases, \c -> {
+				FiCase(c.struct, c.argNames, stripFiDyn(c.body), c.start);
+			}), type, start);
+		}
 		FiCast(e, tFrom, tTo, type, start): FiCast(stripFiDyn(e), tFrom, tTo, type, start);
 		FiSeq(es, type, start): FiSeq(map(es, stripFiDyn), type, start);
 		FiCallPrim(op, es, type, start): {
@@ -260,10 +264,11 @@ reuseOldOutput(env : IncaEnv, code : FiExp, type : FiType, output : FiExp) -> Fi
 				st
 			);
 		}
-		FiSwitch(var, st, cases, t, start): {
+		FiSwitch(var, st, cases0, t, start): {
+			cases = fiExpandSwitchCases(cases0);
 			FiSwitch(var, st,
 				map(cases, \c -> {
-					FiCase(c.struct, c.argNames, 
+					FiCase(c.struct, c.argNames,
 						reuseOldOutput(env, c.body, type, output),
 						c.start
 					)
@@ -353,13 +358,14 @@ reuseOldOutput(env : IncaEnv, code : FiExp, type : FiType, output : FiExp) -> Fi
 								);
 							}
 						}
-						FiSwitch(var, st, cases, t, start): {
+						FiSwitch(var, st, cases0, t, start): {
+							cases = fiExpandSwitchCases(cases0);
 							if (isFiDyn(var)) {
 								code;
 							} else {
 								FiSwitch(var, st,
 									map(cases, \c -> {
-										FiCase(c.struct, c.argNames, 
+										FiCase(c.struct, c.argNames,
 											reuseOldOutput(env, c.body, type, output),
 											c.start
 										)

--- a/tools/flowc/backends/inca/conversion_graph.flow
+++ b/tools/flowc/backends/inca/conversion_graph.flow
@@ -79,8 +79,9 @@ addIncaCasesToGraph(env : IncaEnv, acc : SimpleGraph<string, string>, fn : strin
 			acc2 = addIncaCasesToGraph(env, acc1, fn, e2);
 			addIncaCasesToGraph(env, acc2, fn, e3);
 		} 
-		FiSwitch(x, switchType, cases, type, start): {
-			fold(cases, acc, \acc2, case : FiCase -> {
+		FiSwitch(x, switchType, cases0, type, start): {
+			cs = fiExpandSwitchCases(cases0);
+			fold(cs, acc, \acc2, case -> {
 				addIncaCaseToGraph(env, acc2, fn, case)
 			});
 		}

--- a/tools/flowc/backends/inca/lift_exp.flow
+++ b/tools/flowc/backends/inca/lift_exp.flow
@@ -1,4 +1,5 @@
 import tools/flowc/backends/inca/env;
+import tools/flowc/incremental/fi_helpers;
 import text/blueprint;
 
 export {
@@ -82,7 +83,8 @@ liftIncaExp(env : IncaEnv, ex : FiExp, tabs : int) -> string {
 			"makeIncaValueLazy(\\ -> getIncaCoreBasicValue({\n" + liftIncaExp(env, e3, tabs + 1) + "\n}))\n" +
 			buildTabs(tabs) + ")";
 		}
-		FiSwitch(x, switchType, cases, type, info): {
+		FiSwitch(x, switchType, cases0, type, info): {
+			cases = fiExpandSwitchCases(cases0);
 			buildTabs(tabs) + "listenIncaStructId(" + x.name + "_lifted, \\switchVal" + x.name + " -> {\n" +
 			buildTabs(tabs + 1) + superglue(
 				cases,

--- a/tools/flowc/backends/inca/promote_types.flow
+++ b/tools/flowc/backends/inca/promote_types.flow
@@ -306,8 +306,9 @@ promoteIncaSwitch(data : PromoteData, s : FiSwitch) -> FiSwitch {
 	union = getFiTypeName(s.switchType);
 	structs = getTreeArrayValue(data.promotedUnions, union);
 
+	expandedCases = fiExpandSwitchCases(s.cases);
 	FiSwitch(s with
-		cases = fold(s.cases, [], \acc0 : [FiCase], case : FiCase -> {
+		cases = fold(expandedCases, [], \acc0 : [FiCase], case : FiCase -> {
 			if (contains(structs, case.struct) && switch (case.body) {
 				FiVar(bodyVar, __, __): bodyVar == s.x.name;
 				default: false;

--- a/tools/flowc/backends/java/fi2java_compile.flow
+++ b/tools/flowc/backends/java/fi2java_compile.flow
@@ -562,6 +562,122 @@ emitJavaFunction(gctx : JavaGlobalContext, csm : JavaModule, global : string, na
 	list2string(^reslist);
 }
 
+// Groups consecutive switch cases that can be merged using Java's case fall-through.
+// Cases are mergeable when all argNames are "__" (no field bindings), the body does not
+// use the switch variable in a type-dependent way (field access / set-mutable, where
+// fiExpType drives struct-specific casts), and bodies are structurally equal.
+groupMergeableSwitchCases(cases : [FiCase], switchVar : string) -> [[FiCase]] {
+	if (length(cases) == 0) []
+	else {
+		foldi(cases, [], \i, acc, case -> {
+			if (i == 0) {
+				[[case]]
+			} else {
+				lastIdx = length(acc) - 1;
+				lastGroup = acc[lastIdx];
+				prevCase = lastElement(lastGroup, case);
+				if (canMergeSwitchCases(prevCase, case, switchVar)) {
+					replace(acc, lastIdx, arrayPush(lastGroup, case))
+				} else {
+					arrayPush(acc, [case])
+				}
+			}
+		});
+	}
+}
+
+canMergeSwitchCases(c1 : FiCase, c2 : FiCase, switchVar : string) -> bool {
+	c1.struct != "default" && c2.struct != "default"
+	&& forall(c1.argNames, \a -> a == "__")
+	&& forall(c2.argNames, \a -> a == "__")
+	&& isSameFiExp(c1.body, c2.body);
+}
+
+// Replaces the type of all free occurrences of a variable in an FiExp.
+// Used for merged switch cases: desugaring narrows the switch variable's type
+// per-case, but in the merged body we use FiTypeFlow() to ensure type-independent
+// code generation (e.g., Field_ accessor interfaces instead of direct field access).
+// Respects shadowing: lambdas, lets, switch argNames, and inner switches on the
+// same variable all prevent recursion into their scope.
+generalizeVarInFiExp(exp : FiExp, varName : string, newType : FiType) -> FiExp {
+	if (!fiExpReferencesVar(exp, varName)) exp
+	else switch (exp) {
+		FiVar(n, __, s): if (n == varName) FiVar(n, newType, s) else exp;
+		FiCall(f, es, t, s): FiCall(
+			generalizeVarInFiExp(f, varName, newType),
+			map(es, \e -> generalizeVarInFiExp(e, varName, newType)),
+			t, s
+		);
+		FiLambda(args, body, t, s):
+			if (exists(args, \a -> a.name == varName)) exp
+			else FiLambda(args, generalizeVarInFiExp(body, varName, newType), t, s);
+		FiLet(x, xt, e1, e2, t, s): FiLet(
+			x, xt,
+			generalizeVarInFiExp(e1, varName, newType),
+			if (x == varName) e2 else generalizeVarInFiExp(e2, varName, newType),
+			t, s
+		);
+		FiIf(c, th, el, t, s): FiIf(
+			generalizeVarInFiExp(c, varName, newType),
+			generalizeVarInFiExp(th, varName, newType),
+			generalizeVarInFiExp(el, varName, newType),
+			t, s
+		);
+		FiSwitch(x, st, cases, t, s): FiSwitch(
+			FiVar(x.name, if (x.name == varName) newType else x.type, x.start),
+			st,
+			// If inner switch is on the same variable, it rebinds it in case bodies —
+			// don't generalize there; the inner codegen handles the rebinding.
+			if (x.name == varName) cases
+			else map(cases, \c ->
+				if (exists(c.argNames, \a -> a == varName)) c
+				else FiCase(c.struct, c.argNames, generalizeVarInFiExp(c.body, varName, newType), c.start)
+			),
+			t, s
+		);
+		FiCast(e, ft, tt, t, s): FiCast(generalizeVarInFiExp(e, varName, newType), ft, tt, t, s);
+		FiSeq(es, t, s): FiSeq(map(es, \e -> generalizeVarInFiExp(e, varName, newType)), t, s);
+		FiCallPrim(op, es, t, s): FiCallPrim(op, map(es, \e -> generalizeVarInFiExp(e, varName, newType)), t, s);
+		FiRequire(flowfile, e, t, s): FiRequire(flowfile, generalizeVarInFiExp(e, varName, newType), t, s);
+		FiUnsafe(nm, e, t, s): FiUnsafe(nm, generalizeVarInFiExp(e, varName, newType), t, s);
+		default: exp;
+	}
+}
+
+// Checks whether a variable name appears free (not shadowed) in an FiExp.
+// Accounts for shadowing by lambdas, lets, switch argNames, and inner switches
+// on the same variable (which rebind it in case bodies).
+fiExpReferencesVar(exp : FiExp, name : string) -> bool {
+	switch (exp) {
+		FiVoid(__): false;
+		FiBool(__, __): false;
+		FiInt(__, __): false;
+		FiDouble(__, __): false;
+		FiString(__, __): false;
+		FiVar(n, __, __): n == name;
+		FiCall(f, es, __, __):
+			fiExpReferencesVar(f, name) || exists(es, \e -> fiExpReferencesVar(e, name));
+		FiLambda(args, body, __, __):
+			!exists(args, \a -> a.name == name) && fiExpReferencesVar(body, name);
+		FiLet(x, __, e1, e2, __, __):
+			fiExpReferencesVar(e1, name) || (x != name && fiExpReferencesVar(e2, name));
+		FiIf(c, t, e, __, __):
+			fiExpReferencesVar(c, name) || fiExpReferencesVar(t, name) || fiExpReferencesVar(e, name);
+		FiSwitch(x, __, cases, __, __):
+			// The switch expression references the var. If the switch is on the same
+			// variable, it rebinds it in case bodies — don't recurse into them.
+			fiExpReferencesVar(x, name)
+			|| (x.name != name && exists(cases, \c ->
+				!exists(c.argNames, \a -> a == name) && fiExpReferencesVar(c.body, name)
+			));
+		FiCast(e, __, __, __, __): fiExpReferencesVar(e, name);
+		FiSeq(es, __, __): exists(es, \e -> fiExpReferencesVar(e, name));
+		FiCallPrim(__, es, __, __): exists(es, \e -> fiExpReferencesVar(e, name));
+		FiRequire(__, e, __, __): fiExpReferencesVar(e, name);
+		FiUnsafe(__, e, __, __): fiExpReferencesVar(e, name);
+	}
+}
+
 emitJavaStatement(ctx0 : JavaScopeContext, code0 : FiExp, retloc : JavaReturnLocation) -> void {
 	unw_code = unfoldJavaStatements(ctx0, code0, true);
 	code : FiExp = unw_code.first;
@@ -587,61 +703,104 @@ emitJavaStatement(ctx0 : JavaScopeContext, code0 : FiExp, retloc : JavaReturnLoc
 			subctx = jctxPushIndent(ctx, "\t");
 			tmpvar2 = javaNewLocalName(ctx.func.next_local_id, "_tmp");
 			inputvar = x.name;
-			has_default = fold(cases, false, \hasdef, case -> {
-				case_ctx_v = if (case.struct == "default") {
+
+			// Group consecutive cases with identical bodies to use Java's case fall-through
+			caseGroups = groupMergeableSwitchCases(cases, inputvar);
+
+			has_default = fold(caseGroups, false, \hasdef, group -> {
+				firstCase = group[0];
+
+				if (firstCase.struct == "default") {
+					// Default case
 					jctxPushStr(ctx, ctx.indent + "default: {\n");
-					Pair(subctx, true);
+					emitJavaStatement(subctx, firstCase.body, retloc);
+					if (!isJavaReturnStmt(retloc))
+						jctxPushStr(ctx, subctx.indent + "break;\n");
+					jctxPushStr(ctx, ctx.indent + "}\n");
+					true;
+				} else if (length(group) > 1) {
+					// Merged group: emit fall-through case labels, body only once.
+					// All argNames are "__" so no struct-specific casts are needed.
+					iter(group, \case -> {
+						switch (lookupTree(ctx.func.gctx.cstructs, case.struct)) {
+							Some(cstruct): {
+								jctxPushStr(ctx, ctx.indent + "case " + i2s(cstruct.id) + "/*" + cstruct.name + "*/:\n");
+							}
+							None(): {
+								fail0("invalid struct in case: " + case.struct);
+							}
+						}
+					});
+					jctxPushStr(ctx, ctx.indent + "{\n");
+					// Generalize the switch variable's type in the body to FiTypeFlow()
+					// so that field accesses use accessor interfaces (Field_xxx) instead
+					// of struct-specific casts, which wouldn't be valid across merged cases.
+					mergedBody = if (inputvar != "") {
+						generalizeVarInFiExp(firstCase.body, inputvar, FiTypeFlow());
+					} else firstCase.body;
+					emitJavaStatement(subctx, mergedBody, retloc);
+					if (!isJavaReturnStmt(retloc))
+						jctxPushStr(ctx, subctx.indent + "break;\n");
+					jctxPushStr(ctx, ctx.indent + "}\n");
+					hasdef;
 				} else {
-					switch (lookupTree(ctx.func.gctx.cstructs, case.struct)) {
-						Some(cstruct): {
-							jctxPushStr(ctx, ctx.indent + "case " + i2s(cstruct.id) + "/*" + cstruct.name + "*/: {\n");
+					// Single case - emit with full variable bindings as before
+					case = firstCase;
+					case_ctx_v = if (case.struct == "default") {
+						jctxPushStr(ctx, ctx.indent + "default: {\n");
+						Pair(subctx, true);
+					} else {
+						switch (lookupTree(ctx.func.gctx.cstructs, case.struct)) {
+							Some(cstruct): {
+								jctxPushStr(ctx, ctx.indent + "case " + i2s(cstruct.id) + "/*" + cstruct.name + "*/: {\n");
 
-							has_args = exists(case.argNames, \a -> a != "__");
+								has_args = exists(case.argNames, \a -> a != "__");
 
-							castctx = if (has_args || (length(cstruct.fields) > 0 && inputvar != "")) {
-								stype = "Struct_" + cstruct.javaName;
-								jctxPushStr(ctx, subctx.indent + "final " + stype + " " + tmpvar2 +
-									" = (" + stype + ")" + tmpvar + ";\n");
+								castctx = if (has_args || (length(cstruct.fields) > 0 && inputvar != "")) {
+									stype = "Struct_" + cstruct.javaName;
+									jctxPushStr(ctx, subctx.indent + "final " + stype + " " + tmpvar2 +
+										" = (" + stype + ")" + tmpvar + ";\n");
 
-								if (inputvar != "")
-									jctxPushLocal(subctx, JavaLocalInfo(inputvar, tmpvar2, stype, true, false))
+									if (inputvar != "")
+										jctxPushLocal(subctx, JavaLocalInfo(inputvar, tmpvar2, stype, true, false))
+									else
+										subctx;
+								}
 								else
 									subctx;
+
+								ectx = if (!has_args)
+									castctx
+								else {
+									foldi(case.argNames, castctx, \i, sctx, arg -> {
+										if (arg == "__")
+											sctx
+										else {
+											aname = javaNewLocalName(ctx.func.next_local_id, arg);
+											ty = type2javaObjType(ctx.func.gctx, cstruct.fields[i].type, true, false, false);
+											jctxPushStr(ctx, subctx.indent + "final " + ty + " " + aname +
+												" = " + tmpvar2 + ".f_" + cstruct.fields[i].name + ";\n");
+
+											jctxPushLocal(sctx, JavaLocalInfo(arg,aname,ty,true,false));
+										}
+									});
+								}
+
+								Pair(ectx, hasdef);
 							}
-							else
-								subctx;
-
-							ectx = if (!has_args)
-								castctx
-							else {
-								foldi(case.argNames, castctx, \i, sctx, arg -> {
-									if (arg == "__")
-										sctx
-									else {
-										aname = javaNewLocalName(ctx.func.next_local_id, arg);
-										ty = type2javaObjType(ctx.func.gctx, cstruct.fields[i].type, true, false, false);
-										jctxPushStr(ctx, subctx.indent + "final " + ty + " " + aname +
-											" = " + tmpvar2 + ".f_" + cstruct.fields[i].name + ";\n");
-
-										jctxPushLocal(sctx, JavaLocalInfo(arg,aname,ty,true,false));
-									}
-								});
-							}
-
-							Pair(ectx, hasdef);
+							None():
+								fail0("invalid struct in case: " + case.struct);
 						}
-						None():
-							fail0("invalid struct in case: " + case.struct);
 					}
+
+					emitJavaStatement(case_ctx_v.first, case.body, retloc);
+
+					if (!isJavaReturnStmt(retloc))
+						jctxPushStr(ctx, subctx.indent + "break;\n");
+					jctxPushStr(ctx, ctx.indent + "}\n");
+
+					case_ctx_v.second;
 				}
-
-				emitJavaStatement(case_ctx_v.first, case.body, retloc);
-
-				if (!isJavaReturnStmt(retloc))
-					jctxPushStr(ctx, subctx.indent + "break;\n");
-				jctxPushStr(ctx, ctx.indent + "}\n");
-
-				case_ctx_v.second;
 			});
 
 			if (!has_default) {

--- a/tools/flowc/backends/java/fi2java_compile.flow
+++ b/tools/flowc/backends/java/fi2java_compile.flow
@@ -1,5 +1,6 @@
 import math/hash;
 import tools/flowc/backends/common;
+import tools/flowc/incremental/fi_helpers;
 import tools/flowc/backends/java/fi2java_defines;
 
 export {
@@ -562,122 +563,6 @@ emitJavaFunction(gctx : JavaGlobalContext, csm : JavaModule, global : string, na
 	list2string(^reslist);
 }
 
-// Groups consecutive switch cases that can be merged using Java's case fall-through.
-// Cases are mergeable when all argNames are "__" (no field bindings), the body does not
-// use the switch variable in a type-dependent way (field access / set-mutable, where
-// fiExpType drives struct-specific casts), and bodies are structurally equal.
-groupMergeableSwitchCases(cases : [FiCase], switchVar : string) -> [[FiCase]] {
-	if (length(cases) == 0) []
-	else {
-		foldi(cases, [], \i, acc, case -> {
-			if (i == 0) {
-				[[case]]
-			} else {
-				lastIdx = length(acc) - 1;
-				lastGroup = acc[lastIdx];
-				prevCase = lastElement(lastGroup, case);
-				if (canMergeSwitchCases(prevCase, case, switchVar)) {
-					replace(acc, lastIdx, arrayPush(lastGroup, case))
-				} else {
-					arrayPush(acc, [case])
-				}
-			}
-		});
-	}
-}
-
-canMergeSwitchCases(c1 : FiCase, c2 : FiCase, switchVar : string) -> bool {
-	c1.struct != "default" && c2.struct != "default"
-	&& forall(c1.argNames, \a -> a == "__")
-	&& forall(c2.argNames, \a -> a == "__")
-	&& isSameFiExp(c1.body, c2.body);
-}
-
-// Replaces the type of all free occurrences of a variable in an FiExp.
-// Used for merged switch cases: desugaring narrows the switch variable's type
-// per-case, but in the merged body we use FiTypeFlow() to ensure type-independent
-// code generation (e.g., Field_ accessor interfaces instead of direct field access).
-// Respects shadowing: lambdas, lets, switch argNames, and inner switches on the
-// same variable all prevent recursion into their scope.
-generalizeVarInFiExp(exp : FiExp, varName : string, newType : FiType) -> FiExp {
-	if (!fiExpReferencesVar(exp, varName)) exp
-	else switch (exp) {
-		FiVar(n, __, s): if (n == varName) FiVar(n, newType, s) else exp;
-		FiCall(f, es, t, s): FiCall(
-			generalizeVarInFiExp(f, varName, newType),
-			map(es, \e -> generalizeVarInFiExp(e, varName, newType)),
-			t, s
-		);
-		FiLambda(args, body, t, s):
-			if (exists(args, \a -> a.name == varName)) exp
-			else FiLambda(args, generalizeVarInFiExp(body, varName, newType), t, s);
-		FiLet(x, xt, e1, e2, t, s): FiLet(
-			x, xt,
-			generalizeVarInFiExp(e1, varName, newType),
-			if (x == varName) e2 else generalizeVarInFiExp(e2, varName, newType),
-			t, s
-		);
-		FiIf(c, th, el, t, s): FiIf(
-			generalizeVarInFiExp(c, varName, newType),
-			generalizeVarInFiExp(th, varName, newType),
-			generalizeVarInFiExp(el, varName, newType),
-			t, s
-		);
-		FiSwitch(x, st, cases, t, s): FiSwitch(
-			FiVar(x.name, if (x.name == varName) newType else x.type, x.start),
-			st,
-			// If inner switch is on the same variable, it rebinds it in case bodies —
-			// don't generalize there; the inner codegen handles the rebinding.
-			if (x.name == varName) cases
-			else map(cases, \c ->
-				if (exists(c.argNames, \a -> a == varName)) c
-				else FiCase(c.struct, c.argNames, generalizeVarInFiExp(c.body, varName, newType), c.start)
-			),
-			t, s
-		);
-		FiCast(e, ft, tt, t, s): FiCast(generalizeVarInFiExp(e, varName, newType), ft, tt, t, s);
-		FiSeq(es, t, s): FiSeq(map(es, \e -> generalizeVarInFiExp(e, varName, newType)), t, s);
-		FiCallPrim(op, es, t, s): FiCallPrim(op, map(es, \e -> generalizeVarInFiExp(e, varName, newType)), t, s);
-		FiRequire(flowfile, e, t, s): FiRequire(flowfile, generalizeVarInFiExp(e, varName, newType), t, s);
-		FiUnsafe(nm, e, t, s): FiUnsafe(nm, generalizeVarInFiExp(e, varName, newType), t, s);
-		default: exp;
-	}
-}
-
-// Checks whether a variable name appears free (not shadowed) in an FiExp.
-// Accounts for shadowing by lambdas, lets, switch argNames, and inner switches
-// on the same variable (which rebind it in case bodies).
-fiExpReferencesVar(exp : FiExp, name : string) -> bool {
-	switch (exp) {
-		FiVoid(__): false;
-		FiBool(__, __): false;
-		FiInt(__, __): false;
-		FiDouble(__, __): false;
-		FiString(__, __): false;
-		FiVar(n, __, __): n == name;
-		FiCall(f, es, __, __):
-			fiExpReferencesVar(f, name) || exists(es, \e -> fiExpReferencesVar(e, name));
-		FiLambda(args, body, __, __):
-			!exists(args, \a -> a.name == name) && fiExpReferencesVar(body, name);
-		FiLet(x, __, e1, e2, __, __):
-			fiExpReferencesVar(e1, name) || (x != name && fiExpReferencesVar(e2, name));
-		FiIf(c, t, e, __, __):
-			fiExpReferencesVar(c, name) || fiExpReferencesVar(t, name) || fiExpReferencesVar(e, name);
-		FiSwitch(x, __, cases, __, __):
-			// The switch expression references the var. If the switch is on the same
-			// variable, it rebinds it in case bodies — don't recurse into them.
-			fiExpReferencesVar(x, name)
-			|| (x.name != name && exists(cases, \c ->
-				!exists(c.argNames, \a -> a == name) && fiExpReferencesVar(c.body, name)
-			));
-		FiCast(e, __, __, __, __): fiExpReferencesVar(e, name);
-		FiSeq(es, __, __): exists(es, \e -> fiExpReferencesVar(e, name));
-		FiCallPrim(__, es, __, __): exists(es, \e -> fiExpReferencesVar(e, name));
-		FiRequire(__, e, __, __): fiExpReferencesVar(e, name);
-		FiUnsafe(__, e, __, __): fiExpReferencesVar(e, name);
-	}
-}
-
 emitJavaStatement(ctx0 : JavaScopeContext, code0 : FiExp, retloc : JavaReturnLocation) -> void {
 	unw_code = unfoldJavaStatements(ctx0, code0, true);
 	code : FiExp = unw_code.first;
@@ -694,7 +579,8 @@ emitJavaStatement(ctx0 : JavaScopeContext, code0 : FiExp, retloc : JavaReturnLoc
 			emitJavaStatement(subctx, elseExp, retloc);
 			jctxPushStr(ctx, ctx.indent + "}\n");
 		}
-		FiSwitch(x, __, cases,__,__): {
+		FiSwitch(x, __, cases0,__,__): {
+			cases = fiExpandSwitchCases(cases0);
 			arg_code = unfoldJavaStatements(ctx, x, false);
 			argstr = emitJavaExpression(arg_code.second, arg_code.first, "Struct");
 			tmpvar = javaNewLocalName(ctx.func.next_local_id, "_tmp");
@@ -703,104 +589,61 @@ emitJavaStatement(ctx0 : JavaScopeContext, code0 : FiExp, retloc : JavaReturnLoc
 			subctx = jctxPushIndent(ctx, "\t");
 			tmpvar2 = javaNewLocalName(ctx.func.next_local_id, "_tmp");
 			inputvar = x.name;
-
-			// Group consecutive cases with identical bodies to use Java's case fall-through
-			caseGroups = groupMergeableSwitchCases(cases, inputvar);
-
-			has_default = fold(caseGroups, false, \hasdef, group -> {
-				firstCase = group[0];
-
-				if (firstCase.struct == "default") {
-					// Default case
+			has_default = fold(cases, false, \hasdef, case -> {
+				case_ctx_v = if (case.struct == "default") {
 					jctxPushStr(ctx, ctx.indent + "default: {\n");
-					emitJavaStatement(subctx, firstCase.body, retloc);
-					if (!isJavaReturnStmt(retloc))
-						jctxPushStr(ctx, subctx.indent + "break;\n");
-					jctxPushStr(ctx, ctx.indent + "}\n");
-					true;
-				} else if (length(group) > 1) {
-					// Merged group: emit fall-through case labels, body only once.
-					// All argNames are "__" so no struct-specific casts are needed.
-					iter(group, \case -> {
-						switch (lookupTree(ctx.func.gctx.cstructs, case.struct)) {
-							Some(cstruct): {
-								jctxPushStr(ctx, ctx.indent + "case " + i2s(cstruct.id) + "/*" + cstruct.name + "*/:\n");
-							}
-							None(): {
-								fail0("invalid struct in case: " + case.struct);
-							}
-						}
-					});
-					jctxPushStr(ctx, ctx.indent + "{\n");
-					// Generalize the switch variable's type in the body to FiTypeFlow()
-					// so that field accesses use accessor interfaces (Field_xxx) instead
-					// of struct-specific casts, which wouldn't be valid across merged cases.
-					mergedBody = if (inputvar != "") {
-						generalizeVarInFiExp(firstCase.body, inputvar, FiTypeFlow());
-					} else firstCase.body;
-					emitJavaStatement(subctx, mergedBody, retloc);
-					if (!isJavaReturnStmt(retloc))
-						jctxPushStr(ctx, subctx.indent + "break;\n");
-					jctxPushStr(ctx, ctx.indent + "}\n");
-					hasdef;
+					Pair(subctx, true);
 				} else {
-					// Single case - emit with full variable bindings as before
-					case = firstCase;
-					case_ctx_v = if (case.struct == "default") {
-						jctxPushStr(ctx, ctx.indent + "default: {\n");
-						Pair(subctx, true);
-					} else {
-						switch (lookupTree(ctx.func.gctx.cstructs, case.struct)) {
-							Some(cstruct): {
-								jctxPushStr(ctx, ctx.indent + "case " + i2s(cstruct.id) + "/*" + cstruct.name + "*/: {\n");
+					switch (lookupTree(ctx.func.gctx.cstructs, case.struct)) {
+						Some(cstruct): {
+							jctxPushStr(ctx, ctx.indent + "case " + i2s(cstruct.id) + "/*" + cstruct.name + "*/: {\n");
 
-								has_args = exists(case.argNames, \a -> a != "__");
+							has_args = exists(case.argNames, \a -> a != "__");
 
-								castctx = if (has_args || (length(cstruct.fields) > 0 && inputvar != "")) {
-									stype = "Struct_" + cstruct.javaName;
-									jctxPushStr(ctx, subctx.indent + "final " + stype + " " + tmpvar2 +
-										" = (" + stype + ")" + tmpvar + ";\n");
+							castctx = if (has_args || (length(cstruct.fields) > 0 && inputvar != "")) {
+								stype = "Struct_" + cstruct.javaName;
+								jctxPushStr(ctx, subctx.indent + "final " + stype + " " + tmpvar2 +
+									" = (" + stype + ")" + tmpvar + ";\n");
 
-									if (inputvar != "")
-										jctxPushLocal(subctx, JavaLocalInfo(inputvar, tmpvar2, stype, true, false))
-									else
-										subctx;
-								}
+								if (inputvar != "")
+									jctxPushLocal(subctx, JavaLocalInfo(inputvar, tmpvar2, stype, true, false))
 								else
 									subctx;
-
-								ectx = if (!has_args)
-									castctx
-								else {
-									foldi(case.argNames, castctx, \i, sctx, arg -> {
-										if (arg == "__")
-											sctx
-										else {
-											aname = javaNewLocalName(ctx.func.next_local_id, arg);
-											ty = type2javaObjType(ctx.func.gctx, cstruct.fields[i].type, true, false, false);
-											jctxPushStr(ctx, subctx.indent + "final " + ty + " " + aname +
-												" = " + tmpvar2 + ".f_" + cstruct.fields[i].name + ";\n");
-
-											jctxPushLocal(sctx, JavaLocalInfo(arg,aname,ty,true,false));
-										}
-									});
-								}
-
-								Pair(ectx, hasdef);
 							}
-							None():
-								fail0("invalid struct in case: " + case.struct);
+							else
+								subctx;
+
+							ectx = if (!has_args)
+								castctx
+							else {
+								foldi(case.argNames, castctx, \i, sctx, arg -> {
+									if (arg == "__")
+										sctx
+									else {
+										aname = javaNewLocalName(ctx.func.next_local_id, arg);
+										ty = type2javaObjType(ctx.func.gctx, cstruct.fields[i].type, true, false, false);
+										jctxPushStr(ctx, subctx.indent + "final " + ty + " " + aname +
+											" = " + tmpvar2 + ".f_" + cstruct.fields[i].name + ";\n");
+
+										jctxPushLocal(sctx, JavaLocalInfo(arg,aname,ty,true,false));
+									}
+								});
+							}
+
+							Pair(ectx, hasdef);
 						}
+						None():
+							fail0("invalid struct in case: " + case.struct);
 					}
-
-					emitJavaStatement(case_ctx_v.first, case.body, retloc);
-
-					if (!isJavaReturnStmt(retloc))
-						jctxPushStr(ctx, subctx.indent + "break;\n");
-					jctxPushStr(ctx, ctx.indent + "}\n");
-
-					case_ctx_v.second;
 				}
+
+				emitJavaStatement(case_ctx_v.first, case.body, retloc);
+
+				if (!isJavaReturnStmt(retloc))
+					jctxPushStr(ctx, subctx.indent + "break;\n");
+				jctxPushStr(ctx, ctx.indent + "}\n");
+
+				case_ctx_v.second;
 			});
 
 			if (!has_default) {
@@ -1723,7 +1566,7 @@ addJavaExpressionWrappers(gctx : JavaGlobalContext, expcode : FiExp) -> void {
 		}
 		FiSwitch(x, __, cases, __,__): {
 			addJavaExpressionWrappers(gctx, x);
-			iter(cases, \c -> addJavaExpressionWrappers(gctx, c.body));
+			iter(cases, \c -> addJavaExpressionWrappers(gctx, fiSwitchCaseBody(c)));
 		}
 		FiRequire(__, e, __,__):
 			addJavaExpressionWrappers(gctx, e);

--- a/tools/flowc/backends/java/fi2java_compile.flow
+++ b/tools/flowc/backends/java/fi2java_compile.flow
@@ -1,6 +1,7 @@
 import math/hash;
 import tools/flowc/backends/common;
 import tools/flowc/incremental/fi_helpers;
+import tools/flowc/manipulation/common;
 import tools/flowc/backends/java/fi2java_defines;
 
 export {
@@ -579,8 +580,7 @@ emitJavaStatement(ctx0 : JavaScopeContext, code0 : FiExp, retloc : JavaReturnLoc
 			emitJavaStatement(subctx, elseExp, retloc);
 			jctxPushStr(ctx, ctx.indent + "}\n");
 		}
-		FiSwitch(x, __, cases0,__,__): {
-			cases = fiExpandSwitchCases(cases0);
+		FiSwitch(x, __, cases,__,__): {
 			arg_code = unfoldJavaStatements(ctx, x, false);
 			argstr = emitJavaExpression(arg_code.second, arg_code.first, "Struct");
 			tmpvar = javaNewLocalName(ctx.func.next_local_id, "_tmp");
@@ -589,61 +589,95 @@ emitJavaStatement(ctx0 : JavaScopeContext, code0 : FiExp, retloc : JavaReturnLoc
 			subctx = jctxPushIndent(ctx, "\t");
 			tmpvar2 = javaNewLocalName(ctx.func.next_local_id, "_tmp");
 			inputvar = x.name;
-			has_default = fold(cases, false, \hasdef, case -> {
-				case_ctx_v = if (case.struct == "default") {
-					jctxPushStr(ctx, ctx.indent + "default: {\n");
-					Pair(subctx, true);
-				} else {
-					switch (lookupTree(ctx.func.gctx.cstructs, case.struct)) {
-						Some(cstruct): {
-							jctxPushStr(ctx, ctx.indent + "case " + i2s(cstruct.id) + "/*" + cstruct.name + "*/: {\n");
 
-							has_args = exists(case.argNames, \a -> a != "__");
-
-							castctx = if (has_args || (length(cstruct.fields) > 0 && inputvar != "")) {
-								stype = "Struct_" + cstruct.javaName;
-								jctxPushStr(ctx, subctx.indent + "final " + stype + " " + tmpvar2 +
-									" = (" + stype + ")" + tmpvar + ";\n");
-
-								if (inputvar != "")
-									jctxPushLocal(subctx, JavaLocalInfo(inputvar, tmpvar2, stype, true, false))
-								else
-									subctx;
+			has_default = fold(cases, false, \hasdef, scase -> {
+				switch (scase) {
+					FiCaseUnion(__, structs, body, __): {
+						// Union case: emit fall-through case labels for each struct
+						iter(structs, \sname -> {
+							switch (lookupTree(ctx.func.gctx.cstructs, sname)) {
+								Some(cstruct): {
+									jctxPushStr(ctx, ctx.indent + "case " + i2s(cstruct.id) + "/*" + cstruct.name + "*/:\n");
+								}
+								None(): {
+									fail0("invalid struct in union case: " + sname);
+								}
 							}
-							else
-								subctx;
+						});
+						jctxPushStr(ctx, ctx.indent + "{\n");
+						// Generalize the switch variable's type to FiTypeFlow()
+						// so that field accesses use accessor interfaces (Field_xxx)
+						// instead of struct-specific casts.
+						mergedBody = if (inputvar != "") {
+							generalizeVarType(body, inputvar, FiTypeFlow());
+						} else body;
+						emitJavaStatement(subctx, mergedBody, retloc);
+						if (!isJavaReturnStmt(retloc))
+							jctxPushStr(ctx, subctx.indent + "break;\n");
+						jctxPushStr(ctx, ctx.indent + "}\n");
+						hasdef;
+					}
+					FiCase(struct, argNames, body, __): {
+						if (struct == "default") {
+							// Default case
+							jctxPushStr(ctx, ctx.indent + "default: {\n");
+							emitJavaStatement(subctx, body, retloc);
+							if (!isJavaReturnStmt(retloc))
+								jctxPushStr(ctx, subctx.indent + "break;\n");
+							jctxPushStr(ctx, ctx.indent + "}\n");
+							true;
+						} else {
+							// Single struct case with full variable bindings
+							switch (lookupTree(ctx.func.gctx.cstructs, struct)) {
+								Some(cstruct): {
+									jctxPushStr(ctx, ctx.indent + "case " + i2s(cstruct.id) + "/*" + cstruct.name + "*/: {\n");
 
-							ectx = if (!has_args)
-								castctx
-							else {
-								foldi(case.argNames, castctx, \i, sctx, arg -> {
-									if (arg == "__")
-										sctx
-									else {
-										aname = javaNewLocalName(ctx.func.next_local_id, arg);
-										ty = type2javaObjType(ctx.func.gctx, cstruct.fields[i].type, true, false, false);
-										jctxPushStr(ctx, subctx.indent + "final " + ty + " " + aname +
-											" = " + tmpvar2 + ".f_" + cstruct.fields[i].name + ";\n");
+									has_args = exists(argNames, \a -> a != "__");
 
-										jctxPushLocal(sctx, JavaLocalInfo(arg,aname,ty,true,false));
+									castctx = if (has_args || (length(cstruct.fields) > 0 && inputvar != "")) {
+										stype = "Struct_" + cstruct.javaName;
+										jctxPushStr(ctx, subctx.indent + "final " + stype + " " + tmpvar2 +
+											" = (" + stype + ")" + tmpvar + ";\n");
+
+										if (inputvar != "")
+											jctxPushLocal(subctx, JavaLocalInfo(inputvar, tmpvar2, stype, true, false))
+										else
+											subctx;
 									}
-								});
-							}
+									else
+										subctx;
 
-							Pair(ectx, hasdef);
+									ectx = if (!has_args)
+										castctx
+									else {
+										foldi(argNames, castctx, \i, sctx, arg -> {
+											if (arg == "__")
+												sctx
+											else {
+												aname = javaNewLocalName(ctx.func.next_local_id, arg);
+												ty = type2javaObjType(ctx.func.gctx, cstruct.fields[i].type, true, false, false);
+												jctxPushStr(ctx, subctx.indent + "final " + ty + " " + aname +
+													" = " + tmpvar2 + ".f_" + cstruct.fields[i].name + ";\n");
+
+												jctxPushLocal(sctx, JavaLocalInfo(arg,aname,ty,true,false));
+											}
+										});
+									}
+
+									emitJavaStatement(ectx, body, retloc);
+
+									if (!isJavaReturnStmt(retloc))
+										jctxPushStr(ctx, subctx.indent + "break;\n");
+									jctxPushStr(ctx, ctx.indent + "}\n");
+
+									hasdef;
+								}
+								None():
+									fail0("invalid struct in case: " + struct);
+							}
 						}
-						None():
-							fail0("invalid struct in case: " + case.struct);
 					}
 				}
-
-				emitJavaStatement(case_ctx_v.first, case.body, retloc);
-
-				if (!isJavaReturnStmt(retloc))
-					jctxPushStr(ctx, subctx.indent + "break;\n");
-				jctxPushStr(ctx, ctx.indent + "}\n");
-
-				case_ctx_v.second;
 			});
 
 			if (!has_default) {

--- a/tools/flowc/backends/javascript/fi2javascript_compile.flow
+++ b/tools/flowc/backends/javascript/fi2javascript_compile.flow
@@ -1,5 +1,6 @@
 import tools/flowc/backends/common;
 import tools/flowc/incremental/fimodule;
+import tools/flowc/incremental/fi_helpers;
 import ds/tree;
 import lingo/flow/javascript_keywords;
 import tools/flowc/backends/javascript/fi2javascript_defines;
@@ -416,7 +417,8 @@ fiJsCompileToExpr(cfg : FiJsConfig, ctx : FiJsToplevelContext, expr : FiExp, ind
 			fiJsCompileToExpr(cfg, ctx, e3, subindent, false, true, unusedVars) + ")";
 		}
 
-		FiSwitch(e0, e0type, cs, __, __): {
+		FiSwitch(e0, e0type, cs0, __, __): {
+			cs = fiExpandSwitchCases(cs0);
 			isIf = length(cs) == 2;
 			rdbl = cfg.readable;
 			es6 = cfg.jsmode == STANDARD_ES6 || cfg.jsmode == NODEJS_MODE || cfg.jsmode == NWJS_MODE;
@@ -732,7 +734,8 @@ fiJsCompileToReturn(cfg : FiJsConfig, ctx : FiJsToplevelContext, expr : FiExp, i
 			fiJsCompileToReturn(cfg, ctx, e3, subindent, unusedVars) + "}";
 		}
 
-		FiSwitch(e0, e0type, cs, __, __): {
+		FiSwitch(e0, e0type, cs0, __, __): {
+			cs = fiExpandSwitchCases(cs0);
 			/*
 			There is a problem, that when we have function, which last statement is very large switch operator,
 			execution stack may be exhausted:

--- a/tools/flowc/backends/javascript/fi2javascript_compile.flow
+++ b/tools/flowc/backends/javascript/fi2javascript_compile.flow
@@ -252,14 +252,33 @@ fiJsCompileToplevel(cfg : FiJsConfig, ctx : FiJsToplevelContext, decl : FiDeclar
 fiJsLambdaLevel : ref int = ref 0;
 
 fiGetStructId(ctx : FiJsToplevelContext, item : FiCase) {
-	switch (lookupTree(ctx.ovl.structs, item.struct)) {
+	fiGetStructIdByName(ctx, item.struct);
+}
+
+fiGetStructIdByName(ctx : FiJsToplevelContext, name : string) -> int {
+	switch (lookupTree(ctx.ovl.structs, name)) {
 		Some(info): info.id;
-		None(): fail0("Unknown struct " + item.struct);
+		None(): fail0("Unknown struct " + name);
 	}
 }
 
 fiGetItemId(ctx : FiJsToplevelContext, item, readable) {
 	if (readable) "'" + item.struct + "'" else i2s(fiGetStructId(ctx, item));
+}
+
+// Generate JS case label(s) for a FiSwitchCase. FiCaseUnion emits fall-through labels.
+fiJsSwitchCaseLabels(ctx : FiJsToplevelContext, c : FiSwitchCase, rdbl : bool, indent : string, cfg : FiJsConfig) -> string {
+	switch (c) {
+		FiCase(struct, __, __, __): {
+			if (struct == "default") "default"
+			else if (rdbl) "case '" + struct + "'" else "case " + i2s(fiGetStructIdByName(ctx, struct));
+		}
+		FiCaseUnion(__, structs, __, __): {
+			superglue(structs, \sn -> {
+				if (rdbl) "case '" + sn + "'" else "case " + i2s(fiGetStructIdByName(ctx, sn))
+			}, ":" + finl(cfg) + indent);
+		}
+	}
 }
 
 fiJsCompileToExpr(cfg : FiJsConfig, ctx : FiJsToplevelContext, expr : FiExp, indent : string, tailcall : bool, needPars : bool, unusedVars : Set<string>) -> string {
@@ -418,8 +437,10 @@ fiJsCompileToExpr(cfg : FiJsConfig, ctx : FiJsToplevelContext, expr : FiExp, ind
 		}
 
 		FiSwitch(e0, e0type, cs0, __, __): {
-			cs = fiExpandSwitchCases(cs0);
-			isIf = length(cs) == 2;
+			// Use isIf optimization only when all cases are FiCase (not FiCaseUnion)
+			allFiCase = forall(cs0, \c -> switch(c) { FiCase(__,__,__,__): true; FiCaseUnion(__,__,__,__): false; });
+			cs : [FiCase] = if (allFiCase) fiExpandSwitchCases(cs0) else [];
+			isIf = allFiCase && length(cs) == 2;
 			rdbl = cfg.readable;
 			es6 = cfg.jsmode == STANDARD_ES6 || cfg.jsmode == NODEJS_MODE || cfg.jsmode == NWJS_MODE;
 			switchexp0 = fiJsCompileToExpr(cfg, ctx, e0, indent, false, false, unusedVars);
@@ -446,14 +467,10 @@ fiJsCompileToExpr(cfg : FiJsConfig, ctx : FiJsToplevelContext, expr : FiExp, ind
 			inner = if (isIf)
 					innerIf
 				else
-					fold(cs, Cons(header, EmptyList()), \acc, item -> {
-						choice = if (item.struct == "default") {
-								"default"
-							} else {
-								if (rdbl) "case '" + item.struct + "'"  else "case "+i2s(fiGetStructId(ctx, item));
-							};
-						unused = findUnusedLocalsExpSet(item.body, makeSet(), false, unusedVars);
-						body = fiJsCompileToExpr(cfg, ctx, item.body, indent+ctx.indent4, false, false, unused);
+					fold(cs0, Cons(header, EmptyList()), \acc, item -> {
+						choice = fiJsSwitchCaseLabels(ctx, item, rdbl, indent, cfg);
+						unused = findUnusedLocalsExpSet(fiSwitchCaseBody(item), makeSet(), false, unusedVars);
+						body = fiJsCompileToExpr(cfg, ctx, fiSwitchCaseBody(item), indent+ctx.indent4, false, false, unused);
 						// TODO: If the body ends in a "return", we do not need this "break;" here
 						Cons(";break;}"+ finl(cfg)+indent, Cons(body, Cons(choice+":{s$=", acc)));
 					});
@@ -735,56 +752,35 @@ fiJsCompileToReturn(cfg : FiJsConfig, ctx : FiJsToplevelContext, expr : FiExp, i
 		}
 
 		FiSwitch(e0, e0type, cs0, __, __): {
-			cs = fiExpandSwitchCases(cs0);
+			// Count total struct cases for the >=50 heuristic
+			totalStructCases = fold(cs0, 0, \acc, c -> acc + length(fiSwitchCaseStructs(c)));
 			/*
 			There is a problem, that when we have function, which last statement is very large switch operator,
-			execution stack may be exhausted:
-
-			fn() {
-				...
-				switch(e) {
-					....
-				}
-			}
-
+			execution stack may be exhausted.
 			To solve that we wrap that switch into separate scope using (function() {...})() in JS.
 			But this breaks tail call optimization and we use this heuristic only for really large
 			switches. To be practical, we optimize only switches with more than 50 cases.
 			*/
-			if (length(cs) >= 50) {
+			if (totalStructCases >= 50) {
 				"return " + fiJsCompileToExpr(cfg, ctx, expr, indent, false, false, unusedVars) + ";"
 			} else {
-				isIf = length(cs) == 2;
+				// Use isIf optimization only when all cases are FiCase (not FiCaseUnion)
+				allFiCase = forall(cs0, \c -> switch(c) { FiCase(__,__,__,__): true; FiCaseUnion(__,__,__,__): false; });
+				cs : [FiCase] = if (allFiCase) fiExpandSwitchCases(cs0) else [];
+				isIf = allFiCase && length(cs) == 2;
 
 				rdbl = cfg.readable;
 				aVar = "(" + fiJsCompileToExpr(cfg, ctx, e0, indent, false, false, unusedVars) + ")." + (if (rdbl) "_name" else if (cfg.namespaceMode) "kind" else "_id");
 
 				header = "switch(" + aVar + "){" + finl(cfg) + indent;
 				// TODO: TS processing
-				/*
-				getNextParams = \item -> {
-					changeTSProcessing(params, TypeScriptProcessing(
-						if (!ctx.ovl.typescript || item.tag == "default") ""
-						else resolveTSType(item.tag, ["", "?"][b2i(params.modules != "")]) +
-						if (lookupTreeDef(^genericTypes, item.tag, 0) == 0) ""
-						// Alternative: resolveTSTypes(ctx.ovl.typescript, ns, tSubst, e0.info.derived, 2, false, 0, "%1")
-						else "<" + strGlue(generate(0, lookupTreeDef(^genericTypes, item.tag, 0), \__ -> "any"), ",") + ">",
-						params.tsProcess.voidReturn,
-						params.tsProcess.antiTS
-					));
-				}
-				*/
 				ifText = if (isIf) {
 						// See comment above in jsCompileToExpr.
 						isFirstBranchDefault = cs[0].struct == "default";
 						ifSelector  = fiGetItemId(ctx, cs[if (isFirstBranchDefault) 1 else 0], rdbl);
-						// TODO: TS processing
-						// paramsTrue  = getNextParams(cs[0]);
 						s1 = findUnusedLocalsExpSet(cs[0].body, makeSet(), false, unusedVars);
 						s2 = findUnusedLocalsExpSet(cs[1].body, makeSet(), false, unusedVars);
 						trueBody    = fiJsCompileToReturn(cfg, ctx, cs[0].body, indent+ctx.indent4, s1);
-						// TODO: TS processing
-						// paramsFalse = getNextParams(cs[1]);
 						falseBody   = fiJsCompileToReturn(cfg, ctx, cs[1].body, indent+ctx.indent4, s2);
 						"if(" + aVar + (if (isFirstBranchDefault) "!=" else "==") + ifSelector + "){" + trueBody + "}else{" + falseBody;
 					} else "";
@@ -794,17 +790,10 @@ fiJsCompileToReturn(cfg : FiJsConfig, ctx : FiJsToplevelContext, expr : FiExp, i
 				inner = if (isIf)
 						innerIf
 					else
-						fold(cs, Cons(header, EmptyList()), \acc, item -> {
-							choice = if (item.struct == "default") {
-									"default"
-								} else {
-									if (rdbl) "case '" + item.struct + "'" else "case "+i2s(fiGetStructId(ctx, item));
-								};
-							// TODO if this has a sense
-							// TODO: TS processing
-							// paramsNext = getNextParams(item);
-							unused = findUnusedLocalsExpSet(item.body, makeSet(), false, unusedVars);
-							body = fiJsCompileToReturn(cfg, ctx, item.body, subindent, unused);
+						fold(cs0, Cons(header, EmptyList()), \acc, item -> {
+							choice = fiJsSwitchCaseLabels(ctx, item, rdbl, indent, cfg);
+							unused = findUnusedLocalsExpSet(fiSwitchCaseBody(item), makeSet(), false, unusedVars);
+							body = fiJsCompileToReturn(cfg, ctx, fiSwitchCaseBody(item), subindent, unused);
 							// Maybe TODO : remove "break;" if unreachable due to "return"
 							Cons("}" + finl(cfg) + subindent+"break;" + finl(cfg) + indent, Cons(body, Cons(choice+":{", acc)));
 						});

--- a/tools/flowc/backends/lisp/fi2lisp_compile.flow
+++ b/tools/flowc/backends/lisp/fi2lisp_compile.flow
@@ -426,7 +426,8 @@ fiLispCompileToExpr(cfg, program, expr, indent) {
 			}
 		}
 
-		FiSwitch(e0, e0type, cs, tp, start): {
+		FiSwitch(e0, e0type, cs0, tp, start): {
+			cs = fiExpandSwitchCases(cs0);
 
 			aVar = fiLispCompileToExpr(cfg, program, e0, indent);
 

--- a/tools/flowc/backends/ml/fi2ml_compile.flow
+++ b/tools/flowc/backends/ml/fi2ml_compile.flow
@@ -327,11 +327,12 @@ fiMLCompileToExpr(cfg, program, expr, indent) {
 			}
 		}
 
-		FiSwitch(e0, e0type, cs, tp, start): {
-			
+		FiSwitch(e0, e0type, cs0, tp, start): {
+			cs = fiExpandSwitchCases(cs0);
+
 			aVar = fiMLCompileToExpr(cfg, program, e0, indent);
 
-			cases = foldi(cs, Cons("", EmptyList()), \ix, acc, item : FiCase -> {
+			cases = foldi(cs, Cons("", EmptyList()), \ix, acc, item -> {
 				stDef = lookupTree(program.names.structs, item.struct);
 
 				if (item.struct == "default") {

--- a/tools/flowc/backends/nim/fi2nim_compile.flow
+++ b/tools/flowc/backends/nim/fi2nim_compile.flow
@@ -401,7 +401,8 @@ fiNimCompile(env : FiNimEnv, expr : FiExp, returns: FiNimReturn, locals: Set<str
 		}
 		FiSwitch(x, x_type, cs, type, __): {
 			x_code = fiNimCompile(env, x, FiNimReturnValue(), locals);
-			def_case = switch (find(cs, \c -> c.struct == "default")) {
+			expanded = fiExpandSwitchCases(cs);
+			def_case = switch (find(expanded, \c -> c.struct == "default")) {
 				Some(dc): fi2nimMaybeIndent(fiNimCompile(env, dc.body, returns, locals));
 				None(): fi2nimMaybeIndent(fi2nimJoinNimCode(
 					NimLine(0, "rt_runtime_error(\"illegal struct id in switch: \" & $" + fi2nimUnwrapSnippet(x_code) + ".str_id)"),
@@ -410,9 +411,9 @@ fiNimCompile(env : FiNimEnv, expr : FiExp, returns: FiNimReturn, locals: Set<str
 			}
 			fi2nimJoinNimCodeMany(concat3(
 				[fi2nimCode2Block(fi2nimJoinNimCodeMany([NimSnippet("case "), x_code, NimSnippet(".str_id"), NimSnippet(":")]))],
-				map(filter(cs, \c -> c.struct != "default"), \c ->
+				map(filter(expanded, \c -> c.struct != "default"), \c ->
 					fi2nimJoinNimCode(
-						NimLine(0, "of " + fi2nimStructId(c.struct) + ": "), 
+						NimLine(0, "of " + fi2nimStructId(c.struct) + ": "),
 						fi2nimMaybeIndent(fiNimCompile(env, c.body, returns, locals))
 					)
 				),

--- a/tools/flowc/backends/nim/fi2nim_transform.flow
+++ b/tools/flowc/backends/nim/fi2nim_transform.flow
@@ -325,10 +325,22 @@ fiRenameGlobalsInExp(e: FiExp, renaming: Tree<string, string>) -> FiExp {
 		FiSwitch(v, vtype, cases, type, s): 
 			FiSwitch(v,
 				fiRenameGlobalsInType(vtype, renaming),
-				map(cases, \case -> FiCase(case with
-					struct = lookupTreeDef(renaming, case.struct, case.struct),
-					body = fiRenameGlobalsInExp(case.body, renaming),
-				)),
+				map(cases, \case -> {
+					switch (case) {
+						FiCase(struct, argNames, body, cs): FiCase(
+							lookupTreeDef(renaming, struct, struct),
+							argNames,
+							fiRenameGlobalsInExp(body, renaming),
+							cs
+						);
+						FiCaseUnion(union, structs, body, cs): FiCaseUnion(
+							lookupTreeDef(renaming, union, union),
+							map(structs, \sn -> lookupTreeDef(renaming, sn, sn)),
+							fiRenameGlobalsInExp(body, renaming),
+							cs
+						);
+					}
+				}),
 				fiRenameGlobalsInType(type, renaming), s);
 		FiRequire(file, x, type, s): 
 			FiRequire(file,

--- a/tools/flowc/backends/wasm/wasm_exp_convert.flow
+++ b/tools/flowc/backends/wasm/wasm_exp_convert.flow
@@ -1,4 +1,5 @@
 import tools/flowc/incremental/fiexp;
+import tools/flowc/incremental/fi_helpers;
 import tools/flowc/backends/wasm/wasm_type_descriptor;
 import tools/flowc/backends/wasm/wasm_exp;
 import ds/array;
@@ -130,7 +131,8 @@ dofiexp2wasmexp(context : WasmContext, names : FiGlobalNames, e : FiExp, locals 
 		FiIf(e1, e2, e3, type, __): {
 			WasmIf(do_exp(e1), do_exp(e2), do_exp(e3), do_type(type), []);
 		}
-		FiSwitch(x, switchType, cases, type, __): {
+		FiSwitch(x, switchType, cases0, type, __): {
+			cases = fiExpandSwitchCases(cases0);
 			cases2 = map(cases, \c -> WasmCase(c.struct, c.argNames, do_exp(c.body)));
 			WasmSwitch(do_var(x, false), do_type(switchType), cases2, do_type(type), [])
 		}

--- a/tools/flowc/backends/wasm/wasm_native_wrapper.flow
+++ b/tools/flowc/backends/wasm/wasm_native_wrapper.flow
@@ -1,6 +1,7 @@
 import tools/flowc/backends/wasm/fi2wasm_compile;
 import tools/flowc/backends/wasm/wasm_type_descriptor;
 import tools/flowc/manipulation/lambda_lifting;
+import tools/flowc/incremental/fi_helpers;
 
 export {
 	wrap_natives(cfg : FiWasmConfig, program : FiProgram, names : FiGlobalNames, types : FiWasmTypeTable, natives: Tree<string, FiWasmNativeDec>) -> FiProgram;
@@ -168,13 +169,15 @@ embedd_lambda(names : FiGlobalNames, types : FiWasmTypeTable, natives: Tree<stri
 				process(e3), 
 				type, start
 			);
-		FiSwitch(x, switchType, cases, type, start): 
+		FiSwitch(x, switchType, cases0, type, start): {
+			cases = fiExpandSwitchCases(cases0);
 			FiSwitch(
-				x, 
-				switchType, 
+				x,
+				switchType,
 				map(cases, \c -> FiCase(c.struct, c.argNames, process(c.body), c.start)),
 				type, start
 			);
+		}
 		FiCast(ex, tFrom, tTo, type, start): 
 			FiCast(process(ex), tFrom, tTo, type, start);
 		FiSeq(es, type, start): 

--- a/tools/flowc/backends/wise/fiswitch2wise.flow
+++ b/tools/flowc/backends/wise/fiswitch2wise.flow
@@ -1,5 +1,6 @@
 import tools/flowc/backends/wise/fituple2wise;
 import tools/flowc/incremental/fiexp;
+import tools/flowc/incremental/fi_helpers;
 
 
 import tools/flowc/incremental/fiprettyprint;
@@ -14,7 +15,8 @@ fiSwitch2fiExp(e : FiSwitch, env : WiseAstStructs, tmpIndex : int, templates : T
 		default : [];
 	}
 
-	if (structIds == [] || e.cases == []) {
+	cases = fiExpandSwitchCases(e.cases);
+	if (structIds == [] || cases == []) {
 		println("ERROR : union structs are not found. [ " + toString(e) + " ]");
 		FiVoid(0);
 	} else {
@@ -28,7 +30,7 @@ fiSwitch2fiExp(e : FiSwitch, env : WiseAstStructs, tmpIndex : int, templates : T
 				FiTypeInt(),
 				0
 			),
-			fiCases2fiIfs(e.cases, FiVar(tmpVar, FiTypeInt(), 0), setTemplateInFiType(e.type, templates), env),
+			fiCases2fiIfs(cases, FiVar(tmpVar, FiTypeInt(), 0), setTemplateInFiType(e.type, templates), env),
 			e.type,
 			0
 		)], e.type, 0);
@@ -148,9 +150,12 @@ removeUnusedVars(expr : FiExp, ids : Set<string>) -> FiExp {
 			e2 = removeUnusedVars(e2, ids),
 			e3 = removeUnusedVars(e3, ids)
 		);
-		FiSwitch(x, __, cases, __, __): FiSwitch(expr with 
-			cases = map(cases, \c -> FiCase(c with body = removeUnusedVars(c.body, ids)))
-		);
+		FiSwitch(x, __, cases0, __, __): {
+			cases = fiExpandSwitchCases(cases0);
+			FiSwitch(expr with
+				cases = map(cases, \c -> FiCase(c with body = removeUnusedVars(c.body, ids)))
+			);
+		}
 		FiCast(e, __, __, __, __): FiCast(expr with e = removeUnusedVars(e, ids));
 		FiSeq(es, __, __): FiSeq(expr with es = map(es, \e -> removeUnusedVars(e, ids)));
 		FiCallPrim(__, es, __, __): FiCallPrim(expr with es = map(es, \e -> removeUnusedVars(e, ids)));

--- a/tools/flowc/backends/wise/flow_wise_closure.flow
+++ b/tools/flowc/backends/wise/flow_wise_closure.flow
@@ -1,6 +1,7 @@
 import tools/flowc/manipulation/lambda_lifting;
 import tools/flowc/backends/wise/fi2wise_utils;
 import tools/flowc/backends/wise/fituple2wise;
+import tools/flowc/incremental/fi_helpers;
 
 export {
 	// todo: add structures inside the module
@@ -407,13 +408,16 @@ addClosureToFnTypesInFiExp(
 			}
 		);
 		FiIf(e1, e2, e3, type, start): FiIf(rec(e1), rec(e2), rec(e3), fixType(type), start);
-		FiSwitch(x, switchType, cases, type, start): FiSwitch(
-			FiVar(x.name, fixType(x.type), x.start),
-			fixType(switchType),
-			map(cases, \c -> FiCase(c.struct, c.argNames, rec(c.body), c.start)),
-			fixType(type),
-			start
-		);
+		FiSwitch(x, switchType, cases0, type, start): {
+			cases = fiExpandSwitchCases(cases0);
+			FiSwitch(
+				FiVar(x.name, fixType(x.type), x.start),
+				fixType(switchType),
+				map(cases, \c -> FiCase(c.struct, c.argNames, rec(c.body), c.start)),
+				fixType(type),
+				start
+			);
+		}
 		FiCast(e1, tFrom, tTo, type, start): FiCast(rec(e1), fixType(tFrom), fixType(tTo), fixType(type), start);
 		FiSeq(es, type, start): FiSeq(map(es, rec), fixType(type), start);
 		FiCallPrim(op, es, type, start): {
@@ -517,7 +521,8 @@ wrapFnInStructResultForConstruction(
 			falseBranch = rec(e3);
 			FiIf(e1, trueBranch, falseBranch, extractFiTypeFromFiExp(falseBranch), start);
 		}
-		FiSwitch(__, __, cases, __, __): {
+		FiSwitch(__, __, cases0, __, __): {
+			cases = fiExpandSwitchCases(cases0);
 			if (cases == []) {
 				value
 			} else {

--- a/tools/flowc/callgraph.flow
+++ b/tools/flowc/callgraph.flow
@@ -1,4 +1,5 @@
 import tools/flowc/symbol_nature;
+import tools/flowc/incremental/fi_helpers;
 import formats/lsp;
 
 export {
@@ -514,7 +515,8 @@ fifreevarsOccursBoundFree(expr : FiExp, path : string, src : string, threadId : 
 		FiIf(e1, e2, e3, __, __): {
 			fold_freevars([e1, e2, e3], free);
 		}
-		FiSwitch(e, __, cs, __, __): {
+		FiSwitch(e, __, cs0, __, __): {
+			cs = fiExpandSwitchCases(cs0);
 			e_free = fifreevarsOccursBoundFree(e, path, src, threadId, bound, free);
 			fold(cs, e_free, \acc, c -> {
 				case_bound = fold(c.argNames, bound, \ac, arg_name -> if (arg_name == "__") ac else insertSet(ac, arg_name));

--- a/tools/flowc/completion.flow
+++ b/tools/flowc/completion.flow
@@ -240,12 +240,17 @@ fcDoLocalVars2types(ex : FiExp, env : FcTypeEnvGlobal, acc : Tree<string, Set<Fi
 		FiIf(e1, e2, e3, __,__):       rec(rec(rec(acc, e3), e2), e1);
 		FiSwitch(v, __, cs, __,__): {
 			fold(cs, rec(acc, v), \ac, c ->
-				switch (fcLookupNameInCache(env, c.struct)) {
-					Some(str): {
-						struct = cast(str.named : FiToplevel -> FiTypeStruct);
-						foldi(c.argNames, ac, \i, a, arg -> add_type(a, arg, struct.args[i].type))
+				switch (c) {
+					FiCase(struct, argNames, __, __): {
+						switch (fcLookupNameInCache(env, struct)) {
+							Some(str): {
+								s = cast(str.named : FiToplevel -> FiTypeStruct);
+								foldi(argNames, ac, \i, a, arg -> add_type(a, arg, s.args[i].type))
+							}
+							None(): ac;
+						}
 					}
-					None(): ac;
+					FiCaseUnion(__, __, __, __): ac;
 				}
 			);
 		}

--- a/tools/flowc/desugar.flow
+++ b/tools/flowc/desugar.flow
@@ -1150,8 +1150,14 @@ desugarFcExp(dacc : DesugarAcc, st : SyntaxTree) -> FcExp {
 									Some(uf): {
 									// Keep the union case as a single case instead of expanding to N struct cases.
 									// The body is desugared once with the variable typed as the union.
+									// Instantiate type parameters to fresh tyvars (same as struct cases do).
+									iuf0 = instantiateTypeTyPars(dacc.env.local, dacc.tyvarIdGroup, typars, uf);
+									iuf = switch (iuf0) {
+										FcTypeUnion(__, __, __, __): iuf0;
+										default: uf; // Should never happen
+									};
 									dacc2 = DesugarAcc(dacc with
-										switchVarTypes = setTree(dacc.switchVarTypes, varname, Pair(uf, uf))
+										switchVarTypes = setTree(dacc.switchVarTypes, varname, Pair(iuf, iuf))
 									);
 									body = desugarFcExp(dacc2, bexp);
 									[FcCase(struct, [], body, FcInfo(body.info.type, c.start, c.end))];

--- a/tools/flowc/desugar.flow
+++ b/tools/flowc/desugar.flow
@@ -1148,42 +1148,13 @@ desugarFcExp(dacc : DesugarAcc, st : SyntaxTree) -> FcExp {
 										x;
 									}
 									Some(uf): {
-										// First, expand "local" unions
-										unionstructs = uniq(expandDesugarUnion2structs(dacc, uf));
-
-										// Also see if there are any local union
-										filtermap(unionstructs, \ts : FcTypeStruct -> {
-											if (exists(cases, \cs -> {
-												// We want to skip those that already have a case
-													cstruct = if (cs.choice == 0) {
-														"default"
-													} else {
-														grabSTText(get_flow_id(cs), info.content);
-													}
-													ts.name == cstruct
-												})) None()
-											else {
-												// TODO: We do not handle unions inside unions.
-												structDef = lookupDesugarTypename(dacc, FcTypeName(ts.name, [], FcInfo2(c.start, c.end)));
-												switch (structDef) {
-													FcTypeStruct(__, __, sargs, __): {
-														dacc2 = DesugarAcc(dacc with
-															switchVarTypes = setTree(dacc.switchVarTypes, varname, Pair(structDef, uf))
-														);
-														body = desugarFcExp(dacc2, bexp);
-
-														// OK, construct dummy arguments for this dude
-														newCase = FcCase(ts.name, map(sargs, \__ -> "__"), body, FcInfo(body.info.type, c.start, c.end));
-														Some(newCase);
-													}
-													default: {
-														fcPrintln("TODO: Does not handle unknown types or unions", dacc.env.program.acc.config.threadId);
-														None();
-													}
-												}
-
-											}
-										});
+									// Keep the union case as a single case instead of expanding to N struct cases.
+									// The body is desugared once with the variable typed as the union.
+									dacc2 = DesugarAcc(dacc with
+										switchVarTypes = setTree(dacc.switchVarTypes, varname, Pair(uf, uf))
+									);
+									body = desugarFcExp(dacc2, bexp);
+									[FcCase(struct, [], body, FcInfo(body.info.type, c.start, c.end))];
 									}
 								}
 							}

--- a/tools/flowc/eval.flow
+++ b/tools/flowc/eval.flow
@@ -275,15 +275,27 @@ fcEval(ex : FiExp, env: FcEvalEnv, locals : HashMap<string, FcEvalLocal>) -> flo
 		FiSwitch(v,__,cs,__,pos): {
 			w = fcEval(v, env, locals);
 			name = fcEvalExtractStructName(w);
-			switch (find(cs, \c -> c.struct == name || c.struct == "default")) {
+			switch (find(cs, \c -> {
+				switch (c) {
+					FiCase(struct, __, __, __): struct == name || struct == "default";
+					FiCaseUnion(__, structs, __, __): contains(structs, name);
+				}
+			})) {
 				Some(case): {
 					args = fcEvalExtractStructArguments(w);
-					if (case.struct != "default") {
-						iteri(case.argNames, \i, arg ->
-							if (arg != "__") setHashMap(locals, arg, FcEvalLocal(args[i]))
-						);
+					switch (case) {
+						FiCase(struct, argNames, body, __): {
+							if (struct != "default") {
+								iteri(argNames, \i, arg ->
+									if (arg != "__") setHashMap(locals, arg, FcEvalLocal(args[i]))
+								);
+							}
+							fcEval(body, env, locals);
+						}
+						FiCaseUnion(__, __, body, __): {
+							fcEval(body, env, locals);
+						}
 					}
-					fcEval(case.body, env, locals);
 				}
 				None(): {
 					make_err("case " + name + " is not found in switch:\n" + prettyFiExp(dummyPretty, ex) +  "\nswitch value: " + toString(w), [pos]);

--- a/tools/flowc/find_occurrences.flow
+++ b/tools/flowc/find_occurrences.flow
@@ -193,9 +193,14 @@ start2vardecl(e : FiExp, name : string, acc : Tree<int, FiExpOrCase>) -> Tree<in
 		FiIf(e1, e2, e3, __, s):
 			start2vardecl(e1, name, start2vardecl(e2, name, start2vardecl(e3, name, acc)));
 		FiSwitch(v, __, cs, __, s):
-			fold(cs, acc, \a, c : FiCase -> {
-					rec = start2vardecl(c.body, name, a);
-					if (exists(c.argNames, \an -> an == name)) setTree(rec, c.start, c) else rec
+			fold(cs, acc, \a, c -> {
+					switch (c) {
+						FiCase(struct, argNames, body, cs_start): {
+							rec = start2vardecl(body, name, a);
+							if (exists(argNames, \an -> an == name)) setTree(rec, cs_start, c) else rec
+						}
+						FiCaseUnion(__, __, body, __): start2vardecl(body, name, a);
+					}
 				}
 			);
 		FiCast(e0, __, __, __, s): start2vardecl(e0, name, acc);
@@ -298,6 +303,7 @@ fiall2varNames(e : FiAll, acc : Set<string>) -> Set<string> {
 		FiIf(__, __, __, __, __):     acc;
 		FiSwitch(__, __, __, __, __): acc;
 		FiCase(__, args, __, __):     fold(args, acc, \ac, an -> insertSet(ac, an));
+		FiCaseUnion(__, __, __, __):  acc;
 		FiCast(__, __, __, __, __):   acc;
 		FiSeq(es, __, __):            acc;
 		FiCallPrim(op, es, __, __):   acc;
@@ -325,6 +331,7 @@ fiall2fieldNames(e : FiAll, struct : string, acc : Set<string>) -> Set<string> {
 		FiIf(__, __, __, __, __):     acc;
 		FiSwitch(__, __, __, __, __): acc;
 		FiCase(__, __, __, __):       acc;
+		FiCaseUnion(__, __, __, __):  acc;
 		FiCast(__, __, __, __, __):   acc;
 		FiSeq(es, __, __):            acc;
 		FiCallPrim(op, es, __, __):
@@ -362,6 +369,7 @@ fiall2typeNames(e : FiAll, acc : Set<string>) -> Set<string> {
 		FiIf(__, __, __, t, __):       fitype2names(t, acc);
 		FiSwitch(__, t1, __, t2, __):  fitype2names(t1, fitype2names(t2, acc));
 		FiCase(__, __, __, __):        acc;
+		FiCaseUnion(__, __, __, __):   acc;
 		FiCast(__, t1, t2, t3, __):    fitype2names(t1, fitype2names(t2, fitype2names(t3, acc)));
 		FiSeq(__, t, __):              fitype2names(t, acc);
 		FiCallPrim(op, __, t, __):

--- a/tools/flowc/flowc_find.flow
+++ b/tools/flowc/flowc_find.flow
@@ -165,10 +165,10 @@ findLocalNameSource(e : FiExp, name : string, maxPos : int, ignoreFields : bool)
 		FiIf(e1, e2, e3, __, __): checkMyStart(\ -> recAcc(recAcc(rec(e3, ignoreFields), e2), e1));
 		FiSwitch(v, __, cases, __, __): checkMyStart(\ -> {
 			foldri(cases, Pair(None(), ignoreFields), \idxCase, acc, case -> {
-				if (checkStart(case.start)) {
-					tryFn(recAcc(acc, case.body), \ignoreFields2 -> Pair(
+				if (checkStart(fiSwitchCaseStart(case))) {
+					tryFn(recAcc(acc, fiSwitchCaseBody(case)), \ignoreFields2 -> Pair(
 						maybeMap(
-							findi(case.argNames, eq(name)),
+							findi(fiSwitchCaseArgNames(case), eq(name)),
 							\idxArg -> LocalNameSourceSwitchCaseArg(e, idxCase, idxArg)
 						),
 						ignoreFields2
@@ -587,7 +587,7 @@ findNameTypeInFiExp(config : CompilerConfig, env : FcTypeEnvGlobal, module : FiM
 			switch (localDef) {
 				LocalNameSourceLambdaArg(lambda, idx): Some(lambda.args[idx].type);
 				LocalNameSourceSwitchCaseArg(sw, idxCase, idxArg): {
-					structName = sw.cases[idxCase].struct;
+					structName = fiSwitchCaseName(sw.cases[idxCase]);
 					notFound = \reason -> {
 						if (config.verbose > 0) {
 							fcPrintln(reason + "<br>", config.threadId);

--- a/tools/flowc/flowc_typeverify.flow
+++ b/tools/flowc/flowc_typeverify.flow
@@ -909,7 +909,12 @@ typeverifyFiSwitch(env : TypeVerifyLocalEnv, sw : FiSwitch, onError : (FcError) 
 			)
 		);
 	}
-	switchCaseTypes = fold(sw.cases, makeSet(), \caseTypes, c -> insertSet(caseTypes, c.struct));
+	switchCaseTypes = fold(sw.cases, makeSet(), \caseTypes, c -> {
+		switch (c) {
+			FiCase(struct, __, __, __): insertSet(caseTypes, struct);
+			FiCaseUnion(__, structs, __, __): fold(structs, caseTypes, \acc2, s -> insertSet(acc2, s));
+		}
+	});
 	switchTypeName = switch (sw.switchType) {
 		FiTypeFlow(): "";
 		FiTypeName(name, __): name;
@@ -955,43 +960,50 @@ typeverifyFiSwitch(env : TypeVerifyLocalEnv, sw : FiSwitch, onError : (FcError) 
 	typeverifyFiType(env, sw.switchType, onError, sw.start) && 
 	forall(sw.cases,
 		\c -> {
+			cName = fiSwitchCaseName(c);
+			cArgNames = fiSwitchCaseArgNames(c);
+			cBody = fiSwitchCaseBody(c);
+			cStart = fiSwitchCaseStart(c);
 			newEnv = TypeVerifyLocalEnv(
 				env.moduleEnv,
-				fold(c.argNames, env.varNames, \acc, argname -> insertSet(acc, argname))
+				fold(cArgNames, env.varNames, \acc, argname -> insertSet(acc, argname))
 			);
-			argsNumIsOk = (
-				c.struct == "default" ||
-				isSome(typeverifyName2Union(env, c.struct)) || // This exception is added because unions in switch cases always produce structs with no args
-				typeverifyNumberOfStructArgs(env, c.struct) == length(c.argNames)
-			);
+			argsNumIsOk = switch (c) {
+				FiCase(struct, argNames, __, __): {
+					struct == "default" ||
+					isSome(typeverifyName2Union(env, struct)) || // This exception is added because unions in switch cases always produce structs with no args
+					typeverifyNumberOfStructArgs(env, struct) == length(argNames)
+				}
+				FiCaseUnion(__, __, __, __): true; // Union cases don't bind args
+			};
 			if (!argsNumIsOk) {
-				struct_start = startOfStructOrUnion(typeverifyName2StructOrUnion(env, c.struct));
+				struct_start = startOfStructOrUnion(typeverifyName2StructOrUnion(env, cName));
 				onError(
 					FcError(
-						"Struct '" + c.struct + "' has wrong number of args: " + i2s(length(c.argNames)),
+						"Struct '" + cName + "' has wrong number of args: " + i2s(length(cArgNames)),
 						[
-							FcPosition(env.moduleEnv.module.fileinfo.flowfile, c.start, c.start),
-							FcPosition(moduleWhereNameIsDefined(env.moduleEnv.global.acc.names, c.struct), struct_start, struct_start)
+							FcPosition(env.moduleEnv.module.fileinfo.flowfile, cStart, cStart),
+							FcPosition(moduleWhereNameIsDefined(env.moduleEnv.global.acc.names, cName), struct_start, struct_start)
 						]
 					)
 				);
 			}
-			caseTypeIsOk = isFiSubType(env.moduleEnv.global.acc.names, fiExpType(c.body), sw.type, true, true);
+			caseTypeIsOk = isFiSubType(env.moduleEnv.global.acc.names, fiExpType(cBody), sw.type, true, true);
 			if (!caseTypeIsOk) {
-				struct_start = startOfStructOrUnion(typeverifyName2StructOrUnion(env, c.struct));
+				struct_start = startOfStructOrUnion(typeverifyName2StructOrUnion(env, cName));
 				onError(
 					FcError(
-						"Case '" + c.struct + "' type " + prettyFiType(dummyPretty, fiExpType(c.body), makeSet()) + 
+						"Case '" + cName + "' type " + prettyFiType(dummyPretty, fiExpType(cBody), makeSet()) +
 						" is not a subtype of a switch type " + prettyFiType(dummyPretty, sw.type, makeSet()),
 						[
-							FcPosition(env.moduleEnv.module.fileinfo.flowfile, c.start, c.start),
-							FcPosition(moduleWhereNameIsDefined(env.moduleEnv.global.acc.names, c.struct), struct_start, struct_start)
+							FcPosition(env.moduleEnv.module.fileinfo.flowfile, cStart, cStart),
+							FcPosition(moduleWhereNameIsDefined(env.moduleEnv.global.acc.names, cName), struct_start, struct_start)
 						]
 					)
 				);
 			}
 			argsNumIsOk && caseTypeIsOk &&
-			typeverifyFiExp(newEnv, c.body, onError)
+			typeverifyFiExp(newEnv, cBody, onError)
 		}
 	)
 }

--- a/tools/flowc/flowc_version.flow
+++ b/tools/flowc/flowc_version.flow
@@ -2,5 +2,5 @@
 // Edit 'build-flowc' instead.
 export {
 	flowc_version = "3.0";
-	flowc_git_revision = "46b9e8cfe5";
+	flowc_git_revision = "3d1fec3259";
 }

--- a/tools/flowc/flowc_version.flow
+++ b/tools/flowc/flowc_version.flow
@@ -2,5 +2,5 @@
 // Edit 'build-flowc' instead.
 export {
 	flowc_version = "3.0";
-	flowc_git_revision = "00c26f3";
+	flowc_git_revision = "46b9e8cfe5";
 }

--- a/tools/flowc/flowc_version.flow
+++ b/tools/flowc/flowc_version.flow
@@ -2,5 +2,5 @@
 // Edit 'build-flowc' instead.
 export {
 	flowc_version = "3.0";
-	flowc_git_revision = "8a057ba04";
+	flowc_git_revision = "d32716397f";
 }

--- a/tools/flowc/flowc_version.flow
+++ b/tools/flowc/flowc_version.flow
@@ -2,5 +2,5 @@
 // Edit 'build-flowc' instead.
 export {
 	flowc_version = "3.0";
-	flowc_git_revision = "3d1fec3259";
+	flowc_git_revision = "8a057ba04";
 }

--- a/tools/flowc/incremental.flow
+++ b/tools/flowc/incremental.flow
@@ -25,7 +25,7 @@ export {
 	mergeIncremental2TypeEnvProgram(env : FcTypeEnvProgram, globEnv : FcTypeEnvGlobal, module : FiModule) -> FcTypeEnvProgram;
 }
 
-incrementalVersion = 10;
+incrementalVersion = 11;
 IncrementalModule(version : int, module : FiModule);
 
 saveModuleInIncremental(config : CompilerConfig, module : FiModule, verbose : int, env : FcTypeEnvProgram) -> void {
@@ -107,7 +107,7 @@ preloadIncrementalModule(config : CompilerConfig, globEnv : FcTypeEnvGlobal, flo
 				// Compiler failed to read and interpret contents
 				// of incremental file for given flow file.
 				// It is not an error, we ignore incremental file
-				// and force compiler to reread and reparse flow file. 
+				// and force compiler to reread and reparse flow file.
 
 				fcPrintln("WARNING: Illegal structure of incremental file for " + flowfile + ". Incremental file deleted.", config.threadId);
 				deleteIncrementalModule(config, globEnv, flowfile);

--- a/tools/flowc/incremental/fc2fi.flow
+++ b/tools/flowc/incremental/fc2fi.flow
@@ -173,15 +173,36 @@ fcexp2fi(env : FcTypeEnvLocal, names : FcGlobalNames, onError : (string, FcInfo2
 		FcSeq(s, info): FiSeq(fcexps2fi(env, names, onError, s), mfctype2fi(env, onError, ^(info.type)), info.start);
 		FcCast(ex, tFrom, tTo, info): FiCast(fcexp2fi(env, names, onError, ex), fctype2fi(env, onError, tFrom), fctype2fi(env, onError, tTo), mfctype2fi(env, onError, ^(info.type)), info.start);
 		FcCall(f, args, info): FiCall(fcexp2fi(env, names, onError, f), fcexps2fi(env, names, onError, args), mfctype2fi(env, onError, ^(info.type)), info.start);
-		FcSwitch(x, switchType, cases, info): FiSwitch(fcvar2fi(env, onError, x), fctype2fi(env, onError, switchType), map(cases, \c -> {
-				if (c.struct == "default" || containsKeyTree(names.structs, c.struct)) {
-					FiCase(c.struct, c.argNames, fcexp2fi(env, names, onError, c.body), c.info.start)
-				} else {
-					// Union case: look up the union and expand to struct names
-					structs = fcUnion2structNames(names, c.struct);
-					FiCaseUnion(c.struct, structs, fcexp2fi(env, names, onError, c.body), c.info.start)
-				}
-			}), mfctype2fi(env, onError, ^(info.type)), info.start);
+		FcSwitch(x, switchType, cases, info): {
+			// Collect all explicit struct case names to subtract from union cases.
+			// A switch may have both a union case (e.g. CharacterStyle()) and explicit
+			// struct cases for members of that union (e.g. SetRTL(__)).
+			// The explicit struct cases take priority; union cases cover only the remaining structs.
+			explicitStructNames = buildSet(filtermap(cases, \c -> {
+				if (c.struct == "default" || !containsKeyTree(names.structs, c.struct)) None()
+				else Some(c.struct)
+			}));
+			FiSwitch(fcvar2fi(env, onError, x), fctype2fi(env, onError, switchType),
+				// Use fold to track claimed structs across union cases
+				fold(cases, Pair([], explicitStructNames), \acc : Pair<[FiSwitchCase], Set<string>>, c -> {
+					if (c.struct == "default" || containsKeyTree(names.structs, c.struct)) {
+						Pair(
+							arrayPush(acc.first, FiCase(c.struct, c.argNames, fcexp2fi(env, names, onError, c.body), c.info.start)),
+							acc.second
+						)
+					} else {
+						// Union case: expand to struct names, excluding already-claimed structs
+						allStructs = fcUnion2structNames(names, c.struct);
+						structs = filter(allStructs, \s -> !containsSet(acc.second, s));
+						claimed = fold(structs, acc.second, \s, name -> insertSet(s, name));
+						Pair(
+							arrayPush(acc.first, FiCaseUnion(c.struct, structs, fcexp2fi(env, names, onError, c.body), c.info.start)),
+							claimed
+						)
+					}
+				}).first,
+				mfctype2fi(env, onError, ^(info.type)), info.start);
+		}
 		FcLambda(args, body, info): fclambda2fi(env, names, onError, e);
 		FcLet(name, type, e1, e2, info): FiLet(name, fctype2fi(env, onError, type), fcexp2fi(env, names, onError, e1), fcexp2fi(env, names, onError, e2), mfctype2fi(env, onError, ^(info.type)), info.start);
 		FcIf(e1, e2, e3, info): FiIf(fcexp2fi(env, names, onError, e1), fcexp2fi(env, names, onError, e2), fcexp2fi(env, names, onError, e3), mfctype2fi(env, onError, ^(info.type)), info.start);

--- a/tools/flowc/incremental/fc2fi.flow
+++ b/tools/flowc/incremental/fc2fi.flow
@@ -182,26 +182,30 @@ fcexp2fi(env : FcTypeEnvLocal, names : FcGlobalNames, onError : (string, FcInfo2
 				if (c.struct == "default" || !containsKeyTree(names.structs, c.struct)) None()
 				else Some(c.struct)
 			}));
-			FiSwitch(fcvar2fi(env, onError, x), fctype2fi(env, onError, switchType),
-				// Use fold to track claimed structs across union cases
-				fold(cases, Pair([], explicitStructNames), \acc : Pair<[FiSwitchCase], Set<string>>, c -> {
-					if (c.struct == "default" || containsKeyTree(names.structs, c.struct)) {
-						Pair(
-							arrayPush(acc.first, FiCase(c.struct, c.argNames, fcexp2fi(env, names, onError, c.body), c.info.start)),
-							acc.second
-						)
-					} else {
-						// Union case: expand to struct names, excluding already-claimed structs
-						allStructs = fcUnion2structNames(names, c.struct);
-						structs = filter(allStructs, \s -> !containsSet(acc.second, s));
-						claimed = fold(structs, acc.second, \s, name -> insertSet(s, name));
-						Pair(
-							arrayPush(acc.first, FiCaseUnion(c.struct, structs, fcexp2fi(env, names, onError, c.body), c.info.start)),
-							claimed
-						)
-					}
-				}).first,
-				mfctype2fi(env, onError, ^(info.type)), info.start);
+			result = fold(cases, Pair(makeList(), explicitStructNames), \acc : Pair<List<FiSwitchCase>, Set<string>>, c -> {
+				if (c.struct == "default" || containsKeyTree(names.structs, c.struct)) {
+					Pair(
+						Cons(FiCase(c.struct, c.argNames, fcexp2fi(env, names, onError, c.body), c.info.start), acc.first),
+						acc.second
+					)
+				} else {
+					// Union case: expand to struct names, excluding already-claimed structs
+					allStructs = fcUnion2structNames(names, c.struct);
+					structs = set2array(differenceSets(allStructs, acc.second));
+					claimed = mergeSets(acc.second, allStructs);
+					Pair(
+						Cons(FiCaseUnion(c.struct, structs, fcexp2fi(env, names, onError, c.body), c.info.start), acc.first),
+						claimed
+					)
+				}
+			});
+			FiSwitch(
+				fcvar2fi(env, onError, x),
+				fctype2fi(env, onError, switchType),
+				list2array(result.first),
+				mfctype2fi(env, onError, ^(info.type)),
+				info.start
+			);
 		}
 		FcLambda(args, body, info): fclambda2fi(env, names, onError, e);
 		FcLet(name, type, e1, e2, info): FiLet(name, fctype2fi(env, onError, type), fcexp2fi(env, names, onError, e1), fcexp2fi(env, names, onError, e2), mfctype2fi(env, onError, ^(info.type)), info.start);
@@ -226,13 +230,13 @@ fcexp2fi(env : FcTypeEnvLocal, names : FcGlobalNames, onError : (string, FcInfo2
 }
 
 // Recursively expand a union name to all leaf struct names
-fcUnion2structNames(names : FcGlobalNames, unionName : string) -> [string] {
+fcUnion2structNames(names : FcGlobalNames, unionName : string) -> Set<string> {
 	switch (lookupTree(names.unions, unionName)) {
-		Some(union): concatA(map(union.typenames, \tn -> {
-			if (containsKeyTree(names.structs, tn.name)) [tn.name]
-			else fcUnion2structNames(names, tn.name)
-		}));
-		None(): [];
+		Some(union): fold(union.typenames, makeSet(), \acc, tn -> {
+			if (containsKeyTree(names.structs, tn.name)) insertSet(acc, tn.name)
+			else mergeSets(acc, fcUnion2structNames(names, tn.name))
+		});
+		None(): makeSet();
 	}
 }
 

--- a/tools/flowc/incremental/fc2fi.flow
+++ b/tools/flowc/incremental/fc2fi.flow
@@ -14,9 +14,9 @@ export {
 	fcmodule2fi(e : FcTypeEnv, m : FcModule) -> FiModule;
 
 	// Converts this module to an fimodule. Returns non-dummy FiModule even with errors, errors are handled with onError
-	fcmodule2fiWithErrorHandler(e : FcTypeEnvLocal, m : FcModule, onError : (string, FcInfo2) -> void) -> FiModule;
+	fcmodule2fiWithErrorHandler(e : FcTypeEnvLocal, names : FcGlobalNames, m : FcModule, onError : (string, FcInfo2) -> void) -> FiModule;
 
-    fctypestruct2fi(e : FcTypeEnvLocal, onError : (string, FcInfo2) -> void, f : FcTypeStruct) -> FiTypeStruct;
+	fctypestruct2fi(e : FcTypeEnvLocal, onError : (string, FcInfo2) -> void, f : FcTypeStruct) -> FiTypeStruct;
 
 	// If typenames is true, we prefer to use typenames, rather than unions or structs
 	fctype2fi(e : FcTypeEnvLocal, onError : (string, FcInfo2) -> void, t : FcType) -> FiType;
@@ -55,11 +55,11 @@ fctypeenv2fi(global : FcTypeEnvProgram) -> FiProgram {
 	)
 }
 
-fcdeclaration2fi(e : FcTypeEnvLocal, onError : (string, FcInfo2) -> void, d : FcDeclaration) -> FiDeclaration {
+fcdeclaration2fi(e : FcTypeEnvLocal, names : FcGlobalNames, onError : (string, FcInfo2) -> void, d : FcDeclaration) -> FiDeclaration {
 	switch (d) {
-		FcFunctionDec(__, __, __, __, __): fcfunctiondec2fi(e, onError, d);
-		FcGlobalVar(__, __, __, __): fcglobalvar2fi(e, onError, d);
-		FcNativeDec(__, __, __, __, __, __): fcnative2fi(e, onError, d);
+		FcFunctionDec(__, __, __, __, __): fcfunctiondec2fi(e, names, onError, d);
+		FcGlobalVar(__, __, __, __): fcglobalvar2fi(e, names, onError, d);
+		FcNativeDec(__, __, __, __, __, __): fcnative2fi(e, names, onError, d);
 	}
 }
 
@@ -80,7 +80,7 @@ fcmodule2fi(e : FcTypeEnv, m : FcModule) -> FiModule {
 		}
 	}
 
-	r = fcmodule2fiWithErrorHandler(e.local, m, onError);
+	r = fcmodule2fiWithErrorHandler(e.local, e.program.acc.names, m, onError);
 	if (typed && ^errors) {
 		fcPrintln("Could not type " + m.fileinfo.flowfile, e.program.acc.config.threadId);
 		FiModule(dummyFiModule with fileinfo = FiFileInfo(dummyFiFileInfo with flowfile = m.fileinfo.flowfile))
@@ -89,7 +89,7 @@ fcmodule2fi(e : FcTypeEnv, m : FcModule) -> FiModule {
 	}
 }
 
-fcmodule2fiWithErrorHandler(e : FcTypeEnvLocal, m : FcModule, onError : (string, FcInfo2) -> void) -> FiModule {
+fcmodule2fiWithErrorHandler(e : FcTypeEnvLocal, names : FcGlobalNames, m : FcModule, onError : (string, FcInfo2) -> void) -> FiModule {
 	// Order the global variables in the resulting FiModule by m.initOrder
 	ordered_vars = filter(m.initOrder, \name -> containsKeyTree(m.globalVars, name));
 	FiModule(
@@ -99,12 +99,12 @@ fcmodule2fiWithErrorHandler(e : FcTypeEnvLocal, m : FcModule, onError : (string,
 		set2array(m.exports),
 		map(getTreeValues(m.structs), \s -> fctypestruct2fi(e, onError, s)),
 		map(getTreeValues(m.unions), \u -> fctypeunion2fi(e, onError, u)),
-		map(getTreeValues(m.functions), \f -> fcfunctiondec2fi(e, onError, f)),
+		map(getTreeValues(m.functions), \f -> fcfunctiondec2fi(e, names, onError, f)),
 		map(ordered_vars, \v_name -> {
 			v = lookupTreeDef(m.globalVars, v_name, FcGlobalVar("", None(), dummyFcInfo, dummyFcInfo));
-			fcglobalvar2fi(e, onError, v)
+			fcglobalvar2fi(e, names, onError, v)
 		}),
-		map(getTreeValues(m.natives), \n -> fcnative2fi(e, onError, n)),
+		map(getTreeValues(m.natives), \n -> fcnative2fi(e, names, onError, n)),
 		m.initOrder,
 		m.stringIncludes,
 		m.start,
@@ -123,7 +123,7 @@ fcforbid2fi(f : FcForbid) -> FiForbid {
 }
 
 
-fcfunctiondec2fi(e : FcTypeEnvLocal, onError : (string, FcInfo2) -> void, f : FcFunctionDec) -> FiFunctionDec {
+fcfunctiondec2fi(e : FcTypeEnvLocal, names : FcGlobalNames, onError : (string, FcInfo2) -> void, f : FcFunctionDec) -> FiFunctionDec {
 	lambda = switch (f.lambda) {
 		None(): {
 			onError("Missing body for " + f.name, copyFcInfo2(f.declInfo));
@@ -140,10 +140,10 @@ fcfunctiondec2fi(e : FcTypeEnvLocal, onError : (string, FcInfo2) -> void, f : Fc
 		}
 	}
 
-	FiFunctionDec(f.name, fclambda2fi(e, onError, lambda), ftype, f.declInfo.start, f.defiInfo.start);
+	FiFunctionDec(f.name, fclambda2fi(e, names, onError, lambda), ftype, f.declInfo.start, f.defiInfo.start);
 }
 
-fcglobalvar2fi(e : FcTypeEnvLocal, onError : (string, FcInfo2) -> void, v : FcGlobalVar) -> FiGlobalVar {
+fcglobalvar2fi(e : FcTypeEnvLocal, names : FcGlobalNames, onError : (string, FcInfo2) -> void, v : FcGlobalVar) -> FiGlobalVar {
 	ex = switch (v.value) {
 		None(): {
 			onError("Missing value for global " + v.name, copyFcInfo2(v.bodyInfo));
@@ -151,37 +151,43 @@ fcglobalvar2fi(e : FcTypeEnvLocal, onError : (string, FcInfo2) -> void, v : FcGl
 		}
 		Some(vv): vv;
 	}
-	FiGlobalVar(v.name, fcexp2fi(e, onError, ex), mfctype2fi(e, onError, ^(v.bodyInfo.type)), v.declInfo.start, v.bodyInfo.start);
+	FiGlobalVar(v.name, fcexp2fi(e, names, onError, ex), mfctype2fi(e, onError, ^(v.bodyInfo.type)), v.declInfo.start, v.bodyInfo.start);
 }
 
-fcnative2fi(e : FcTypeEnvLocal, onError : (string, FcInfo2) -> void, n : FcNativeDec) -> FiNativeDec {
-	ifn = eitherMap(n.flowfallback, \fn -> fcfunctiondec2fi(e, onError, fn).lambda, FiVoid(0));
+fcnative2fi(e : FcTypeEnvLocal, names : FcGlobalNames, onError : (string, FcInfo2) -> void, n : FcNativeDec) -> FiNativeDec {
+	ifn = eitherMap(n.flowfallback, \fn -> fcfunctiondec2fi(e, names, onError, fn).lambda, FiVoid(0));
 	FiNativeDec(n.name, n.io, fctype2fi(e, onError, n.type), n.nativeName, ifn, n.info.start, eitherMap(n.flowfallback, \fn -> fn.defiInfo.start, -1));
 }
 
-fcexps2fi(env : FcTypeEnvLocal, onError : (string, FcInfo2) -> void, es : [FcExp]) -> [FiExp] {
-	map(es, \e -> fcexp2fi(env, onError, e));
+fcexps2fi(env : FcTypeEnvLocal, names : FcGlobalNames, onError : (string, FcInfo2) -> void, es : [FcExp]) -> [FiExp] {
+	map(es, \e -> fcexp2fi(env, names, onError, e));
 }
 
-fcexp2fi(env : FcTypeEnvLocal, onError : (string, FcInfo2) -> void, e : FcExp) -> FiExp {
+fcexp2fi(env : FcTypeEnvLocal, names : FcGlobalNames, onError : (string, FcInfo2) -> void, e : FcExp) -> FiExp {
 	switch (e) {
 		FcVoid(info): FiVoid(info.start);
 		FcBool(b, info): FiBool(b, info.start);
 		FcInt(i, info): FiInt(i, info.start);
 		FcDouble(d, info): FiDouble(d, info.start);
 		FcString(s, info): FiString(s, info.start);
-		FcSeq(s, info): FiSeq(fcexps2fi(env, onError, s), mfctype2fi(env, onError, ^(info.type)), info.start);
-		FcCast(ex, tFrom, tTo, info): FiCast(fcexp2fi(env, onError, ex), fctype2fi(env, onError, tFrom), fctype2fi(env, onError, tTo), mfctype2fi(env, onError, ^(info.type)), info.start);
-		FcCall(f, args, info): FiCall(fcexp2fi(env, onError, f), fcexps2fi(env, onError, args), mfctype2fi(env, onError, ^(info.type)), info.start);
+		FcSeq(s, info): FiSeq(fcexps2fi(env, names, onError, s), mfctype2fi(env, onError, ^(info.type)), info.start);
+		FcCast(ex, tFrom, tTo, info): FiCast(fcexp2fi(env, names, onError, ex), fctype2fi(env, onError, tFrom), fctype2fi(env, onError, tTo), mfctype2fi(env, onError, ^(info.type)), info.start);
+		FcCall(f, args, info): FiCall(fcexp2fi(env, names, onError, f), fcexps2fi(env, names, onError, args), mfctype2fi(env, onError, ^(info.type)), info.start);
 		FcSwitch(x, switchType, cases, info): FiSwitch(fcvar2fi(env, onError, x), fctype2fi(env, onError, switchType), map(cases, \c -> {
-				FiCase(c.struct, c.argNames, fcexp2fi(env, onError, c.body), c.info.start)
+				if (c.struct == "default" || containsKeyTree(names.structs, c.struct)) {
+					FiCase(c.struct, c.argNames, fcexp2fi(env, names, onError, c.body), c.info.start)
+				} else {
+					// Union case: look up the union and expand to struct names
+					structs = fcUnion2structNames(names, c.struct);
+					FiCaseUnion(c.struct, structs, fcexp2fi(env, names, onError, c.body), c.info.start)
+				}
 			}), mfctype2fi(env, onError, ^(info.type)), info.start);
-		FcLambda(args, body, info): fclambda2fi(env, onError, e);
-		FcLet(name, type, e1, e2, info): FiLet(name, fctype2fi(env, onError, type), fcexp2fi(env, onError, e1), fcexp2fi(env, onError, e2), mfctype2fi(env, onError, ^(info.type)), info.start);
-		FcIf(e1, e2, e3, info): FiIf(fcexp2fi(env, onError, e1), fcexp2fi(env, onError, e2), fcexp2fi(env, onError, e3), mfctype2fi(env, onError, ^(info.type)), info.start);
+		FcLambda(args, body, info): fclambda2fi(env, names, onError, e);
+		FcLet(name, type, e1, e2, info): FiLet(name, fctype2fi(env, onError, type), fcexp2fi(env, names, onError, e1), fcexp2fi(env, names, onError, e2), mfctype2fi(env, onError, ^(info.type)), info.start);
+		FcIf(e1, e2, e3, info): FiIf(fcexp2fi(env, names, onError, e1), fcexp2fi(env, names, onError, e2), fcexp2fi(env, names, onError, e3), mfctype2fi(env, onError, ^(info.type)), info.start);
 		FcCallPrim(op, es, info): {
 			if (op == FcQuote()) {
-				ies = fcexps2fi(env, onError, es);
+				ies = fcexps2fi(env, names, onError, es);
 				r = expandFiQuote(ies[0], info.start);
 
 				conf = FcPretty(false /* true */, true, makeTree(), makeTree());
@@ -189,12 +195,23 @@ fcexp2fi(env : FcTypeEnvLocal, onError : (string, FcInfo2) -> void, e : FcExp) -
 
 				r;
 			} else {
-				FiCallPrim(op, fcexps2fi(env, onError, es), mfctype2fi(env, onError, ^(info.type)), info.start);
+				FiCallPrim(op, fcexps2fi(env, names, onError, es), mfctype2fi(env, onError, ^(info.type)), info.start);
 			}
 		}
 		FcVar(__, __): fcvar2fi(env, onError, e);
-		FcRequire(flowfile, ex, info): FiRequire(flowfile, fcexp2fi(env, onError, ex), mfctype2fi(env, onError, ^(info.type)), info.start);
-		FcUnsafe(name, fallback, info): FiUnsafe(name, fcexp2fi(env, onError, fallback), mfctype2fi(env, onError, ^(info.type)), info.start);
+		FcRequire(flowfile, ex, info): FiRequire(flowfile, fcexp2fi(env, names, onError, ex), mfctype2fi(env, onError, ^(info.type)), info.start);
+		FcUnsafe(name, fallback, info): FiUnsafe(name, fcexp2fi(env, names, onError, fallback), mfctype2fi(env, onError, ^(info.type)), info.start);
+	}
+}
+
+// Recursively expand a union name to all leaf struct names
+fcUnion2structNames(names : FcGlobalNames, unionName : string) -> [string] {
+	switch (lookupTree(names.unions, unionName)) {
+		Some(union): concatA(map(union.typenames, \tn -> {
+			if (containsKeyTree(names.structs, tn.name)) [tn.name]
+			else fcUnion2structNames(names, tn.name)
+		}));
+		None(): [];
 	}
 }
 
@@ -202,7 +219,7 @@ fcvar2fi(e : FcTypeEnvLocal, onError : (string, FcInfo2) -> void, v : FcVar) -> 
 	FiVar(v.name, mfctype2fi(e, onError, ^(v.info.type)), v.info.start);
 }
 
-fclambda2fi(e : FcTypeEnvLocal, onError : (string, FcInfo2) -> void, lambda : FcLambda) -> FiLambda {
+fclambda2fi(e : FcTypeEnvLocal, names : FcGlobalNames, onError : (string, FcInfo2) -> void, lambda : FcLambda) -> FiLambda {
 	type = mfctype2fi(e, onError, ^(lambda.info.type));
 	ftype = switch (type) {
 		FiTypeFunction(__, __): type;
@@ -211,7 +228,7 @@ fclambda2fi(e : FcTypeEnvLocal, onError : (string, FcInfo2) -> void, lambda : Fc
 			FiTypeFunction([], type);
 		}
 	}
-	FiLambda(map(lambda.args, \a -> FiFunArg(a.name, fctype2fi(e, onError, a.type))), fcexp2fi(e, onError, lambda.body), ftype, lambda.info.start);
+	FiLambda(map(lambda.args, \a -> FiFunArg(a.name, fctype2fi(e, onError, a.type))), fcexp2fi(e, names, onError, lambda.body), ftype, lambda.info.start);
 }
 
 fctypes2fi(e : FcTypeEnvLocal, onError : (string, FcInfo2) -> void, types : [FcType]) -> [FiType] {

--- a/tools/flowc/incremental/fi2fc.flow
+++ b/tools/flowc/incremental/fi2fc.flow
@@ -103,7 +103,10 @@ fiexp2fc(e : FiExp) -> FcExp {
 		FiCast(ex, tFrom, tTo, info, start): FcCast(fiexp2fc(ex), fitype2fc(tFrom), fitype2fc(tTo), fi2fcinfo(tTo, start));
 		FiCall(f, args, type, start): FcCall(fiexp2fc(f), fiexps2fc(args), fi2fcinfo(type, start));
 		FiSwitch(x, switchType, cases, type, start): FcSwitch(fivar2fc(x), fitype2fc(switchType), map(cases, \c -> {
-				FcCase(c.struct, c.argNames, fiexp2fc(c.body), fi2fcinfo(type, c.start))
+				switch (c) {
+					FiCase(struct, argNames, body, cstart): FcCase(struct, argNames, fiexp2fc(body), fi2fcinfo(type, cstart));
+					FiCaseUnion(union, __, body, cstart): FcCase(union, [], fiexp2fc(body), fi2fcinfo(type, cstart));
+				}
 			}), fi2fcinfo(type, start));
 		FiLambda(args, body, type, start): filambda2fc(e);
 		FiLet(name, stype, e1, e2, type, start): FcLet(name, fitype2fc(stype), fiexp2fc(e1), fiexp2fc(e2), fi2fcinfo(type, start));

--- a/tools/flowc/incremental/fi_helpers.flow
+++ b/tools/flowc/incremental/fi_helpers.flow
@@ -159,6 +159,36 @@ export {
 
 	// Split a full native name into a native host and native name: Native.fold to Pair("Native", "fold")
 	fiSplitNativeName(nname: string) -> Pair<string, string>;
+
+	// FiSwitchCase helpers — use these to handle both FiCase and FiCaseUnion uniformly
+
+	// Get the body of a switch case
+	fiSwitchCaseBody(c : FiSwitchCase) -> FiExp;
+
+	// Get the start position of a switch case
+	fiSwitchCaseStart(c : FiSwitchCase) -> int;
+
+	// Get the case name (struct name or union name)
+	fiSwitchCaseName(c : FiSwitchCase) -> string;
+
+	// Get the list of struct names this case covers
+	// For FiCase: [struct] (single element). For FiCaseUnion: structs field.
+	// For "default": []
+	fiSwitchCaseStructs(c : FiSwitchCase) -> [string];
+
+	// Is this a default case?
+	fiSwitchCaseIsDefault(c : FiSwitchCase) -> bool;
+
+	// Get argNames (empty for FiCaseUnion and default)
+	fiSwitchCaseArgNames(c : FiSwitchCase) -> [string];
+
+	// Transform the body of a switch case, preserving case type
+	fiMapSwitchCaseBody(c : FiSwitchCase, fn : (FiExp) -> FiExp) -> FiSwitchCase;
+
+	// Expand FiSwitchCase list: FiCase passes through, FiCaseUnion expands to
+	// one FiCase per struct (all with empty argNames and the shared body).
+	// Useful for backends that need struct-level dispatch.
+	fiExpandSwitchCases(cases : [FiSwitchCase]) -> [FiCase];
 }
 
 fiDeclarationArgNames(decl) {
@@ -393,9 +423,9 @@ isSameFiExp(e1 : FiExp, e2 : FiExp) -> bool {
 					&& length(cs1) == length(cs2)
 					&& foldi(cs1, true,
 						\i, acc, c1 ->
-							acc && c1.struct == cs2[i].struct
-							&& c1.argNames == cs2[i].argNames
-							&& isSameFiExp(c1.body, cs2[i].body)
+							acc && fiSwitchCaseName(c1) == fiSwitchCaseName(cs2[i])
+							&& fiSwitchCaseArgNames(c1) == fiSwitchCaseArgNames(cs2[i])
+							&& isSameFiExp(fiSwitchCaseBody(c1), fiSwitchCaseBody(cs2[i]))
 					)
 				}
 				default: false;
@@ -802,7 +832,7 @@ fiRenameVar(e : FiExp, var: string, new: string) -> FiExp {
 		FiSwitch(v, __,cases,__, __): {
 			FiSwitch(e with
 				x = if (v.name != var) v else FiVar(v with name = new),
-				cases = map(cases, \c -> FiCase(c with body = ren(c.body)))
+				cases = map(cases, \c -> fiMapSwitchCaseBody(c, ren))
 			);
 		}
 		FiCast(ex, __, __, __, __): {
@@ -855,7 +885,7 @@ fiReplaceVar(e : FiExp, var: string, new: FiExp) -> FiExp {
 			);
 		}
 		FiSwitch(v, __,cases,__, __): {
-			sw1 = FiSwitch(e with cases = map(cases, \c -> FiCase(c with body = ren(c.body))));
+			sw1 = FiSwitch(e with cases = map(cases, \c -> fiMapSwitchCaseBody(c, ren)));
 			switch (new) {
 				FiVar(__, new_t,__): if (v.name != var) sw1 else {
 					FiSwitch(sw1 with
@@ -1268,3 +1298,66 @@ fiSplitNativeName(nname: string) -> Pair<string, string> {
 	native_name = parts[1];
 	Pair(native_host, native_name);
 }
+
+// FiSwitchCase helpers
+
+fiSwitchCaseBody(c : FiSwitchCase) -> FiExp {
+	switch (c) {
+		FiCase(__, __, body, __): body;
+		FiCaseUnion(__, __, body, __): body;
+	}
+}
+
+fiSwitchCaseStart(c : FiSwitchCase) -> int {
+	switch (c) {
+		FiCase(__, __, __, start): start;
+		FiCaseUnion(__, __, __, start): start;
+	}
+}
+
+fiSwitchCaseName(c : FiSwitchCase) -> string {
+	switch (c) {
+		FiCase(struct, __, __, __): struct;
+		FiCaseUnion(union, __, __, __): union;
+	}
+}
+
+fiSwitchCaseStructs(c : FiSwitchCase) -> [string] {
+	switch (c) {
+		FiCase(struct, __, __, __): if (struct == "default") [] else [struct];
+		FiCaseUnion(__, structs, __, __): structs;
+	}
+}
+
+fiSwitchCaseIsDefault(c : FiSwitchCase) -> bool {
+	switch (c) {
+		FiCase(struct, __, __, __): struct == "default";
+		FiCaseUnion(__, __, __, __): false;
+	}
+}
+
+fiSwitchCaseArgNames(c : FiSwitchCase) -> [string] {
+	switch (c) {
+		FiCase(__, argNames, __, __): argNames;
+		FiCaseUnion(__, __, __, __): [];
+	}
+}
+
+fiMapSwitchCaseBody(c : FiSwitchCase, fn : (FiExp) -> FiExp) -> FiSwitchCase {
+	switch (c) {
+		FiCase(struct, argNames, body, start): FiCase(struct, argNames, fn(body), start);
+		FiCaseUnion(union, structs, body, start): FiCaseUnion(union, structs, fn(body), start);
+	}
+}
+
+fiExpandSwitchCases(cases : [FiSwitchCase]) -> [FiCase] {
+	concatA(map(cases, \c -> {
+		switch (c) {
+			FiCase(__, __, __, __): [c];
+			FiCaseUnion(__, structs, body, start): {
+				map(structs, \s -> FiCase(s, [], body, start));
+			}
+		}
+	}))
+}
+

--- a/tools/flowc/incremental/fiexp.flow
+++ b/tools/flowc/incremental/fiexp.flow
@@ -10,9 +10,13 @@ export {
 		FiVar(name: string, type : FiType, start : int);
 		FiLet(name: string, type : FiType, e1: FiExp, e2: FiExp, type2 : FiType, start : int);
 		FiIf(e1: FiExp, e2: FiExp, e3: FiExp, type : FiType, start : int);
-		FiSwitch(x: FiVar, switchType : FiType, cases: [FiCase], type : FiType, start : int);
+		FiSwitch(x: FiVar, switchType : FiType, cases: [FiSwitchCase], type : FiType, start : int);
+
+		FiSwitchCase ::= FiCase, FiCaseUnion;
 			// struct is "default" for default case
 			FiCase(struct: string, argNames : [string], body: FiExp, start : int);
+			// Union case: covers multiple structs, body uses union-typed variable
+			FiCaseUnion(union: string, structs: [string], body: FiExp, start : int);
 		FiCast(e: FiExp, tFrom : FiType, tTo : FiType, type : FiType, start : int);
 		FiSeq(es: [FiExp], type : FiType, start : int);
 		FiCallPrim(op: FcPrim, es: [FiExp], type : FiType, start : int);

--- a/tools/flowc/manipulation/auto_smart_cast.flow
+++ b/tools/flowc/manipulation/auto_smart_cast.flow
@@ -22,9 +22,9 @@ recurseTypeErasure(ex : FiExp) -> FiExp {
 		FiCall(f, args, type, start): 
             FiCall(recurseTypeErasure(f), map(args, recurseTypeErasure), type, start);
 		FiSwitch(x, switchType, cases, type, start): 
-            FiSwitch(x, switchType, map(cases, 
-                \c -> FiCase(c.struct, c.argNames, recurseTypeErasure(c.body), c.start)),
-                type, start);
+			FiSwitch(x, switchType, map(cases, 
+				\c -> fiMapSwitchCaseBody(c, recurseTypeErasure)),
+				type, start);
 		FiLambda(args, body, type, start): 
             FiLambda(args, recurseTypeErasure(body), type, start);
 		FiLet(name, type, e1, e2, type2, start): 

--- a/tools/flowc/manipulation/common.flow
+++ b/tools/flowc/manipulation/common.flow
@@ -1,5 +1,6 @@
 import tools/flowc/fcexp;
 import tools/flowc/incremental/fiprettyprint;
+import tools/flowc/incremental/fi_helpers;
 
 export {
 	mapFcExp(expr : FcExp, fn : (FcExp) -> FcExp) -> FcExp;
@@ -76,6 +77,17 @@ export {
 	fiIterExp(e: FiExp, fn: (FiExp, FiExpTraverseEnv) -> void) -> void;
 
 	fiAddModule2GlobalNames(module: FiModule, names: FiGlobalNames) -> FiGlobalNames;
+
+	// Checks whether a variable name appears free (not shadowed) in an FiExp.
+	// Accounts for shadowing by lambdas, lets, switch argNames, and inner switches
+	// on the same variable (which rebind it in case bodies).
+	fiExpReferencesVar(exp : FiExp, name : string) -> bool;
+
+	// Replaces the type of all free occurrences of a variable in an FiExp tree.
+	// Respects shadowing: lambdas, lets, and switch case argNames that rebind the
+	// variable prevent recursion into their bodies. Inner switches on the same
+	// variable rebind it, so their case bodies are not generalized.
+	generalizeVarType(exp : FiExp, varName : string, newType : FiType) -> FiExp;
 }
 
 mapFcExp(expr : FcExp, fn : (FcExp) -> FcExp) -> FcExp {
@@ -219,8 +231,8 @@ mapFiExp(expr : FiExp, fn : (FiExp) -> FiExp) -> FiExp {
 			}
 		}
 		FiSwitch(v, typ, cs, type, start): {
-			mapped_cs = map(cs, \c -> FiCase(c.struct, c.argNames, mapFiExp(c.body, fn), c.start));
-			if (forall(zipWith(cs, mapped_cs, \c1, c2 -> Pair(c1.body, c2.body)), \p -> isSameObj(p.first, p.second))) {
+			mapped_cs = map(cs, \c -> fiMapSwitchCaseBody(c, \b -> mapFiExp(b, fn)));
+			if (forall(zipWith(cs, mapped_cs, \c1, c2 -> Pair(fiSwitchCaseBody(c1), fiSwitchCaseBody(c2))), \p -> isSameObj(p.first, p.second))) {
 				expr
 			} else {
 				FiSwitch(v, typ, mapped_cs, type, start)
@@ -590,8 +602,8 @@ fiMapExpArgs(e: FiExp, env: FiExpTraverseEnv, fn: (FiExp, FiExpTraverseEnv) -> F
 			x_mapped = fiDoMapExp(x, set_parent(unset_returns(env), 0), fn, argsFirst);
 			switch (x_mapped) {
 				FiVar(__,__,__): {
-					cases_mapped = mapi(cs, \i, c -> FiCase(c with body = fiDoMapExp(c.body, set_parent(env, i + 1), fn, argsFirst)));
-					if (isSameObj(x_mapped, x) && all(mapi(cases_mapped, \i, c_mapped -> isSameObj(c_mapped.body, cs[i].body)))) e else
+					cases_mapped = mapi(cs, \i, c -> fiMapSwitchCaseBody(c, \b -> fiDoMapExp(b, set_parent(env, i + 1), fn, argsFirst)));
+					if (isSameObj(x_mapped, x) && all(mapi(cases_mapped, \i, c_mapped -> isSameObj(fiSwitchCaseBody(c_mapped), fiSwitchCaseBody(cs[i]))))) e else
 					FiSwitch(e with x = x_mapped, cases = cases_mapped);
 				}
 				default: fail0("During switch mapping of expression expected a var in switch, got:\n" + prettyFiExp(dummyPretty, x_mapped));
@@ -742,10 +754,10 @@ fiFoldMapExpArgs(e: FiExp, env: FiExpTraverseEnv, acc: ?, fn: (FiExp, FiExpTrave
 				switch (x_mapped) {
 					FiVar(__,__,__): {
 						p_cs = foldi(cs, Pair([], p_x.second), \i, p_acc, c -> {
-							p_c = fiDoFoldMapExp(c.body, set_parent(env, i + 1), p_acc.second, fn, order);
-							Pair(concat(p_acc.first, [FiCase(c with body = p_c.first)]), p_c.second);
+							p_c = fiDoFoldMapExp(fiSwitchCaseBody(c), set_parent(env, i + 1), p_acc.second, fn, order);
+							Pair(concat(p_acc.first, [fiMapSwitchCaseBody(c, \__ -> p_c.first)]), p_c.second);
 						});
-						e_mapped = if (isSameObj(x_mapped, x) && all(mapi(p_cs.first, \i, c_mapped -> isSameObj(c_mapped.body, cs[i].body)))) e else
+						e_mapped = if (isSameObj(x_mapped, x) && all(mapi(p_cs.first, \i, c_mapped -> isSameObj(fiSwitchCaseBody(c_mapped), fiSwitchCaseBody(cs[i]))))) e else
 						FiSwitch(e with x = x_mapped, cases = p_cs.first);
 						Pair(e_mapped, p_cs.second);
 					}
@@ -753,14 +765,14 @@ fiFoldMapExpArgs(e: FiExp, env: FiExpTraverseEnv, acc: ?, fn: (FiExp, FiExpTrave
 				}
 			} else {
 				p_cs = foldri(cs, Pair([], acc), \i, p_acc, c -> {
-					p_c = fiDoFoldMapExp(c.body, set_parent(env, i + 1), p_acc.second, fn, order);
-					Pair(concat(p_acc.first, [FiCase(c with body = p_c.first)]), p_c.second);
+					p_c = fiDoFoldMapExp(fiSwitchCaseBody(c), set_parent(env, i + 1), p_acc.second, fn, order);
+					Pair(concat(p_acc.first, [fiMapSwitchCaseBody(c, \__ -> p_c.first)]), p_c.second);
 				});
 				p_x = fiDoFoldMapExp(x, set_parent(unset_returns(env), 0), p_cs.second, fn, order);
 				x_mapped = p_x.first;
 				switch (x_mapped) {
 					FiVar(__,__,__): {
-						e_mapped = if (isSameObj(x_mapped, x) && all(mapi(p_cs.first, \i, c_mapped -> isSameObj(c_mapped.body, cs[i].body)))) e else
+						e_mapped = if (isSameObj(x_mapped, x) && all(mapi(p_cs.first, \i, c_mapped -> isSameObj(fiSwitchCaseBody(c_mapped), fiSwitchCaseBody(cs[i]))))) e else
 						FiSwitch(e with x = x_mapped, cases = p_cs.first);
 						Pair(e_mapped, p_x.second);
 					}
@@ -1115,3 +1127,76 @@ fiDoIterExp(e: FiExp, env: FiExpTraverseEnv, fn: (FiExp, FiExpTraverseEnv) -> vo
 	}
 	fn(e, env);
 }
+
+fiExpReferencesVar(exp : FiExp, name : string) -> bool {
+	switch (exp) {
+		FiVoid(__): false;
+		FiBool(__, __): false;
+		FiInt(__, __): false;
+		FiDouble(__, __): false;
+		FiString(__, __): false;
+		FiVar(n, __, __): n == name;
+		FiCall(f, es, __, __):
+			fiExpReferencesVar(f, name) || exists(es, \e -> fiExpReferencesVar(e, name));
+		FiLambda(args, body, __, __):
+			!exists(args, \a -> a.name == name) && fiExpReferencesVar(body, name);
+		FiLet(x, __, e1, e2, __, __):
+			fiExpReferencesVar(e1, name) || (x != name && fiExpReferencesVar(e2, name));
+		FiIf(c, t, e, __, __):
+			fiExpReferencesVar(c, name) || fiExpReferencesVar(t, name) || fiExpReferencesVar(e, name);
+		FiSwitch(x, __, cases, __, __):
+			fiExpReferencesVar(x, name)
+			|| (x.name != name && exists(cases, \c ->
+				!exists(fiSwitchCaseArgNames(c), \a -> a == name) && fiExpReferencesVar(fiSwitchCaseBody(c), name)
+			));
+		FiCast(e, __, __, __, __): fiExpReferencesVar(e, name);
+		FiSeq(es, __, __): exists(es, \e -> fiExpReferencesVar(e, name));
+		FiCallPrim(__, es, __, __): exists(es, \e -> fiExpReferencesVar(e, name));
+		FiRequire(__, e, __, __): fiExpReferencesVar(e, name);
+		FiUnsafe(__, e, __, __): fiExpReferencesVar(e, name);
+	}
+}
+
+generalizeVarType(exp : FiExp, varName : string, newType : FiType) -> FiExp {
+	if (!fiExpReferencesVar(exp, varName)) exp
+	else switch (exp) {
+		FiVar(n, __, s): if (n == varName) FiVar(n, newType, s) else exp;
+		FiCall(f, es, t, s): FiCall(
+			generalizeVarType(f, varName, newType),
+			map(es, \e -> generalizeVarType(e, varName, newType)),
+			t, s
+		);
+		FiLambda(args, body, t, s):
+			if (exists(args, \a -> a.name == varName)) exp
+			else FiLambda(args, generalizeVarType(body, varName, newType), t, s);
+		FiLet(x, xt, e1, e2, t, s): FiLet(
+			x, xt,
+			generalizeVarType(e1, varName, newType),
+			if (x == varName) e2 else generalizeVarType(e2, varName, newType),
+			t, s
+		);
+		FiIf(c, th, el, t, s): FiIf(
+			generalizeVarType(c, varName, newType),
+			generalizeVarType(th, varName, newType),
+			generalizeVarType(el, varName, newType),
+			t, s
+		);
+		FiSwitch(x, st, cases, t, s): FiSwitch(
+			FiVar(x.name, if (x.name == varName) newType else x.type, x.start),
+			st,
+			if (x.name == varName) cases
+			else map(cases, \c ->
+				if (exists(fiSwitchCaseArgNames(c), \a -> a == varName)) c
+				else fiMapSwitchCaseBody(c, \b -> generalizeVarType(b, varName, newType))
+			),
+			t, s
+		);
+		FiCast(e, ft, tt, t, s): FiCast(generalizeVarType(e, varName, newType), ft, tt, t, s);
+		FiSeq(es, t, s): FiSeq(map(es, \e -> generalizeVarType(e, varName, newType)), t, s);
+		FiCallPrim(op, es, t, s): FiCallPrim(op, map(es, \e -> generalizeVarType(e, varName, newType)), t, s);
+		FiRequire(flowfile, e, t, s): FiRequire(flowfile, generalizeVarType(e, varName, newType), t, s);
+		FiUnsafe(nm, e, t, s): FiUnsafe(nm, generalizeVarType(e, varName, newType), t, s);
+		default: exp;
+	}
+}
+

--- a/tools/flowc/manipulation/cse.flow
+++ b/tools/flowc/manipulation/cse.flow
@@ -361,9 +361,9 @@ replaceCSEFiExps(acc : CSEAcc, e : FiExp) -> FiExp {
 			}
 			FiSwitch(x, st, cs, ty, s):  {
 				rcs = map(cs, \c -> {
-					rc = replaceCSEFiExps(acc, c.body);
-					if (rc != c.body) {
-						FiCase(c.struct, c.argNames, rc, c.start)
+					rc = replaceCSEFiExps(acc, fiSwitchCaseBody(c));
+					if (rc != fiSwitchCaseBody(c)) {
+						fiMapSwitchCaseBody(c, \__ -> rc)
 					} else c;
 				});
 				if (rcs != cs) {

--- a/tools/flowc/manipulation/cse_global.flow
+++ b/tools/flowc/manipulation/cse_global.flow
@@ -383,9 +383,9 @@ csegReplaceFiExps(acc : CSEGAcc, e : FiExp) -> FiExp {
 			}
 			FiSwitch(x, st, cs, ty, s):  {
 				rcs = map(cs, \c -> {
-					rc = csegReplaceFiExps(acc, c.body);
-					if (rc != c.body) {
-						FiCase(c.struct, c.argNames, rc, c.start)
+					rc = csegReplaceFiExps(acc, fiSwitchCaseBody(c));
+					if (rc != fiSwitchCaseBody(c)) {
+						fiMapSwitchCaseBody(c, \__ -> rc)
 					} else c;
 				});
 				if (rcs != cs) {

--- a/tools/flowc/manipulation/effects.flow
+++ b/tools/flowc/manipulation/effects.flow
@@ -136,7 +136,8 @@ hasFiSideEffects(effects : FiEffects, expr : FiExp) -> bool {
 			);
 			hasFiSideEffects(lambda_es, b);
 		}
-		FiSwitch(__,__, cases, __, __): {
+		FiSwitch(__,__, cases0, __, __): {
+			cases = fiExpandSwitchCases(cases0);
 			exists(cases, \c -> {
 				// Add all variables from case to effect-free
 				case_es = fold(c.argNames, effects, \acc, x ->
@@ -319,7 +320,8 @@ checkHasFiSideEffects(effects : FiEffects, expr : FiExp) -> Maybe<bool> {
 			);
 			checkHasFiSideEffects(lambda_es, b);
 		}
-		FiSwitch(__,__, cases, __, __): {
+		FiSwitch(__,__, cases0, __, __): {
+			cases = fiExpandSwitchCases(cases0);
 			fold(cases, Some(false), \acc, c -> {
 				// Add all variables from case to effect-free
 				case_es = fold(c.argNames, effects, \ac, x ->

--- a/tools/flowc/manipulation/explicit_casts.flow
+++ b/tools/flowc/manipulation/explicit_casts.flow
@@ -116,7 +116,7 @@ expandFlowCastsExp(expr : FiExp) {
 			FiIf(expandFlowCastsExp(e1), injectFlowCast(type, e2), injectFlowCast(type, e3), type, start);
 		FiSwitch(e0, typ, cs, type, start): 
 			FiSwitch(e0, typ, 
-				map(cs, \c -> FiCase(c.struct, c.argNames, injectFlowCast(type, c.body), c.start)),
+				map(cs, \c -> fiMapSwitchCaseBody(c, \b -> injectFlowCast(type, b))),
 				type, start);
 		FiCast(e0, tFrom, tTo, type, start): FiCast(injectFlowCast(tFrom, e0), tFrom, tTo, type, start);
 		FiSeq(es, type, start): 

--- a/tools/flowc/manipulation/find_unused.flow
+++ b/tools/flowc/manipulation/find_unused.flow
@@ -1,4 +1,5 @@
 import tools/flowc/incremental/fiprogram;
+import tools/flowc/incremental/fi_helpers;
 import tools/flowc/manipulation/freevars;
 import ds/treeutils;
 // This import is used for FcError and FcPosition
@@ -56,8 +57,9 @@ findUnusedLocalsExp(expr : FiExp, bound : Set<string>, flowfile : string, argume
 			}
 		}
 		FiIf(e1, e2, e3, __, __): { rec(e1); rec(e2); rec(e3); }
-		FiSwitch(e, __, cs, __, __): {
+		FiSwitch(e, __, cs0, __, __): {
 			rec(e);
+			cs = fiExpandSwitchCases(cs0);
 			iter(cs, \c -> findUnusedLocalsExp(c.body, mergeSets(bound, buildSet(c.argNames)), flowfile, arguments, onError));
 		}
 		FiCast(e, __, __, __, __):    rec(e);
@@ -101,8 +103,9 @@ findUnusedLocalsExpSet(expr : FiExp, bound : Set<string>, arguments : bool, acc 
 				}
 		}
 		FiIf(e1, e2, e3, __, __): { r0 = rec(acc, e1); r1 = rec(r0, e2); rec(r1, e3); }
-		FiSwitch(e, __, cs, __, __): {
+		FiSwitch(e, __, cs0, __, __): {
 			r0 = rec(acc, e);
+			cs = fiExpandSwitchCases(cs0);
 			fold(cs, r0, \acc1, c -> findUnusedLocalsExpSet(c.body, mergeSets(bound, buildSet(c.argNames)), arguments, acc));
 		}
 		FiCast(e, __, __, __, __):  rec(acc, e);

--- a/tools/flowc/manipulation/freevars.flow
+++ b/tools/flowc/manipulation/freevars.flow
@@ -59,8 +59,9 @@ fifreetypesFree(expr : FiExp, ofree : Set<string>) -> Set<string> {
 		FiSwitch(e, t, cs, __, __):  {
 			nfree = extractTypeNames(free, t);
 			fold(cs, fifreetypesFree(e, nfree), \acc, c -> {
-				if (c.struct == "default") fifreetypesFree(c.body, acc)
-				else fifreetypesFree(c.body, insertSet(acc, c.struct))
+				cname = fiSwitchCaseName(c);
+				if (cname == "default") fifreetypesFree(fiSwitchCaseBody(c), acc)
+				else fifreetypesFree(fiSwitchCaseBody(c), insertSet(acc, cname))
 			});
 		}
 		FiCast(e, f, t, __, __):    {

--- a/tools/flowc/manipulation/inline_functions.flow
+++ b/tools/flowc/manipulation/inline_functions.flow
@@ -31,7 +31,7 @@ doInlineVars(ex : FiExp, varmap : ref Tree<string, string>) -> FiExp {
 		FiCall(f, args, type, start): FiCall(process(f), map(args, process), type, start);
 		FiSwitch(__, __, __, __, __): 
 			FiSwitch(ex with cases = 
-				map(ex.cases, \c -> FiCase(c with body = process(c.body))));
+				map(ex.cases, \c -> fiMapSwitchCaseBody(c, process)));
 		FiLambda(args, body, type, start):
 			FiLambda(args, process(body), type, start); 
 		FiLet(name, type, e1, e2, type2, start): {
@@ -124,7 +124,7 @@ doInlineFunctions(ex : FiExp, inlines : [Triple<string, string, FiDeclaration>])
 		}
 		FiSwitch(__, __, __, __, __): 
 			FiSwitch(ex with cases = 
-				map(ex.cases, \c -> FiCase(c with body = process(c.body))));
+				map(ex.cases, \c -> fiMapSwitchCaseBody(c, process)));
 		FiLambda(args, body, type, start):
 			FiLambda(args, process(body), type, start); 
 		FiLet(name, type, e1, e2, type2, start): 

--- a/tools/flowc/manipulation/lambda_lifting.flow
+++ b/tools/flowc/manipulation/lambda_lifting.flow
@@ -144,8 +144,8 @@ lift_lambdas_exp(context : LLContext, sc : Maybe<LexicalScope>, ex : FiExp, expT
 			FiCall(process(f), newArgs, type, start);
 		}
 		FiSwitch(__, __, __, __, __): 
-            FiSwitch(ex with cases = 
-                map(ex.cases, \c -> FiCase(c with body = process(c.body))));
+			FiSwitch(ex with cases = 
+				map(ex.cases, \c -> fiMapSwitchCaseBody(c, \b -> process(b))));
 		FiLambda(args, body, type, start): 
 			lift_lambda(context, sc, ex, expType);
 		FiLet(name, type, e1, e2, type2, start): 

--- a/tools/flowc/manipulation/lint.flow
+++ b/tools/flowc/manipulation/lint.flow
@@ -263,7 +263,7 @@ lintExp(env : LintEnv, expr : FiExp, onErr : (string, int) -> void) -> void {
 
 			if (0 < missing && missing < 3) {
 				missingCases = fold(structs, [], \acc : [string], s : FiTypeName -> {
-					if (exists(cs, \c -> c.struct == s.name)) {
+					if (exists(cs, \c -> fiSwitchCaseName(c) == s.name)) {
 						acc
 					} else {
 						arrayPush(acc, s.name);

--- a/tools/flowc/manipulation/livestructs.flow
+++ b/tools/flowc/manipulation/livestructs.flow
@@ -1,4 +1,5 @@
 import tools/flowc/incremental/fiprogram;
+import tools/flowc/incremental/fi_helpers;
 import ds/set;
 
 export {
@@ -34,7 +35,7 @@ livestructsFiExp(expr : FiExp, live : Set<string>, covered : Set<string>) -> Set
 			fold(
 				cs,
 				livestructsFiExp(e, live, covered), 
-				\acc, c -> livestructsFiExp(c.body, acc, insertSet(covered, c.struct))
+				\acc, c -> livestructsFiExp(fiSwitchCaseBody(c), acc, fold(fiSwitchCaseStructs(c), covered, \cv, s -> insertSet(cv, s)))
 			);
 		FiCast(e, __, __, __, __):     livestructsFiExp(e, live, covered);
 		FiSeq(es, __, __):             foldlivestructsFiExp(es, live, covered);

--- a/tools/flowc/manipulation/mangle.flow
+++ b/tools/flowc/manipulation/mangle.flow
@@ -372,7 +372,8 @@ instantiateFiExpTypars(f : FiExp, typars : Tree<string, FiType>, polymorphic : T
 				start
 			);
 		}
-		FiSwitch(x, switchType, cases, type, start):  {
+		FiSwitch(x, switchType, cases0, type, start):  {
+			cases = fiExpandSwitchCases(cases0);
 			FiSwitch(
 				instantiateFiVarTypars(x, typars, polymorphic, bound, mangle, jsmangling),
 				instantiateFiTypeTypars(polymorphic, switchType, typars, mangle, jsmangling),

--- a/tools/flowc/manipulation/optimizer.flow
+++ b/tools/flowc/manipulation/optimizer.flow
@@ -7,6 +7,7 @@ import tools/flowc/incremental/fi2fc;
 import tools/flowc/incremental/fiprettyprint;
 import tools/flowc/manipulation/common;
 import tools/flowc/manipulation/effects;
+import tools/flowc/incremental/fi_helpers;
 import tools/flowc/manipulation/dupstrings;
 import tools/flowc/manipulation/livestructs;
 import tools/flowc/manipulation/dump;
@@ -322,30 +323,29 @@ optimizeIf(e1 : FiExp, e2 : FiExp, e3 : FiExp, type : FiType, s : int, envExp : 
 	}
 }
 
-optimizeSwitch(v : FiVar, typ : FiType, cs : [FiCase], type : FiType, s : int, envExp : OptEnvExp) -> FiSwitch {
+optimizeSwitch(v : FiVar, typ : FiType, cs0 : [FiSwitchCase], type : FiType, s : int, envExp : OptEnvExp) -> FiSwitch {
+	cs = fiExpandSwitchCases(cs0);
 	live_cs = if (envExp.env.doLiveStructs) filter(cs, \c -> {
 		containsSet(envExp.livestructs, c.struct) || c.struct == "default";
 	}) else cs;
 	// TODO: If the value of v is given in the environment, we could simplify this
-	FiSwitch(v, typ,
-		map(live_cs,
-			\c -> {
-				opt_body = optimizeExp(c.body,
-					addLocals(envExp,
-						pairs2tree(map(c.argNames,
-							\arg -> {
-								e : FiExp = FiVar(arg, FiTypeVoid(), -1);
-								Pair(arg, e)
-							})
-						)
+	opt_cs : [FiSwitchCase] = map(live_cs,
+		\c -> {
+			opt_body = optimizeExp(c.body,
+				addLocals(envExp,
+					pairs2tree(map(c.argNames,
+						\arg -> {
+							e : FiExp = FiVar(arg, FiTypeVoid(), -1);
+							Pair(arg, e)
+						})
 					)
-				);
-				opt_args = map(c.argNames, \var -> if (fiVarIsUsed(var, opt_body)) var else "__");
-				FiCase(c.struct, opt_args, opt_body, c.start)
-			}
-		),
-		type, s
+				)
+			);
+			opt_args = map(c.argNames, \var -> if (fiVarIsUsed(var, opt_body)) var else "__");
+			FiCase(c.struct, opt_args, opt_body, c.start)
+		}
 	);
+	FiSwitch(v, typ, opt_cs, type, s);
 }
 
 optimizeVar(x : string, envExp : OptEnvExp, def_val : FiExp) -> FiExp {
@@ -942,7 +942,7 @@ instantiateTyPars2Exp(expr : FiExp, sub : Tree<string, FiType>) -> FiExp {
 				FiVar(e.name, applyTypeSubstitution2Type(e.type, sub), e.start),
 				applyTypeSubstitution2Type(st, sub),
 				map(cs, \c -> 
-					FiCase(c.struct, c.argNames, instantiateTyPars2Exp(c.body, sub), c.start)
+					fiMapSwitchCaseBody(c, \b -> instantiateTyPars2Exp(b, sub))
 				),
 				applyTypeSubstitution2Type(t, sub), s
 			);
@@ -1202,16 +1202,16 @@ makeSwitchVarsSafeForSubstitution(expr : FiExp, vars : Set<string>) -> FiExp {
 			vars_with_v = mergeSets(vars, makeSet1(v.name));
 			safe_cs = map(cs, 
 				\c -> {
-					vars_with_cs = mergeSets(vars_with_v, fold(c.argNames, makeSet(), \acc, a -> mergeSets(acc, makeSet1(a))));
-					safe_c_body = makeSwitchVarsSafeForSubstitution(c.body, vars_with_cs);
-					if (isSameObj(c.body, safe_c_body)) {
+					vars_with_cs = mergeSets(vars_with_v, fold(fiSwitchCaseArgNames(c), makeSet(), \acc, a -> mergeSets(acc, makeSet1(a))));
+					safe_c_body = makeSwitchVarsSafeForSubstitution(fiSwitchCaseBody(c), vars_with_cs);
+					if (isSameObj(fiSwitchCaseBody(c), safe_c_body)) {
 						c
 					} else {
-						FiCase(c.struct, c.argNames, safe_c_body, c.start)
+						fiMapSwitchCaseBody(c, \__ -> safe_c_body)
 					}
 				}
 			);
-			safe_switch : FiSwitch = if (forall(zipWith(cs, safe_cs, \c1, c2 -> Pair(c1.body, c2.body)), \p -> isSameObj(p.first, p.second))) {
+			safe_switch : FiSwitch = if (forall(zipWith(cs, safe_cs, \c1, c2 -> Pair(fiSwitchCaseBody(c1), fiSwitchCaseBody(c2))), \p -> isSameObj(p.first, p.second))) {
 				expr
 			} else {
 				FiSwitch(v, typ, safe_cs, type, start)
@@ -1225,14 +1225,14 @@ makeSwitchVarsSafeForSubstitution(expr : FiExp, vars : Set<string>) -> FiExp {
 					FiSwitch(
 						FiVar(tmp_var, type, 0), typ,
 						map(safe_switch.cases, 
-							\c -> FiCase(c.struct, c.argNames, mapFiExp(c.body, 
+							\c -> fiMapSwitchCaseBody(c, \b -> mapFiExp(b,
 								\e -> {
 									switch (e) {
 										FiVar(x, t, s): if (x == v.name) FiVar(tmp_var, t, s) else e;
 										default: e;
 									}
 								}
-							), c.start)
+							))
 						), 
 						type, start
 					), 

--- a/tools/flowc/manipulation/pull_statements.flow
+++ b/tools/flowc/manipulation/pull_statements.flow
@@ -45,7 +45,7 @@ fiPullStatementUpStage1(x: FiExp, cnt: ref int) -> FiExp {
 		}
 		FiSwitch(v, switchType, cases, type, start): {
 			FiSwitch(x with cases = map(cases, \c ->
-				FiCase(c with body = fiPullStatementUpStage1(c.body, cnt))
+				fiMapSwitchCaseBody(c, \b -> fiPullStatementUpStage1(b, cnt))
 			));
 		}
 		FiSeq(es, type, start): {
@@ -168,7 +168,7 @@ fiPullStatementUpStage2(x: FiExp) -> FiExp {
 		}
 		FiSwitch(v, switchType, cases, type, start): {
 			FiSwitch(x with cases = map(cases, \c ->
-				FiCase(c with body = fiPullStatementUpStage2(c.body))
+				fiMapSwitchCaseBody(c, fiPullStatementUpStage2)
 			));
 		}
 		FiSeq(es, type, start): {

--- a/tools/flowc/manipulation/pull_statements2.flow
+++ b/tools/flowc/manipulation/pull_statements2.flow
@@ -96,8 +96,8 @@ fiExp2FiStat(e : FiExp, returns: FiReturnPolicy, locals: Set<string>, tmp: ref i
 		FiSwitch(v, vtype, cs, type, __): {
 			FiSwitch(e with
 				cases = map(cs, \c -> {
-					case_locals = fold(c.argNames, locals, \acc, arg -> if (arg == "__") acc else insertSet(acc, arg));
-					FiCase(c with body = fiExp2FiStat(c.body, returns, case_locals, tmp))
+					case_locals = fold(fiSwitchCaseArgNames(c), locals, \acc, arg -> if (arg == "__") acc else insertSet(acc, arg));
+					fiMapSwitchCaseBody(c, \b -> fiExp2FiStat(b, returns, case_locals, tmp))
 				})
 			);
 		}
@@ -191,9 +191,8 @@ fiExp2FiExp(e : FiExp, locals: Set<string>, tmp: ref int) -> Pair<FiExp, [FiExp]
 		FiSwitch(v, vtype, cases, type, start): {
 			default_switch_stat = \returnPolicy -> {
 				cases_stats = map(cases, \c -> {
-					case_locals = fold(c.argNames, locals, \acc, arg -> if (arg == "__") acc else insertSet(acc, arg));
-					case_stat = fiExp2FiStat(c.body, returnPolicy, case_locals, tmp);
-					FiCase(c.struct, c.argNames, case_stat, c.start);
+					case_locals = fold(fiSwitchCaseArgNames(c), locals, \acc, arg -> if (arg == "__") acc else insertSet(acc, arg));
+					fiMapSwitchCaseBody(c, \b -> fiExp2FiStat(b, returnPolicy, case_locals, tmp))
 				});
 				FiSwitch(e with cases = cases_stats);
 			}

--- a/tools/flowc/manipulation/specialization.flow
+++ b/tools/flowc/manipulation/specialization.flow
@@ -119,7 +119,8 @@ find_free_vars_with_types_multiple(expr : FiExp, bound : Set<string>, free : Tre
 				polymorphics),
 			polymorphics);
 		FiIf(e1, e2, e3, type, __):     fold_freevars([e1, e2, e3], bound, addTypeRef(free, type));
-		FiSwitch(e, type, cs, __, __):  {
+		FiSwitch(e, type, cs0, __, __):  {
+			cs = fiExpandSwitchCases(cs0);
 			typars = getTypars(type); // 1. get type parameters from the switch variable type
 			// 2. apply all of those to each of the struct options
 			freeWithCases = fold(cs, free, \f, c -> addTypeRef(f, FiTypeName(c.struct, typars)));

--- a/tools/flowc/manipulation/specialization_js.flow
+++ b/tools/flowc/manipulation/specialization_js.flow
@@ -113,7 +113,8 @@ find_free_vars_with_types_multiple_js(expr : FiExp, bound : Set<string>, free : 
 				polymorphics),
 			polymorphics);
 		FiIf(e1, e2, e3, type, __):     fold_freevars([e1, e2, e3], bound, addTypeRef(free, type));
-		FiSwitch(e, type, cs, __, __):  {
+		FiSwitch(e, type, cs0, __, __):  {
+			cs = fiExpandSwitchCases(cs0);
 			typars = getTypars(type); // 1. get type parameters from the switch variable type
 			// 2. apply all of those to each of the struct options
 			freeWithCases = fold(cs, free, \f, c -> addTypeRef(f, FiTypeName(c.struct, typars)));

--- a/tools/flowc/manipulation/split_expressions.flow
+++ b/tools/flowc/manipulation/split_expressions.flow
@@ -104,7 +104,7 @@ splitExpressionsRec(ex : FiExp, typeFilter : (FiType) -> bool, scopeType : FiTyp
 					splitExpressions(e3, typeFilter), type, start)));
 		FiSwitch(x, switchType, cases, type, start): 
 			 makeWrapper(FiSwitch(x, switchType, 
-				map(cases, \c -> FiCase(c.struct, c.argNames, splitExpressions(c.body, typeFilter), c.start)),
+				map(cases, \c -> fiMapSwitchCaseBody(c, \b -> splitExpressions(b, typeFilter))),
 				type, start));
 		FiCast(e, tFrom, tTo, type, start): 
 			expandExpression(e, typeFilter, scopeType, \v -> makeWrapper(FiCast(v, tFrom, tTo, type, start)));

--- a/tools/flowc/manipulation/tail_call.flow
+++ b/tools/flowc/manipulation/tail_call.flow
@@ -1,4 +1,5 @@
 import tools/flowc/incremental/fiprogram;
+import tools/flowc/incremental/fi_helpers;
 
 export {
     fcOptimizeTailCalls(prog : FiProgram) -> FiProgram;
@@ -208,7 +209,7 @@ fcConvertReturnExps(e : FiExp, args : [FiFunArg], ret_type : FiType, tail_func :
 		}
 		FiSwitch(__,__,cs,__,__): {
 			FiSwitch(e with
-				cases = map(cs, \c -> FiCase(c with body = fcConvertReturnExps(c.body, args, ret_type, tail_func))),
+				cases = map(cs, \c -> fiMapSwitchCaseBody(c, \b -> fcConvertReturnExps(b, args, ret_type, tail_func))),
 				type = FiTypeBool()
 			);
 		}

--- a/tools/flowc/manipulation/transform_exps.flow
+++ b/tools/flowc/manipulation/transform_exps.flow
@@ -285,7 +285,8 @@ fiRemoveUnusedVars(e : FiExp, effects : FiEffects) -> FiExp {
 fiExplicitCastInSwitch(e : FiExp, names: FiGlobalNames) -> FiExp {
 	fiMapExp(e, \x,__ -> 
 		switch (x) {
-			FiSwitch(var, vtype, cases, type, start): {
+			FiSwitch(var, vtype, cases0, type, start): {
+				cases : [FiCase] = fiExpandSwitchCases(cases0);
 				do_switch = \case_resolver -> {
 					FiSwitch(x with
 						cases = map(cases, \c -> {
@@ -618,7 +619,7 @@ fiDoExpMakeVarsUnique(e: FiExp, counter: Tree<string, int>, rename: Tree<string,
 		FiSwitch(v, vtype, cases,__,__): {
 			FiSwitch(e with 
 				x = FiVar(v with name = lookupTreeDef(rename, v.name, v.name)),
-				cases = map(cases, \c -> FiCase(c with body = do(c.body)))
+				cases = map(cases, \c -> fiMapSwitchCaseBody(c, do))
 			);
 		}
 		FiIf(e1, e2, e3, __,__): { 
@@ -738,7 +739,7 @@ fiExpMakeCastsExplicit(x: FiExp, t: FiType, names: FiGlobalNames) -> FiExp {
 		}
 		FiSwitch(v, v_type, cases, type,__): {
 			x1 = FiSwitch(x with
-				cases = map(cases, \c -> FiCase(c with body = fiExpMakeCastsExplicit(c.body, t, names))),
+				cases = map(cases, \c -> fiMapSwitchCaseBody(c, \b -> fiExpMakeCastsExplicit(b, t, names))),
 				type = t
 			);
 			make_cast(x1, fiExpType(x1), t);
@@ -1244,7 +1245,7 @@ fiDoExpReturnVars(e: FiExp, returns: bool) -> FiExp {
 		}
 		FiSwitch(v, __,cases,__, __): {
 			FiSwitch(e with 
-				cases = map(cases, \c -> FiCase(c with body = fiDoExpReturnVars(c.body, returns)))
+				cases = map(cases, \c -> fiMapSwitchCaseBody(c, \b -> fiDoExpReturnVars(b, returns)))
 			);
 		}
 		FiCast(ex, __, __, __, __): {
@@ -1481,7 +1482,7 @@ fiDoPushExpsDown(i: int, xs: [FiExp], as: [FiExp], fn: ([FiExp]) -> FiExp, type:
 				FiSwitch(x with
 					type = type,
 					cases = map(cs, \c -> 
-						FiCase(c with body = fiDoPushExpsDown(i + 1, xs, concat(as, [c.body]), fn, type))
+						fiMapSwitchCaseBody(c, \b -> fiDoPushExpsDown(i + 1, xs, concat(as, [b]), fn, type))
 					)
 				);
 			}
@@ -1516,7 +1517,7 @@ fiPushExpDown(x: FiExp) -> FiExp {
 						}
 						FiSwitch(x1, swtype1, cs1, type1, start1): {
 							FiSwitch(x1, swtype1, map(cs1, \c1 ->
-									FiCase(c1 with body = fiPushExpDown(FiLet(v, vtype, c1.body, e2, type, start)))
+									fiMapSwitchCaseBody(c1, \b -> fiPushExpDown(FiLet(v, vtype, b, e2, type, start)))
 								), 
 								type, start1
 							);
@@ -1553,7 +1554,7 @@ fiPushExpDown(x: FiExp) -> FiExp {
 						}
 						FiSwitch(x1, swtype1, cs1, type1, start1): {
 							FiSwitch(x1, swtype1, map(cs1, \c1 ->
-									FiCase(c1 with body = fiPushExpDown(FiIf(c1.body, e2, e3, type, start)))
+									fiMapSwitchCaseBody(c1, \b -> fiPushExpDown(FiIf(b, e2, e3, type, start)))
 								), 
 								type, start1
 							);
@@ -1608,7 +1609,8 @@ fiPushExpsDown(e: FiExp) -> FiExp {
 // In case a switch has only one variant - remove it
 fiExpShortcutTrivialSwitch(x: FiExp, names: FiGlobalNames) -> FiExp {
 	mapFiExp(x, \e -> switch (e) {
-		FiSwitch(v, vtype, cs, type, start): {
+		FiSwitch(v, vtype, cs0, type, start): {
+			cs : [FiCase] = fiExpandSwitchCases(cs0);
 			switch (vtype) {
 				FiTypeName(typename,__): {
 					if (containsKeyTree(names.unions, typename)) {
@@ -2037,7 +2039,7 @@ fiDoWrapGlobalFuncInLambdas(names : FiGlobalNames, ex : FiExp, isArg : bool) -> 
 			FiCall(process(f), map(args, \a -> processA(a)), type, start);
 		FiSwitch(__, __, __, __, __): 
 			FiSwitch(ex with cases = 
-				map(ex.cases, \c -> FiCase(c with body = processA(c.body))));
+				map(ex.cases, \c -> fiMapSwitchCaseBody(c, processA)));
 		FiLambda(args, body, type, start):
 			FiLambda(args, processA(body), type, start); 
 		FiLet(name, type, e1, e2, type2, start): 
@@ -2202,7 +2204,7 @@ fiCorrectCastCaseVarType(e: FiExp, sw: Tree<string, Pair<string, FiType>>) -> Fi
 		}
 		FiSwitch(x, typ, cs, __, __): {
 			FiSwitch(e with 
-				cases = map(cs, \c -> FiCase(c with body = fiCorrectCastCaseVarType(c.body, sw)))
+				cases = map(cs, \c -> fiMapSwitchCaseBody(c, \b -> fiCorrectCastCaseVarType(b, sw)))
 			);
 		}
 		FiCast(e0, tFrom, tTo, __, __): {

--- a/tools/flowc/manipulation/transform_programs.flow
+++ b/tools/flowc/manipulation/transform_programs.flow
@@ -358,7 +358,7 @@ fiRemoveImplicitStructTyparsFromFiExp(
 		FiSwitch(v, vtype, cases, type, start): {
 			FiSwitch(
 				FiVar(v.name, rt(v.type), v.start), rt(vtype), 
-				map(cases, \c -> FiCase(c with body = re(c.body))), 
+				map(cases, \c -> fiMapSwitchCaseBody(c, \b -> re(b))), 
 				rt(type), start
 			);
 		}
@@ -408,7 +408,7 @@ fiSetImplicitStructTyparsFromFiExp(e : FiExp, typars: Set<string>, implicit: FiT
 		FiSwitch(v, vtype, cases, type, start): {
 			FiSwitch(
 				FiVar(v.name, rt(v.type), v.start), rt(vtype), 
-				map(cases, \c -> FiCase(c with body = re(c.body))), 
+				map(cases, \c -> fiMapSwitchCaseBody(c, \b -> re(b))), 
 				rt(type), start
 			);
 		}
@@ -1177,7 +1177,7 @@ fiRemoveStructsFromExp(x: FiExp, structs: Tree<string, FiTypeStruct>) -> FiExp {
 			FiSwitch(x with
 				x = FiVar(v with type = do_t(v.type)),
 				switchType = do_t(sw_type),
-				cases = map(cs, \c -> FiCase(c with body = do_e(c.body))),
+				cases = map(cs, \c -> fiMapSwitchCaseBody(c, \b -> do_e(b))),
 				type = do_t(type)
 			);
 		}

--- a/tools/flowc/manipulation/wrap_funcs_as_args.flow
+++ b/tools/flowc/manipulation/wrap_funcs_as_args.flow
@@ -43,7 +43,7 @@ doWrapFuncArgs(names : FiGlobalNames, ex : FiExp, isArg : bool) -> FiExp {
 			FiCall(process(f), map(args, \a -> processA(a)), type, start);
 		FiSwitch(__, __, __, __, __): 
 			FiSwitch(ex with cases = 
-				map(ex.cases, \c -> FiCase(c with body = processA(c.body))));
+				map(ex.cases, \c -> fiMapSwitchCaseBody(c, \b -> processA(b))));
 		FiLambda(args, body, type, start):
 			FiLambda(args, process(body), type, start); 
 		FiLet(name, type, e1, e2, type2, start): 

--- a/tools/flowc/statements/fi2fs.flow
+++ b/tools/flowc/statements/fi2fs.flow
@@ -1,6 +1,7 @@
 import tools/flowc/statements/fs_helpers;
 import tools/flowc/manipulation/freevars;
 import tools/flowc/manipulation/transform_exps;
+import tools/flowc/incremental/fi_helpers;
 
 export {
 	// The variable pair second bool component tells, if a var was initialized, or is uninitialized (dangling pointer)
@@ -23,9 +24,10 @@ fiExp2FsStat2(e : FiExp, names: FiGlobalNames, returns: bool, locals: Tree<strin
 				}
 			);
 		}
-		FiSwitch(v, vtype, cs, type, start): {
+		FiSwitch(v, vtype, cs0, type, start): {
+			cs = fiExpandSwitchCases(cs0);
 			FsSwitch(
-				fiVar2FsVarUse(FsVar(v.name, v.type), names, locals), 
+				fiVar2FsVarUse(FsVar(v.name, v.type), names, locals),
 				switch (vtype) {
 					FiTypeName(__,__): vtype;
 					default: FiTypeName("", []);

--- a/tools/flowc/symbol_nature.flow
+++ b/tools/flowc/symbol_nature.flow
@@ -24,7 +24,7 @@ export {
 		FcLocalScope();
 
 	// Unions, which hold all possible syntax structures of flow program
-	FiExpOrCase ::= FiExp, FiCase;
+	FiExpOrCase ::= FiExp, FiCase, FiCaseUnion;
 	FiAll ::= FiExpOrCase, FiDeclaration, FiStructOrUnion;
 
 	// The components of bool pair in return:
@@ -85,7 +85,7 @@ fastSymbolNature(config : CompilerConfig, globEnv : FcTypeEnvGlobal, name : stri
 			None();
 		} else {
 			fcModule = parseAndDesugarFile(config, globEnv, config.flowfile);
-			fiModule = fcmodule2fiWithErrorHandler(initFcTypeEnvLocal(), fcModule, nop2);
+			fiModule = fcmodule2fiWithErrorHandler(initFcTypeEnvLocal(), dummyFcGlobalNames, fcModule, nop2);
 			switch (fastGuessSymbolFieldOrVar(globEnv, config, fiModule, name, line, col)) {
 				Some(kind) : {
 					scope : FcSymbolScope = switch (kind) {
@@ -387,6 +387,7 @@ start2fiall(fiany : FiAll, acc : Tree<int, Set<FiAll>>) -> Tree<int, Set<FiAll>>
 		FiIf(e1, e2, e3, __, s):      start2fiall(e1, start2fiall(e2, start2fiall(e3, add_any(acc, s))));
 		FiSwitch(v, __, cs, __, s):   start2fiall(v, fold(cs, add_any(acc, s), \a, c -> start2fiall(c, a)));
 		FiCase(__, __, body, s):      start2fiall(body, add_any(acc, s));
+		FiCaseUnion(__, __, body, s): start2fiall(body, add_any(acc, s));
 		FiCast(e0, __, __, __, s):    start2fiall(e0, add_any(acc, s));
 		FiSeq(es, __, s):             fold(es, add_any(acc, s), \a, ex -> start2fiall(ex, a));
 		FiCallPrim(__, es, __, s):    fold(es, add_any(acc, s), \a, ex -> start2fiall(ex, a));
@@ -423,6 +424,7 @@ fiExpOrCaseChildren(ex : FiExpOrCase) -> [FiExpOrCase] {
 		FiIf(e1, e2, e3, __, __): [e1, e2, e3];
 		FiSwitch(e, __, cs, __, __): concat([e], cs);
 		FiCase(__, __, e, __): [e];
+		FiCaseUnion(__, __, e, __): [e];
 		FiCast(e, __, __, __, __): [e];
 		FiSeq(es, __, __): es;
 		FiCallPrim(__, es, __, __): es;
@@ -445,6 +447,7 @@ fiExpOrCaseTypes(ex : FiExpOrCase) -> [FiType] {
 		FiIf(___, __, __, t, __): [t];
 		FiSwitch(__, t1, __, t2, __): [t1, t2];
 		FiCase(s,__, e,__): [FiTypeName(s, [])];
+		FiCaseUnion(u, __, e, __): [FiTypeName(u, [])];
 		FiCast(__, t1, t2, t3, __): [t1, t2, t3];
 		FiSeq(__, t, __): [t];
 		FiCallPrim(__, __, t, __): [t];

--- a/tools/flowc/typechecker/combine_types.flow
+++ b/tools/flowc/typechecker/combine_types.flow
@@ -332,7 +332,20 @@ combinePositiveAndNegative(env : FcTypeEnv, positive : FcType, negative : FcType
 						});
 						switch (str) {
 							None(): {
-								error();
+								// Struct not in this union, but they may share a common
+								// parent union (e.g. IsEqualMathsStrict + MathRoundingOption
+								// both belong to IsEqualMathsOption)
+								s2u = env.program.acc.names.struct2unions;
+								structUnions = buildSet(getTreeArrayValue(s2u, ps));
+								unionLeafNames = map(instantiated, \st -> st.name);
+								unionParentUnions = fold(unionLeafNames, structUnions, \acc, ln -> {
+									intersectSets(acc, buildSet(getTreeArrayValue(s2u, ln)))
+								});
+								if (!isEmptySet(unionParentUnions)) {
+									arrayPush([positive], negative);
+								} else {
+									error();
+								}
 							}
 							Some(st): {
 								// OK, we found it. Check these dudes
@@ -373,7 +386,18 @@ combinePositiveAndNegative(env : FcTypeEnv, positive : FcType, negative : FcType
 								});
 								switch (str) {
 									None(): {
-										error();
+										// Struct not in this union, check common parent
+										s2u = env.program.acc.names.struct2unions;
+										pLeafNames = map(instantiated, \ss -> ss.name);
+										allNames = arrayPush(pLeafNames, ns);
+										commonParents = fold(tail(allNames), buildSet(getTreeArrayValue(s2u, allNames[0])), \acc, ln -> {
+											intersectSets(acc, buildSet(getTreeArrayValue(s2u, ln)))
+										});
+										if (!isEmptySet(commonParents)) {
+											arrayPush([negative], positive);
+										} else {
+											error();
+										}
 									}
 									Some(st): {
 										// OK, we found it. Check these dudes
@@ -413,10 +437,21 @@ combinePositiveAndNegative(env : FcTypeEnv, positive : FcType, negative : FcType
 							ptns = buildSet(map(union2typenames(env, pun), \tn -> tn.name));
 							ntns = buildSet(map(union2typenames(env, nun), \tn -> tn.name));
 
-							if (! isEmptySet(differenceSets(ptns, ntns)) && !isEmptySet(differenceSets(ptns, ntns)) ) {
-								// Something is not overlapping!
-								error();
-								{}
+							pInN = isEmptySet(differenceSets(ptns, ntns));
+							nInP = isEmptySet(differenceSets(ntns, ptns));
+
+							if (!pInN && !nInP) {
+								// Neither is a subset of the other.
+								// Check if they share a common parent union
+								s2u = env.program.acc.names.struct2unions;
+								allLeafNames = set2array(mergeSets(ptns, ntns));
+								commonParents = fold(tail(allLeafNames), buildSet(getTreeArrayValue(s2u, allLeafNames[0])), \acc, ln -> {
+									intersectSets(acc, buildSet(getTreeArrayValue(s2u, ln)))
+								});
+								if (isEmptySet(commonParents)) {
+									error();
+									{}
+								}
 							};
 
 							[if (length(ntn) < length(ptn)) positive else negative]

--- a/tools/flowc/typechecker/ftype2fctype.flow
+++ b/tools/flowc/typechecker/ftype2fctype.flow
@@ -4,6 +4,9 @@ import tools/flowc/typechecker/combine_types;
 export {
 	// Set the given FcType in our environment to the type given by the ftype. Returns true if we get something
 	setFTyvar(env : FEnv, tyvar : int, type : FType, onError : (string) -> void) -> bool;
+
+	// Convert FType to FcType. Returns an array because some types can resolve to multiple alternatives.
+	ftype2fctype(env : FEnv, type : FType, seen : Set<int>, onError : (string) -> void) -> [FcType];
 }
 
 setFTyvar(env : FEnv, tyvar : int, type : FType, onError : (string) -> void) -> bool {

--- a/tools/flowc/typechecker/ftype_finalize.flow
+++ b/tools/flowc/typechecker/ftype_finalize.flow
@@ -27,6 +27,11 @@ ftypeFinalize(name : string, pos : FcPosition, count : int, env : FcTypeEnv, be0
 	onError = \tyvar, m -> {
 		reportErrorOnTyvar(be00, tyvar2infoMap, seenTyvarErrors, name, pos, tyvar, m)
 	};
+
+	// Check annotation constraints before finalization narrows types.
+	// This detects downcasts where annotation type is narrower than expression type.
+	checkAnnotationConstraints(name, pos, env, be00);
+
 	finalizeIteration(name, pos, count, env, be00, funify, onError);
 }
 
@@ -564,4 +569,127 @@ buildFTyvarInfos(env : FcTypeEnvLocal) -> Tree<int, [Pair<string, FcInfo2>]> {
 			}
 		}
 	});
+}
+
+// Check annotation constraints: detect when annotation type is narrower than expression type (downcast).
+// Runs before finalization so expression types are not yet narrowed by FReduceLeft.
+// Uses cross-referencing of annotation types to avoid false positives from annotation contamination:
+// when FcLessOrEqual grows a shared tyvar (e.g., lambda return type) to match one annotation,
+// other annotations on the same expression may appear as downcasts even though they are valid.
+checkAnnotationConstraints(name : string, pos : FcPosition, env : FcTypeEnv, fenv : FEnv) -> void {
+	checks = ^(env.local.checks);
+
+	// First pass: collect all annotation type struct sets to detect contamination.
+	// If the resolved expression type matches an annotation seen elsewhere, the expression
+	// type was likely widened BY that annotation, not by the expression itself.
+	allAnnotStructSets : [Set<string>] = foldList(checks, [], \acc : [Set<string>], check -> {
+		switch (check) {
+			FcCheckAnnotation(__, annotationType, __, __): {
+				annotInner = fcTypeUnwrapArray(annotationType);
+				annotStructs = expandFcTypeName2structs(env, annotInner);
+				if (isEmptySet(annotStructs)) acc
+				else arrayPush(acc, annotStructs);
+			}
+			default: acc;
+		}
+	});
+
+	// Second pass: check each annotation constraint
+	iterList(checks, \check -> {
+		switch (check) {
+			FcCheckAnnotation(exprType, annotationType, desc, info): {
+				checkOneAnnotation(name, pos, env, fenv, exprType, annotationType, desc, info, allAnnotStructSets);
+			}
+			default: {}
+		}
+	});
+}
+
+checkOneAnnotation(name : string, pos : FcPosition, env : FcTypeEnv, fenv : FEnv,
+	exprType : FcType, annotationType : FcType, desc : string, info : FcInfo2,
+	allAnnotStructSets : [Set<string>]) -> void {
+	// Convert exprType (usually FcTypeVar) to FType via the solver's tyvar map
+	exprFType = fctype2ftype(env, fenv.tyvarIdGroup, exprType);
+	// Convert back to FcType using ftype2fctype which resolves tyvars and finds named unions
+	errIgnore = \__ -> {};
+	exprFcTypes = ftype2fctype(fenv, exprFType, makeSet(), errIgnore);
+
+	if (exprFcTypes != []) {
+		exprFcType = exprFcTypes[0];
+		// Extract the inner type from arrays for comparison: [ExprType] vs [AnnotType]
+		exprInner = fcTypeUnwrapArray(exprFcType);
+		annotInner = fcTypeUnwrapArray(annotationType);
+		// Get struct sets for both
+		exprStructs = expandFcTypeName2structs(env, exprInner);
+		annotStructs = expandFcTypeName2structs(env, annotInner);
+		// Only check when both sides have known struct sets
+		if (!isEmptySet(exprStructs) && !isEmptySet(annotStructs)) {
+			// If expression struct set is NOT a subset of annotation struct set, it's a downcast candidate
+			if (!forallSet(exprStructs, \s -> containsSet(annotStructs, s))) {
+				// Check for contamination: if the expression's struct set matches an annotation
+				// type seen in another constraint, the expression type was likely widened BY that
+				// other annotation (via FcLessOrEqual on a shared tyvar), not by the expression itself.
+				isContaminated = exists(allAnnotStructSets, \otherAnnotStructs -> {
+					// The other annotation must be different from this one (same annotation = self)
+					// and must match the expression type exactly
+					!equalSet(otherAnnotStructs, annotStructs)
+						&& equalSet(otherAnnotStructs, exprStructs)
+				});
+
+				if (!isContaminated) {
+					pt = \t -> prettyFcType(FcPretty(false, true, ^(env.local.tyvars), ^(env.local.typars)), t, makeSet());
+					poss = FcPosition(pos.file, info.start, info.end);
+					addFcTypeError(env.program, FcError(
+						name + ": Type annotation '" + desc + " : " + pt(annotationType) + "' is incompatible with expression type " + pt(exprFcType),
+						[poss]
+					));
+				}
+			}
+		}
+	}
+}
+
+// Unwrap array type: [T] -> T, otherwise identity
+fcTypeUnwrapArray(t : FcType) -> FcType {
+	switch (t) {
+		FcTypeArray(at, __): at;
+		default: t;
+	}
+}
+
+// Get the name from an FcType (union or struct name)
+fcTypeGetName(t : FcType) -> string {
+	switch (t) {
+		FcTypeName(n, __, __): n;
+		FcTypeUnion(n, __, __, __): n;
+		FcTypeStruct(n, __, __, __): n;
+		default: "";
+	}
+}
+
+// Expand an FcType to its set of leaf struct names.
+// For a struct, returns {structName}. For a union, recursively expands to all leaf structs.
+expandFcTypeName2structs(env : FcTypeEnv, t : FcType) -> Set<string> {
+	tname = fcTypeGetName(t);
+	if (tname == "") makeSet()
+	else {
+		// Check if it's a union
+		munion = lookupTree(env.program.acc.names.unions, tname);
+		switch (munion) {
+			None(): {
+				// Check if it's a struct
+				mstruct = lookupTree(env.program.acc.names.structs, tname);
+				switch (mstruct) {
+					None(): makeSet();
+					Some(__): makeSet1(tname);
+				}
+			}
+			Some(udef): {
+				// Recursively expand union members
+				fold(udef.typenames, makeSet(), \acc, tn -> {
+					mergeSets(acc, expandFcTypeName2structs(env, tn))
+				});
+			}
+		}
+	}
 }

--- a/tools/flowc/typechecker/funify_cases.flow
+++ b/tools/flowc/typechecker/funify_cases.flow
@@ -1161,7 +1161,21 @@ funifyBounded(env : FEnv, range : FBounded, type : FType, boundedLeft : bool, fn
 					etl = unify(etr.env, u1, u2, FReduceLeft());
 
 					if (fns.kind == FUnifyLeft()) {
-						makeFBoundedEnv(etl.env, l1, etl.type, fns.kind, fns.unifyType, fns.onError);
+						// When both l1 and the grown result are FUnion with the
+						// same name, use the grown type to preserve widened type
+						// params (e.g. Maybe<TacticResult> grows to Maybe<GuidanceResult>).
+						// Otherwise keep l1 to avoid container type contamination
+						// (e.g. Tree<int, StructA> widening to Tree<int, Union>).
+						gl1 = switch (l1) {
+							FUnion(ln, __): {
+								switch (etr.type) {
+									FUnion(en, __): if (ln == en) etr.type else l1;
+									default: l1;
+								}
+							}
+							default: l1;
+						}
+						makeFBoundedEnv(etl.env, gl1, etl.type, fns.kind, fns.unifyType, fns.onError);
 					} else {
 						// l1 ... u1  <= l2 ... u2   ->    (l1  grow_right . l2)  .. u2
 						makeFBoundedEnv(etl.env, etr.type, u2, fns.kind, fns.unifyType, fns.onError);

--- a/tools/flowc/typechecker/funify_cases.flow
+++ b/tools/flowc/typechecker/funify_cases.flow
@@ -354,9 +354,26 @@ funifyUnionAndStruct(env : FEnv, union : FUnion, struct : FStruct, unionIsLeft :
 					} else {
 						// All unification, this is an error, but not in interesection
 						if (fns.kind != FReduceLeft()) {
-							fns.onError("Expected " + sname + " in union " + uname);
+							// Struct not in this union, but they may share a common
+							// parent union (e.g. IsEqualMathsStrict + MathRoundingOption
+							// are both in IsEqualMathsOption). Expand to unnamed union
+							// and let finalization resolve to the correct parent.
+							ltypars = foldi(union.typars, makeTree(), \i, acc, tp -> {
+								setTree(acc, strLeft("????????????????", i + 1), tp)
+							});
+							members = arrayPush(
+								map(typenames, \tn -> fcstructname2ftype(env, tn.name, ltypars)),
+								struct
+							);
+							if (unnamedUnionsShareCommonUnion(env, members, [])) {
+								FEnvType(env, makeFUnnamedUnion(members));
+							} else {
+								fns.onError("Expected " + sname + " in union " + uname);
+								FEnvType(env, union);
+							}
+						} else {
+							FEnvType(env, union);
 						}
-						FEnvType(env, union);
 					}
 				}
 				Some(st): {
@@ -385,17 +402,15 @@ funifyUnionAndStruct(env : FEnv, union : FUnion, struct : FStruct, unionIsLeft :
 					} else if (unionIsLeft) {
 						// union+ <= struct-
 
-						// Unify the struct in the union to capture info
+						// Unify the struct in the union to capture type params
 						et = fns.unifyType(env, inst, struct, fns.kind, fns.onError);
 
-						// The union can only contain l, otherwise we have a problem.
-						if (length(typenames) > 1) {
-							// OK, too many in the union. Something is not right here
-							super = set2array(removeSet(buildSet(map(typenames, \tn -> tn.name)), sname));
-							fns.onError("Expected just " + sname + " here, got union " + uname + ".");
-						}
-						// We are good with the struct, which has been determined
-						et;
+						// The struct is a member of the union. Return the union
+						// to preserve the full range (matching struct+ <= union- behavior).
+						// Narrowing to just the struct would lose type information
+						// in contexts like array construction where type params are
+						// grown to cover multiple members.
+						FEnvType(et.env, union);
 					} else {
 						// struct+ <= union-
 
@@ -752,9 +767,20 @@ funifyUnnamedUnion(env : FEnv, unnamed : FUnnamedUnion, right : FType, unnamedLe
 							// We have some field stuff going on. Maybe that works
 							rec();
 						} else {
-							// In all other cases, we need the overlap to be there
-							fns.onError("Expected " + rname + " in union " + ftype2string(env, unnamed));
-							FEnvType(env, unnamed);
+							// A struct may be compared against an unnamed union that
+							// doesn't contain it yet, but both share a common parent
+							// union. Add the struct and let finalization resolve.
+							existingStructNames = filtermap(utypes, \ut -> {
+								sn = getFTypeName(ut);
+								if (sn == "") None() else Some(sn)
+							});
+							if (rname != "" && existingStructNames != [] && unnamedUnionsShareCommonUnion(env, utypes, [right])) {
+								FEnvType(env, makeFUnnamedUnion(arrayPush(utypes, right)));
+							} else {
+								// In all other cases, we need the overlap to be there
+								fns.onError("Expected " + rname + " in union " + ftype2string(env, unnamed));
+								FEnvType(env, unnamed);
+							}
 						}
 					}
 				}
@@ -889,7 +915,13 @@ funifyUnnamedUnion(env : FEnv, unnamed : FUnnamedUnion, right : FType, unnamedLe
 
 				// OK, check if at least we cover all of the left hand side dudes. We are allowed to drop right hand guys
 				if (length(namedOverlap.types) != length(utypes) && nonstructs == []) {
-					fns.onError("We expect " + ftype2string(env, right)+ " to fully contain " + ftype2string(env, unnamed));
+					// The unnamed union may have members from a parent union
+					// of `right`. E.g. unnamed {IsEqualMathsStrict, MathRoundingAllowTo, ...}
+					// vs MathRoundingOption — all share parent IsEqualMathsOption.
+					// Suppress error when they share a common parent union.
+					if (!unnamedUnionsShareCommonUnion(env, utypes, [])) {
+						fns.onError("We expect " + ftype2string(env, right)+ " to fully contain " + ftype2string(env, unnamed));
+					}
 				}
 				if (length(namedOverlap.types) == length(rtypenames)) {
 					// OK, we cover the entire union, so we can keep it as a union
@@ -911,13 +943,27 @@ funifyUnnamedUnion(env : FEnv, unnamed : FUnnamedUnion, right : FType, unnamedLe
 
 				// OK, check if at least we cover all of the right hand side dudes. We are allowed to drop unnamed members
 				if (length(namedOverlap.types) != length(rtypenames) && nonstructs== []) {
-					fns.onError("We expect " + ftype2string(env, right) + " to be fully contained in " + ftype2string(env, unnamed));
+					// Suppress error when members share a common parent union
+					if (!unnamedUnionsShareCommonUnion(env, utypes, [])) {
+						fns.onError("We expect " + ftype2string(env, right) + " to be fully contained in " + ftype2string(env, unnamed));
+					}
 				}
 
 				if (length(namedOverlap.types) == length(rtypenames)) {
-					// OK, we know the right hand is also the union
-					// FRange(right, FUnion(rname, false, rtps))
-					right
+					if (length(namedOverlap.types) == length(utypes)) {
+						// Exact match between unnamed and named union members
+						right
+					} else {
+						// Named union fully contained, but unnamed has extra members.
+						// Only keep unnamed if extras share a common parent union
+						// with the named union (e.g. IsEqualMathsStrict + MathRoundingOption
+						// both in IsEqualMathsOption). Otherwise narrow as before.
+						if (unnamedUnionsShareCommonUnion(env, utypes, [])) {
+							unnamed
+						} else {
+							right
+						}
+					}
 				} else {
 					// FRange(right, FUnnamedUnion(overlap.second))
 					makeFUnnamedUnion(namedOverlap.types)
@@ -969,20 +1015,47 @@ funifyUnnamedUnion(env : FEnv, unnamed : FUnnamedUnion, right : FType, unnamedLe
 
 				// OK, check if at least we cover all of the left hand side dudes. We are allowed to drop right hand guys
 				if (length(overlap.second) != length(utypes)) {
-					fns.onError("We expect " + ftype2string(env, unnamed) + " to be fully contained in " + ftype2string(env, right));
+					// During array/if-else constraint processing, inner type params of
+					// polymorphic types (e.g. Maybe<?>) can accumulate different subsets
+					// of struct names into partial unnamed unions. These fail the
+					// containment check. If all struct names share a common parent union,
+					// they will resolve to that union during finalization — suppress the
+					// error and merge the unions.
+					if (!unnamedUnionsShareCommonUnion(env, utypes, rtypes)) {
+						fns.onError("We expect " + ftype2string(env, unnamed) + " to be fully contained in " + ftype2string(env, right));
+					}
 				}
 				// FRange(unnamed, FUnnamedUnion(overlap.second, false));
-				unnamed;
+				// When suppressing the error, merge both sides so finalization sees all members
+				if (length(overlap.second) != length(utypes) && unnamedUnionsShareCommonUnion(env, utypes, rtypes)) {
+					makeFUnnamedUnion(concat3(overlap.second,
+						filter(utypes, \ltn -> !exists(rtypes, \rtn -> getFTypeName(rtn) == getFTypeName(ltn))),
+						filter(rtypes, \rtn -> !exists(utypes, \ltn -> getFTypeName(rtn) == getFTypeName(ltn)))
+					));
+				} else {
+					unnamed;
+				}
 			} else {
 				// right+ <= un-
 
 				// OK, check if at least we cover all of the right hand side dudes. We are allowed to drop unnamed members
 				if (length(overlap.second) != length(rtypes)) {
-					fns.onError("We expect " + ftype2string(env, right) + " to be fully contained in " + ftype2string(env, unnamed));
+					// Same as above — suppress error when both unnamed unions
+					// share a common parent union.
+					if (!unnamedUnionsShareCommonUnion(env, utypes, rtypes)) {
+						fns.onError("We expect " + ftype2string(env, right) + " to be fully contained in " + ftype2string(env, unnamed));
+					}
 				}
 
 				// FRange(right, FUnnamedUnion(overlap.second, false))
-				right
+				if (length(overlap.second) != length(rtypes) && unnamedUnionsShareCommonUnion(env, utypes, rtypes)) {
+					makeFUnnamedUnion(concat3(overlap.second,
+						filter(utypes, \ltn -> !exists(rtypes, \rtn -> getFTypeName(rtn) == getFTypeName(ltn))),
+						filter(rtypes, \rtn -> !exists(utypes, \ltn -> getFTypeName(rtn) == getFTypeName(ltn)))
+					));
+				} else {
+					right
+				}
 			}
 			FEnvType(overlap.first, rt);
 		}
@@ -994,6 +1067,29 @@ funifyUnnamedUnion(env : FEnv, unnamed : FUnnamedUnion, right : FType, unnamedLe
 			funifyBounded(env, right, unnamed, !unnamedLeft, fns);
 		}
 		default: fns.rest();
+	}
+}
+
+// Check if all struct names from two unnamed unions share at least one common parent
+// union. During array/if-else constraint processing, inner type params of polymorphic
+// types (e.g. Maybe<?>) can accumulate different subsets of struct names into partial
+// unnamed unions. If they share a common parent union, finalization will resolve both
+// to that union, so containment errors between them are spurious.
+unnamedUnionsShareCommonUnion(env : FEnv, ltypes : [FType], rtypes : [FType]) -> bool {
+	allNames = filtermap(concat(ltypes, rtypes), \t -> {
+		n = getFTypeName(t);
+		if (n == "") None() else Some(n)
+	});
+	if (length(allNames) < 2) false
+	else {
+		s2u = env.env.program.acc.names.struct2unions;
+		unions : [Set<string>] = map(allNames, \n -> {
+			buildSet(getTreeArrayValue(s2u, n))
+		});
+		shared = fold(tail(unions), unions[0], \acc, c -> {
+			intersectSets(acc, c)
+		});
+		!isEmptySet(shared)
 	}
 }
 
@@ -1030,12 +1126,18 @@ funifyBounded(env : FEnv, range : FBounded, type : FType, boundedLeft : bool, fn
 				if (boundedLeft) {
 					et0 = unify(env, l1, l2, FGrowRight());
 					et1 = unify(et0.env, u1, u2, FGrowRight());
-
 					// Examples like  {Maybe<> .. *}  union  None<>
 					// show that we have to make sure the upper bound respects the lower bound
 					et2 = fns.unifyType(et1.env, et0.type, et1.type, FGrowRight(), fns.onError);
 
-					makeFBoundedEnv(et2.env, et0.type, et2.type, FUnifyLeft(), fns.unifyType, fns.onError);
+					// When BOTH original upper bounds are open (FTopBottom), keep the
+					// result open. This prevents premature bound collapse when growing
+					// two open-bounded types (e.g. {LP .. *} grow {PW .. *} should give
+					// {LP, PW .. *}, not the closed {LP, PW}). When only one side is
+					// open, the concrete upper bound must propagate to resolve type
+					// parameters (e.g. ArrayOperation<?> members need the union's ? param).
+					finalUpper = if (u1 == FTopBottom() && u2 == FTopBottom()) FTopBottom() else et2.type;
+					makeFBoundedEnv(et2.env, et0.type, finalUpper, FUnifyLeft(), fns.unifyType, fns.onError);
 				} else {
 					et0 = unify(env, l2, l1, FGrowRight());
 					et1 = unify(et0.env, u2, u1, FGrowRight());
@@ -1043,7 +1145,9 @@ funifyBounded(env : FEnv, range : FBounded, type : FType, boundedLeft : bool, fn
 					// show that we have to make sure the upper bound respects the lower bound
 					et2 = fns.unifyType(et1.env, et0.type, et1.type, FGrowRight(), fns.onError);
 
-					makeFBoundedEnv(et2.env, et0.type, et2.type, FUnifyLeft(), fns.unifyType, fns.onError);
+					// Same as above: preserve open upper bounds only when both sides are open
+					finalUpper = if (u1 == FTopBottom() && u2 == FTopBottom()) FTopBottom() else et2.type;
+					makeFBoundedEnv(et2.env, et0.type, finalUpper, FUnifyLeft(), fns.unifyType, fns.onError);
 				}
 			}
 		}

--- a/tools/flowc/typechecker/funify_cases.flow
+++ b/tools/flowc/typechecker/funify_cases.flow
@@ -803,11 +803,38 @@ funifyUnnamedUnion(env : FEnv, unnamed : FUnnamedUnion, right : FType, unnamedLe
 
 			// Find the named overlaps
 			namedOverlap : FEnvTypes = fold(utypes, FEnvTypes(env, []), \acc : FEnvTypes, utn : FType -> {
+				uname = getFTypeName(utn);
 				rstruct = find(rtypenames, \rtn : FcTypeName -> {
-					getFTypeName(utn) == rtn.name;
+					uname == rtn.name;
 				});
 				switch (rstruct) {
-					None(): acc;
+					None(): {
+						// Check if utn is a sub-union whose leaf structs are all in rtypenames
+						switch (utn) {
+							FUnion(subname, subtps): {
+								subLeafs = union2typenames(env.env, subname);
+								if (subLeafs != [] && forall(subLeafs, \sl -> exists(rtypenames, \rtn -> rtn.name == sl.name))) {
+									// All leaf structs of this sub-union are in the named union.
+									// Unify each leaf struct individually.
+									subtypars = foldi(subtps, makeTree(), \i, a, tp -> {
+										setTree(a, strLeft("????????????????", i + 1), tp)
+									});
+									fold(subLeafs, acc, \acc2 : FEnvTypes, sl : FcTypeName -> {
+										rinst = fcstructname2ftype(acc2.env, sl.name, rtypars);
+										sinst = fcstructname2ftype(acc2.env, sl.name, subtypars);
+										et = fns.unifyType(acc2.env, sinst, rinst, fns.kind, fns.onError);
+										FEnvTypes(
+											et.env,
+											arrayPush(acc2.types, et.type)
+										)
+									});
+								} else {
+									acc;
+								}
+							}
+							default: acc;
+						}
+					}
 					Some(rst): {
 						eenv = acc.env;
 						// The same struct in both unions.
@@ -1030,8 +1057,14 @@ funifyBounded(env : FEnv, range : FBounded, type : FType, boundedLeft : bool, fn
 					etl = unify(etr.env, u1, u2, FReduceLeft());
 
 					if (fns.kind == FUnifyLeft()) {
-						// l1 ... u1  <= l2 ... u2   ->    l1 ... (u1 . reduce_left u2)
-						makeFBoundedEnv(etl.env, l1, etl.type, fns.kind, fns.unifyType, fns.onError);
+						// Use grown lower only for same-name unions to prevent makeFBoundedEnv
+						// from collapsing {Maybe<SubUnion>..Maybe<SuperUnion>} to the narrower
+						// lower bound via FUnifyLeft. Structs keep original to preserve precision.
+						gl1 = switch (l1) {
+							FUnion(ln, __): switch (etr.type) { FUnion(en, __): if (ln == en) etr.type else l1; default: l1; };
+							default: l1;
+						};
+						makeFBoundedEnv(etl.env, gl1, etl.type, fns.kind, fns.unifyType, fns.onError);
 					} else {
 						// l1 ... u1  <= l2 ... u2   ->    (l1  grow_right . l2)  .. u2
 						makeFBoundedEnv(etl.env, etr.type, u2, fns.kind, fns.unifyType, fns.onError);
@@ -1041,8 +1074,11 @@ funifyBounded(env : FEnv, range : FBounded, type : FType, boundedLeft : bool, fn
 					etl = unify(env, u2, u1, FReduceLeft());
 					etr = unify(etl.env, l2, l1, FGrowRight());
 					if (fns.kind == FUnifyLeft()) {
-						// l2 ... u2  <= l1 ... u1   ->    l2 ... (u2 . reduce_left u1)
-						makeFBoundedEnv(etr.env, l2, etl.type, fns.kind, fns.unifyType, fns.onError);
+						gl2 = switch (l2) {
+							FUnion(ln, __): switch (etr.type) { FUnion(en, __): if (ln == en) etr.type else l2; default: l2; };
+							default: l2;
+						};
+						makeFBoundedEnv(etr.env, gl2, etl.type, fns.kind, fns.unifyType, fns.onError);
 					} else {
 						// l2 ... u2  <= l1 ... u1   ->    (l2  grow_right . l1)  .. u1
 						makeFBoundedEnv(etr.env, etr.type, u1, fns.kind, fns.unifyType, fns.onError);

--- a/tools/flowc/typechecker/funify_cases.flow
+++ b/tools/flowc/typechecker/funify_cases.flow
@@ -1161,14 +1161,7 @@ funifyBounded(env : FEnv, range : FBounded, type : FType, boundedLeft : bool, fn
 					etl = unify(etr.env, u1, u2, FReduceLeft());
 
 					if (fns.kind == FUnifyLeft()) {
-						// Use grown lower only for same-name unions to prevent makeFBoundedEnv
-						// from collapsing {Maybe<SubUnion>..Maybe<SuperUnion>} to the narrower
-						// lower bound via FUnifyLeft. Structs keep original to preserve precision.
-						gl1 = switch (l1) {
-							FUnion(ln, __): switch (etr.type) { FUnion(en, __): if (ln == en) etr.type else l1; default: l1; };
-							default: l1;
-						};
-						makeFBoundedEnv(etl.env, gl1, etl.type, fns.kind, fns.unifyType, fns.onError);
+						makeFBoundedEnv(etl.env, l1, etl.type, fns.kind, fns.unifyType, fns.onError);
 					} else {
 						// l1 ... u1  <= l2 ... u2   ->    (l1  grow_right . l2)  .. u2
 						makeFBoundedEnv(etl.env, etr.type, u2, fns.kind, fns.unifyType, fns.onError);
@@ -1178,11 +1171,7 @@ funifyBounded(env : FEnv, range : FBounded, type : FType, boundedLeft : bool, fn
 					etl = unify(env, u2, u1, FReduceLeft());
 					etr = unify(etl.env, l2, l1, FGrowRight());
 					if (fns.kind == FUnifyLeft()) {
-						gl2 = switch (l2) {
-							FUnion(ln, __): switch (etr.type) { FUnion(en, __): if (ln == en) etr.type else l2; default: l2; };
-							default: l2;
-						};
-						makeFBoundedEnv(etr.env, gl2, etl.type, fns.kind, fns.unifyType, fns.onError);
+						makeFBoundedEnv(etr.env, l2, etl.type, fns.kind, fns.unifyType, fns.onError);
 					} else {
 						// l2 ... u2  <= l1 ... u1   ->    (l2  grow_right . l1)  .. u1
 						makeFBoundedEnv(etr.env, etr.type, u1, fns.kind, fns.unifyType, fns.onError);

--- a/tools/flowc/typechecker/solve_expectations.flow
+++ b/tools/flowc/typechecker/solve_expectations.flow
@@ -150,16 +150,24 @@ checkFinalTypeExpect(env : FcTypeEnv, check : FcTypeCheck, error : (string, [FcI
 
 checkStructs(env : FcTypeEnv, names : [string], open : bool, union : string, error : (string) -> void) -> void {
 	structs = union2typenames(env, union);
-	if (!forall(names, \n -> {
+	// Expand union names in cases to their constituent struct names
+	expandedNames = concatA(map(names, \n -> {
+		if (containsKeyTree(env.program.acc.names.unions, n)) {
+			map(union2typenames(env, n), \tn -> tn.name)
+		} else {
+			[n]
+		}
+	}));
+	if (!forall(expandedNames, \n -> {
 		exists(structs, \s -> s.name == n)
 	})) {
 		error("Expected " + strGlue(names, ", ") + " in " + union + " for switch");
 	}
-	if (!open && length(structs) != length(names)) {
+	if (!open && length(structs) != length(expandedNames)) {
 		// We try to be nice and print which ones are missing here
-		missing = subtractA(map(structs, \st -> getFcTypeName(env, st)), names);
+		missing = subtractA(map(structs, \st -> getFcTypeName(env, st)), expandedNames);
 
-		error("Expected " + union + " to have " + i2s(length(structs)) + " entries in switch, but got " + i2s(length(names)) + ". Missing cases:"
+		error("Expected " + union + " to have " + i2s(length(structs)) + " entries in switch, but got " + i2s(length(expandedNames)) + ". Missing cases:"
 			+ superglue(missing, \m -> {
 				mstruct = lookupTree(env.program.acc.names.structs, m);
 				args = switch (mstruct) {
@@ -171,7 +179,7 @@ checkStructs(env : FcTypeEnv, names : [string], open : bool, union : string, err
 				"\n\t" + m + "(" + args + "): "
 			}, "")
 		);
-	} else if (open && length(structs) == length(names)) {
+	} else if (open && length(structs) == length(expandedNames)) {
 		error("Unnecessary default case in union");
 	}
 }

--- a/tools/flowc/typechecker/solve_expectations.flow
+++ b/tools/flowc/typechecker/solve_expectations.flow
@@ -145,6 +145,9 @@ checkFinalTypeExpect(env : FcTypeEnv, check : FcTypeCheck, error : (string, [FcI
 				default: {}
 			}
 		}
+		FcCheckAnnotation(__, __, __, __): {
+			// Handled in checkAnnotationConstraints() in ftype_finalize.flow
+		}
 	}
 }
 

--- a/tools/flowc/typechecker/solve_expectations.flow
+++ b/tools/flowc/typechecker/solve_expectations.flow
@@ -150,14 +150,16 @@ checkFinalTypeExpect(env : FcTypeEnv, check : FcTypeCheck, error : (string, [FcI
 
 checkStructs(env : FcTypeEnv, names : [string], open : bool, union : string, error : (string) -> void) -> void {
 	structs = union2typenames(env, union);
-	// Expand union names in cases to their constituent struct names
-	expandedNames = concatA(map(names, \n -> {
+	// Expand union names in cases to their constituent struct names.
+	// Deduplicate: a switch may have both a union case (e.g. CharacterStyle()) and
+	// an explicit struct case (e.g. SetRTL(__)) where SetRTL is a member of CharacterStyle.
+	expandedNames = uniq(sort(concatA(map(names, \n -> {
 		if (containsKeyTree(env.program.acc.names.unions, n)) {
 			map(union2typenames(env, n), \tn -> tn.name)
 		} else {
 			[n]
 		}
-	}));
+	}))));
 	if (!forall(expandedNames, \n -> {
 		exists(structs, \s -> s.name == n)
 	})) {

--- a/tools/flowc/typechecker/type_expect.flow
+++ b/tools/flowc/typechecker/type_expect.flow
@@ -17,7 +17,10 @@ export {
 		FcVerifyType(type : FcType, declared : FcType, description : string, info : FcInfo2, e : FcExp);
 
 	// Checks we should do at the end, once we know the type
-	FcTypeCheck ::= FcExpectOneOf, FcCheckStructs, FcCheckMutable, FcNotVoid, FcNotFunction;
+	FcTypeCheck ::= FcExpectOneOf, FcCheckStructs, FcCheckMutable, FcNotVoid, FcNotFunction, FcCheckAnnotation;
+
+		// Check that the expression type is compatible with the annotation type (not a downcast)
+		FcCheckAnnotation(exprType : FcType, annotationType : FcType, description : string, info : FcInfo2);
 
 		// Only base types allowed here, but exact match
 		FcExpectOneOf(types : [FcBaseType], type : FcType, info : FcInfo2);

--- a/tools/flowc/typechecker/type_expect_helpers.flow
+++ b/tools/flowc/typechecker/type_expect_helpers.flow
@@ -43,5 +43,8 @@ fcCheck2string(env : FcTypeEnv, e : FcTypeCheck) -> string {
 		FcNotFunction(t, __): {
 			pt(t) + " not function";
 		}
+		FcCheckAnnotation(et, at, d, __): {
+			pt(et) + " compatible with annotation " + pt(at) + " in " + d;
+		}
 	}
 }

--- a/tools/flowc/typechecker/typechecker.flow
+++ b/tools/flowc/typechecker/typechecker.flow
@@ -828,7 +828,7 @@ typecheckFcExp(acc : FcTypeEnv, tyvarIdGroup : IdGroup, flowfile : string, e : F
 
 					// For union cases, connect the structdef's type params to the switch variable's type params
 					if (isUnionCase) {
-						checkOrRecordTypeExpect(acc, FcLessOrEqual(structdef, varType, "union case in switch", copyFcInfo2(case.info), case.body));
+						checkOrRecordTypeExpect(acc, FcLessOrEqual(structdef, unionType, "union case in switch", copyFcInfo2(case.info), case.body));
 					}
 					setFcType(acc, x.name, Some(structdef));
 				}

--- a/tools/flowc/typechecker/typechecker.flow
+++ b/tools/flowc/typechecker/typechecker.flow
@@ -188,7 +188,7 @@ typecheckFcModule(env0 : FcTypeEnv, module : FcModule) -> FcTypecheckResult {
 	}
 
 
-	fi = fcmodule2fiWithErrorHandler(ret.first.local, module,
+	fi = fcmodule2fiWithErrorHandler(ret.first.local, ret.first.program.acc.names, module,
 		\err, info ->
 			onModuleError(FcError(err, [FcPosition(module.fileinfo.flowfile, info.start, info.end)]))
 	);
@@ -700,7 +700,16 @@ typecheckFcExp(acc : FcTypeEnv, tyvarIdGroup : IdGroup, flowfile : string, e : F
 											mstruct = lookupTree(acc.program.acc.names.structs, case.struct);
 											switch (mstruct) {
 												None(): {
-													acc2;
+													// Could be a union case
+													munion = lookupTree(acc.program.acc.names.unions, case.struct);
+													switch (munion) {
+														None(): acc2;
+														Some(union): {
+															arrayPush(acc2, FcTypeName(case.struct, generate(0, length(union.typeparameters), \__ -> {
+																makeFcTyVar2(tyvarIdGroup, ci)
+															}), ci));
+														}
+													}
 												}
 												Some(struct): {
 													// TODO: We might be able to do this a bit smarter, since we
@@ -753,20 +762,28 @@ typecheckFcExp(acc : FcTypeEnv, tyvarIdGroup : IdGroup, flowfile : string, e : F
 
 			// Find the resulting types of all bodies
 			aat = map(cases, \case : FcCase -> {
+				isUnionCase = containsKeyTree(acc.program.acc.names.unions, case.struct);
 				// Be sure to override the type of the case variable to this type of this particular case
 				// As best we can, grab it from the concrete union type we have
-				beststruct : Maybe<FcTypeName> = find(unionStructs, \us -> us.name == case.struct);
-				structdef = switch (beststruct) {
-					None(): {
-						body : FcExp = case.body;
-						if (isConfigParameterTrue(acc.program.acc.config.config, "gtype")) {
-							tn = FcTypeName(case.struct, [], copyFcInfo2(body.info));
-							getFcNamedTypeError(acc, tyvarIdGroup, tn, error);
-						} else {
-							FcTypeName(case.struct, [], copyFcInfo2(body.info));
+				structdef = if (isUnionCase) {
+					// Union case: resolve the union type, don't narrow to struct
+					body0 : FcExp = case.body;
+					tn0 = FcTypeName(case.struct, [], copyFcInfo2(body0.info));
+					getFcNamedTypeError(acc, tyvarIdGroup, tn0, error);
+				} else {
+					beststruct : Maybe<FcTypeName> = find(unionStructs, \us -> us.name == case.struct);
+					switch (beststruct) {
+						None(): {
+							body : FcExp = case.body;
+							if (isConfigParameterTrue(acc.program.acc.config.config, "gtype")) {
+								tn = FcTypeName(case.struct, [], copyFcInfo2(body.info));
+								getFcNamedTypeError(acc, tyvarIdGroup, tn, error);
+							} else {
+								FcTypeName(case.struct, [], copyFcInfo2(body.info));
+							}
 						}
+						Some(tn): getFcNamedTypeError(acc, tyvarIdGroup, tn, error);
 					}
-					Some(tn): getFcNamedTypeError(acc, tyvarIdGroup, tn, error);
 				}
 				acc3 = if (case.struct == "default") acc
 				else {
@@ -776,21 +793,23 @@ typecheckFcExp(acc : FcTypeEnv, tyvarIdGroup : IdGroup, flowfile : string, e : F
 					setFcType(acc, x.name, Some(structdef));
 				}
 
-				switch (structdef) {
-					FcTypeStruct(__, __, sargs, __): {
-						if (length(case.argNames) != length(structdef.args)) {
-							pt = prettyFcType(FcPretty(false, true, ^(acc3.local.tyvars), ^(acc3.local.typars)), structdef, makeSet());
-							error("Expected " + i2s(length(structdef.args)) + " arguments to " + pt + " in case, got " + i2s(length(case.argNames)));
+				if (!isUnionCase) {
+					switch (structdef) {
+						FcTypeStruct(__, __, sargs, __): {
+							if (length(case.argNames) != length(structdef.args)) {
+								pt = prettyFcType(FcPretty(false, true, ^(acc3.local.tyvars), ^(acc3.local.typars)), structdef, makeSet());
+								error("Expected " + i2s(length(structdef.args)) + " arguments to " + pt + " in case, got " + i2s(length(case.argNames)));
+							}
 						}
+						default: {}
 					}
-					default: {}
 				}
 
 				// Here we pass varinfo because case variables would be added later at 'let' construction
 				ct = typecheckFcExp(acc3, tyvarIdGroup, flowfile, case.body);
 				// Check if the body has "let" bodies with the name of the switch-var,
 				// and then mark that this var is less than the struct case!
-				if (case.struct != "default") {
+				if (case.struct != "default" && !isUnionCase) {
 					checkSwitchBodyVars(acc3, x, xtype, structdef, case.body);
 				}
 				ct;

--- a/tools/flowc/typechecker/typechecker.flow
+++ b/tools/flowc/typechecker/typechecker.flow
@@ -626,8 +626,8 @@ typecheckFcExp(acc : FcTypeEnv, tyvarIdGroup : IdGroup, flowfile : string, e : F
 			});
 
 			// Now check that the x type we get matches the cases we have
-			unionCases = fold(cases, [], \acc2, case -> 
-				if (case.struct == "default") acc2 
+			unionCases = fold(cases, [], \acc2, case ->
+				if (case.struct == "default") acc2
 				else arrayPush(acc2, case.struct)
 			);
 			if (length(unionCases) != length(uniq(unionCases))) {
@@ -684,7 +684,16 @@ typecheckFcExp(acc : FcTypeEnv, tyvarIdGroup : IdGroup, flowfile : string, e : F
 						}
 						default: {
 							names = filtermap(cases, \c -> if (c.struct == "default") None() else Some(c.struct));
-							unionCandidates = names2unions(acc, names, open);
+							// Expand union names to leaf struct names for names2unions lookup,
+							// since names2unions uses struct2unions which only maps struct names
+							expandedNames = uniq(sort(concatA(map(names, \n -> {
+								if (containsKeyTree(acc.program.acc.names.unions, n)) {
+									map(union2typenames(acc, n), \tn -> tn.name)
+								} else {
+									[n]
+								}
+							}))));
+							unionCandidates = names2unions(acc, expandedNames, open);
 
 							undef = if (length(unionCandidates) == 1) {
 								unname = unionCandidates[0];
@@ -704,10 +713,21 @@ typecheckFcExp(acc : FcTypeEnv, tyvarIdGroup : IdGroup, flowfile : string, e : F
 													munion = lookupTree(acc.program.acc.names.unions, case.struct);
 													switch (munion) {
 														None(): acc2;
-														Some(union): {
-															arrayPush(acc2, FcTypeName(case.struct, generate(0, length(union.typeparameters), \__ -> {
-																makeFcTyVar2(tyvarIdGroup, ci)
-															}), ci));
+														Some(__): {
+															// Add leaf struct names (not the union name) so type inference
+															// finds the correct containing union
+															leafStructs = union2typenames(acc, case.struct);
+															fold(leafStructs, acc2, \acc3, tn -> {
+																mstruct2 = lookupTree(acc.program.acc.names.structs, tn.name);
+																switch (mstruct2) {
+																	None(): acc3;
+																	Some(struct2): {
+																		arrayPush(acc3, FcTypeName(tn.name, generate(0, length(struct2.typars), \__ -> {
+																			makeFcTyVar2(tyvarIdGroup, ci)
+																		}), ci));
+																	}
+																}
+															});
 														}
 													}
 												}
@@ -748,6 +768,14 @@ typecheckFcExp(acc : FcTypeEnv, tyvarIdGroup : IdGroup, flowfile : string, e : F
 									un = FcTypeName(uniondef.name, generate(0, ntv, \__ -> makeFcTyVar2(tyvarIdGroup, ci)), ci);
 									expect = FcLessOrEqual(un, unionType, "cases in switch against " + uniondef.name, ci, e);
 									checkOrRecordTypeExpect(acc, expect);
+									// Also constrain against varType so type parameters are linked.
+									// Without this, union cases like EditDialogAction2<α1> in a switch on Action2<User2>
+									// leave α1 unconstrained (unionType may be FcTypeFlow when unannotated).
+									// Only when the union has type params AND varType is not already a struct
+									// (a struct varType like CompilerConfig is a member of the union, not the union itself).
+									if (ntv > 0) {
+										checkOrRecordTypeExpect(acc, FcLessOrEqual(varType, un, "switch var type params", ci, e));
+									}
 									rs = getFcNamedTypeError(acc, tyvarIdGroup, un, error);
 									switch (rs) {
 										FcTypeUnion(__, __, tns, __): tns;
@@ -766,10 +794,17 @@ typecheckFcExp(acc : FcTypeEnv, tyvarIdGroup : IdGroup, flowfile : string, e : F
 				// Be sure to override the type of the case variable to this type of this particular case
 				// As best we can, grab it from the concrete union type we have
 				structdef = if (isUnionCase) {
-					// Union case: resolve the union type, don't narrow to struct
+					// Union case: look up in unionStructs first (like struct cases) to get
+					// type params from parent union. Only fall back to fresh tyvars if not found.
+					bestunion : Maybe<FcTypeName> = find(unionStructs, \us -> us.name == case.struct);
 					body0 : FcExp = case.body;
-					tn0 = FcTypeName(case.struct, [], copyFcInfo2(body0.info));
-					getFcNamedTypeError(acc, tyvarIdGroup, tn0, error);
+					switch (bestunion) {
+						Some(tn): getFcNamedTypeError(acc, tyvarIdGroup, tn, error);
+						None(): {
+							tn0 = FcTypeName(case.struct, [], copyFcInfo2(body0.info));
+							getFcNamedTypeError(acc, tyvarIdGroup, tn0, error);
+						}
+					}
 				} else {
 					beststruct : Maybe<FcTypeName> = find(unionStructs, \us -> us.name == case.struct);
 					switch (beststruct) {
@@ -790,6 +825,11 @@ typecheckFcExp(acc : FcTypeEnv, tyvarIdGroup : IdGroup, flowfile : string, e : F
 					// Record that our struct is less than the switch var type!
 					// This causes problems for some reasons.
 					// checkOrRecordTypeExpect(acc, FcLessOrEqual(structdef, varType, "special switch", copyFcInfo2(case.info), case.body));
+
+					// For union cases, connect the structdef's type params to the switch variable's type params
+					if (isUnionCase) {
+						checkOrRecordTypeExpect(acc, FcLessOrEqual(structdef, varType, "union case in switch", copyFcInfo2(case.info), case.body));
+					}
 					setFcType(acc, x.name, Some(structdef));
 				}
 

--- a/tools/flowc/typechecker/typechecker.flow
+++ b/tools/flowc/typechecker/typechecker.flow
@@ -908,6 +908,10 @@ typecheckFcExp(acc : FcTypeEnv, tyvarIdGroup : IdGroup, flowfile : string, e : F
 				checkOrRecordTypeExpect(acc, FcVerifyType(et, itype, "definition of", ci, e));
 			} else {
 				checkOrRecordTypeExpect(acc1, FcLessOrEqual(et, itype, "definition of", ci, e));
+				// Also record a post-solve annotation check that detects unsafe downcasts.
+				// FcLessOrEqual is needed for type inference (resolving polymorphic types),
+				// but it can silently accept narrowing annotations. FcCheckAnnotation catches these.
+				recordTypeCheck(acc1, FcCheckAnnotation(et, itype, name, ci));
 			}
 
 			// Record this in the type environment when we check the body


### PR DESCRIPTION
### Problem

When a Flow `switch` uses union names in cases, the desugarer previously expanded each union case into individual struct cases, duplicating the case body for every struct in the union. For nested switches over large unions, this caused **O(n×m) code explosion** — the same body was repeated dozens of times in generated Java and JavaScript output.

## Example
```flow
import server/ssql/ssql_i;

main() {
	t : STableUnion = STable(["field"], []);
	q : SSql = t;

	switch (q) {
		SValue(): {
			switch (q) {
				SSimpleValue(): {
					println("The query is a simple value: " + q.structname);
				}
				STableUnion(): {
					println("The query is a table with fields: [" + strGlue(q.fieldNames, ", ") + "]");
				}
				default: {
					println("The query is a value, but not simple: " + toString(q));
				}
			}
		}
		default: {
			println("The query is not a value: " + q.structname);
		}
	}

	println(t.fieldNames);
}
```

flowc translates this flow code to such JS code
```js
function main(){
  var t=c$F3(["field"],[]),q=t;
    (function(){var s$;switch(q._id){
    case 272:{s$=(function(){var s$;switch(q._id){
        case 272:{s$=console.log(HaxeRuntime.toString(("The query is a simple value: "+(HaxeRuntime.getStructName(q._id))), true));break;}
        case 198:{s$=console.log(HaxeRuntime.toString(("The query is a simple value: "+(HaxeRuntime.getStructName(q._id))), true));break;}
        case 248:{s$=console.log(HaxeRuntime.toString(("The query is a simple value: "+(HaxeRuntime.getStructName(q._id))), true));break;}
        case 181:{s$=console.log(HaxeRuntime.toString(("The query is a simple value: "+(HaxeRuntime.getStructName(q._id))), true));break;}
        case 228:{s$=console.log(HaxeRuntime.toString(("The query is a simple value: "+(HaxeRuntime.getStructName(q._id))), true));break;}
        case 284:{s$=console.log(HaxeRuntime.toString(("The query is a simple value: "+(HaxeRuntime.getStructName(q._id))), true));break;}
        case 152:{s$=console.log(HaxeRuntime.toString(("The query is a simple value: "+(HaxeRuntime.getStructName(q._id))), true));break;}
        case 214:{s$=console.log(HaxeRuntime.toString(("The query is a simple value: "+(HaxeRuntime.getStructName(q._id))), true));break;}
        case 211:{s$=console.log(HaxeRuntime.toString(("The query is a simple value: "+(HaxeRuntime.getStructName(q._id))), true));break;}
        case 289:{s$=console.log(HaxeRuntime.toString((("The query is a table with fields: ["+A9__strGlue(q.fieldNames,", "))+"]"), true));break;}
        case 290:{s$=console.log(HaxeRuntime.toString((("The query is a table with fields: ["+A9__strGlue(q.fieldNames,", "))+"]"), true));break;}
        default:{s$=console.log(HaxeRuntime.toString(("The query is a value, but not simple: "+A9__toString(q)), true));break;}
        }return s$;}());break;}
    case 198:{s$=(function(){var s$;switch(q._id){
        case 272:{s$=console.log(HaxeRuntime.toString(("The query is a simple value: "+(HaxeRuntime.getStructName(q._id))), true));break;}
        case 198:{s$=console.log(HaxeRuntime.toString(("The query is a simple value: "+(HaxeRuntime.getStructName(q._id))), true));break;}
        case 248:{s$=console.log(HaxeRuntime.toString(("The query is a simple value: "+(HaxeRuntime.getStructName(q._id))), true));break;}
        case 181:{s$=console.log(HaxeRuntime.toString(("The query is a simple value: "+(HaxeRuntime.getStructName(q._id))), true));break;}
        case 228:{s$=console.log(HaxeRuntime.toString(("The query is a simple value: "+(HaxeRuntime.getStructName(q._id))), true));break;}
        case 284:{s$=console.log(HaxeRuntime.toString(("The query is a simple value: "+(HaxeRuntime.getStructName(q._id))), true));break;}
        case 152:{s$=console.log(HaxeRuntime.toString(("The query is a simple value: "+(HaxeRuntime.getStructName(q._id))), true));break;}
        case 214:{s$=console.log(HaxeRuntime.toString(("The query is a simple value: "+(HaxeRuntime.getStructName(q._id))), true));break;}
        case 211:{s$=console.log(HaxeRuntime.toString(("The query is a simple value: "+(HaxeRuntime.getStructName(q._id))), true));break;}
        case 289:{s$=console.log(HaxeRuntime.toString((("The query is a table with fields: ["+A9__strGlue(q.fieldNames,", "))+"]"), true));break;}
        case 290:{s$=console.log(HaxeRuntime.toString((("The query is a table with fields: ["+A9__strGlue(q.fieldNames,", "))+"]"), true));break;}
        default:{s$=console.log(HaxeRuntime.toString(("The query is a value, but not simple: "+A9__toString(q)), true));break;}
        }return s$;}());break;}
...
```

### Solution

Introduce `FiCaseUnion` — a new IR node that preserves union-level switch cases throughout the compilation pipeline, instead of expanding them eagerly during desugaring.

```flow
FiSwitchCase ::= FiCase, FiCaseUnion;
FiCase(struct: string, argNames: [string], body: FiExp, start: int);
FiCaseUnion(union: string, structs: [string], body: FiExp, start: int);
```

### Commits

1. **Java backend: merge switch cases with shared fields using Field_ accessor interfaces** — When multiple struct cases in a switch access the same fields, merge them into a single case using `Field_` accessor interfaces instead of duplicating the body.

2. **Introduce FiCaseUnion** — Core infrastructure: new `FiSwitchCase` union type, desugar produces single `FiCaseUnion` per union case (body desugared once), type checker handles union cases, all 50+ backend and manipulation files adapted using `fiExpandSwitchCases` helper for backward compatibility.

3. **Java backend: native FiCaseUnion support** — Emits Java fall-through `case` labels for each struct in the union, with a single shared body. Uses `Field_` accessor interfaces (via `generalizeVarType` → `FiTypeFlow()`) for field access across struct types.

4. **JavaScript backend: native FiCaseUnion support** — Emits JS fall-through `case` labels similarly. Adds `fiJsSwitchCaseLabels` helper. Adapts `isIf` optimization and `>=50` case heuristic for `FiCaseUnion`.

5. **Update flowc.jar with FiCaseUnion support**

6. **Fix overlapping union/struct cases in switches** — Switches can have both a union case (e.g. `CharacterStyle()`) and a struct case for a member of that union (e.g. `SetRTL()`). Added dedup in `solve_expectations` and struct subtraction in `fc2fi` to handle overlaps.

7. **Fix type checker bugs for FiCaseUnion switch cases** — Fix union case type parameter instantiation in desugar, fix `names2unions` expansion for union names, fix `bestunion` lookup for union cases.

8. **Fix type checker: common parent union checks and union-struct narrowing** — When unnamed unions contain structs from a common parent union, suppress false type errors. Fix `FUnion ≤ FStruct` and `FStruct ≤ FUnnamedUnion` containment paths.

9. **Fix type checker: detect incompatible type annotations as errors** — Type annotations like `x : [SubType] = expr` where `expr` has type `[SuperType]` now produce errors instead of silently accepting the incompatible narrowing.

10. **Fix type checker: tyvar contamination through polymorphic calls and union case switch type** — Fix union case switch to use `unionType` instead of `varType`. Remove gl2 guard in `funifyBounded` to prevent type variable contamination through `grow_right` in non-bounded FUnifyLeft path.

11. **Fix type checker: restore gl1 guard for bounded FUnifyLeft path** — The gl1 guard in `funifyBounded` is needed for the bounded+FUnifyLeft path (fixes Maybe/Some narrowing in switch cases). Only gl2 removal was correct.

12. **Update flowc.jar**

### Key design decisions

- **Clean semantic separation**: `FiCase` = single struct with field bindings; `FiCaseUnion` = union with list of structs, no field bindings, body uses union-typed variable
- **Backward compatible**: backends that don't need native support call `fiExpandSwitchCases()` to get `[FiCase]` as before
- **No expand-then-merge**: removed the old `fiMergeExpandedUnionCases` pass that did wasteful double work (expand all cases, then try to re-merge identical bodies)

### The same example after the PR

```js
function main(){
  var t=c$F3(["field"],[]),q=t;
    (function(){var s$;switch(q._id){
    case 272:
    case 198:
    case 248:
    case 181:
    case 228:
    case 284:
    case 152:
    case 214:
    case 211:
    case 282:
    case 289:
    case 290:{s$=(function(){var s$;switch(q._id){
        case 272:
        case 198:
        case 248:
        case 181:
        case 228:
        case 284:
        case 152:
        case 214:
        case 211:{s$=console.log(HaxeRuntime.toString(("The query is a simple value: "+(HaxeRuntime.getStructName(q._id))), true));break;}
        case 289:
        case 290:{s$=console.log(HaxeRuntime.toString((("The query is a table with fields: ["+A9__strGlue(q.fieldNames,", "))+"]"), true));break;}
        default:{s$=console.log(HaxeRuntime.toString(("The query is a value, but not simple: "+A9__toString(q)), true));break;}
        }return s$;}());break;}
    default:{s$=console.log(HaxeRuntime.toString(("The query is not a value: "+(HaxeRuntime.getStructName(q._id))), true));break;}
    }return s$;}());
    return console.log(HaxeRuntime.toString(t.fieldNames, true));
}
```

### Code size reduction

`educator.js` compiled with flag `debug=1`: **61.0 MB → 59.4 MB** (−1.6 MB, **−2.7%**).

### Adding native FiCaseUnion support to other backends

Currently only Java and JS backends emit compact fall-through code for `FiCaseUnion`. All other backends (C++, bytecode, D, Lisp, ML, Nim, Wasm, Wise) use `fiExpandSwitchCases()` to expand union cases back to individual struct cases before code generation — they produce correct but unoptimized output.

To add native support to another backend, follow the Java/JS pattern:

1. In the `FiSwitch` code generation, iterate `[FiSwitchCase]` directly instead of calling `fiExpandSwitchCases`
2. Handle `FiCaseUnion` by emitting fall-through case labels for each struct in `FiCaseUnion.structs`, with the body emitted once
3. Handle `FiCase` as before (single struct with field bindings)
4. For field access in `FiCaseUnion` bodies: the switch variable has union type, so use the target language's equivalent of interface-based dispatch (Java uses `Field_` accessor interfaces; other backends may use casts to a common base type or dynamic dispatch)
