### PR TITLE
Type checker: per-tyvar polarity-aware bounds resolution

### DIFF
--- a/tools/flowc/flowc_version.flow
+++ b/tools/flowc/flowc_version.flow
@@ -2,5 +2,5 @@
 // Edit 'build-flowc' instead.
 export {
 	flowc_version = "3.0";
-	flowc_git_revision = "90bf0dd28";
+	flowc_git_revision = "cc334419f";
 }

--- a/tools/flowc/flowc_version.flow
+++ b/tools/flowc/flowc_version.flow
@@ -2,5 +2,5 @@
 // Edit 'build-flowc' instead.
 export {
 	flowc_version = "3.0";
-	flowc_git_revision = "d32716397f";
+	flowc_git_revision = "90bf0dd28";
 }

--- a/tools/flowc/typechecker/combine_types.flow
+++ b/tools/flowc/typechecker/combine_types.flow
@@ -343,7 +343,9 @@ combinePositiveAndNegative(env : FcTypeEnv, positive : FcType, negative : FcType
 									intersectSets(acc, buildSet(getTreeArrayValue(s2u, ln)))
 								});
 								if (!isEmptySet(unionParentUnions)) {
-									arrayPush([positive], negative);
+									// Common parent: polarity determines which goes first
+									if (posPolarity) arrayPush([positive], negative)
+									else arrayPush([negative], positive);
 								} else {
 									error();
 								}
@@ -351,8 +353,11 @@ combinePositiveAndNegative(env : FcTypeEnv, positive : FcType, negative : FcType
 							Some(st): {
 								// OK, we found it. Check these dudes
 								t = combinePositiveAndNegative(env, positive, st, posPolarity, onError);
-								// Both the struct and union work
-								arrayPush(t, negative);
+								// Both the struct and union work.
+								// Polarity determines ordering: covariant prefers struct (lower bound),
+								// contravariant prefers union (upper bound). tts[0] is picked by setFTyvar.
+								if (posPolarity) arrayPush(t, negative)
+								else concat([negative], t);
 							}
 						}
 					}
@@ -395,7 +400,9 @@ combinePositiveAndNegative(env : FcTypeEnv, positive : FcType, negative : FcType
 											intersectSets(acc, buildSet(getTreeArrayValue(s2u, ln)))
 										});
 										if (!isEmptySet(commonParents)) {
-											arrayPush([negative], positive);
+											// Common parent: polarity determines which goes first
+											if (posPolarity) arrayPush([negative], positive)
+											else arrayPush([positive], negative);
 										} else {
 											error();
 										}
@@ -403,8 +410,10 @@ combinePositiveAndNegative(env : FcTypeEnv, positive : FcType, negative : FcType
 									Some(st): {
 										// OK, we found it. Check these dudes
 										t = combinePositiveAndNegative(env, st, negative, posPolarity, onError);
-										// TODO: Should we just ignore the result, or do more with it?
-										arrayPush(t, positive);
+										// Polarity determines ordering: covariant prefers struct (lower bound),
+										// contravariant prefers union (upper bound). tts[0] is picked by setFTyvar.
+										if (posPolarity) arrayPush(t, positive)
+										else concat([positive], t);
 									}
 								}
 

--- a/tools/flowc/typechecker/combine_types.flow
+++ b/tools/flowc/typechecker/combine_types.flow
@@ -353,8 +353,6 @@ combinePositiveAndNegative(env : FcTypeEnv, positive : FcType, negative : FcType
 								t = combinePositiveAndNegative(env, positive, st, posPolarity, onError);
 								// Both the struct and union work
 								arrayPush(t, negative);
-
-
 							}
 						}
 					}
@@ -407,8 +405,6 @@ combinePositiveAndNegative(env : FcTypeEnv, positive : FcType, negative : FcType
 										t = combinePositiveAndNegative(env, st, negative, posPolarity, onError);
 										// TODO: Should we just ignore the result, or do more with it?
 										arrayPush(t, positive);
-
-
 									}
 								}
 

--- a/tools/flowc/typechecker/combine_types.flow
+++ b/tools/flowc/typechecker/combine_types.flow
@@ -351,8 +351,8 @@ combinePositiveAndNegative(env : FcTypeEnv, positive : FcType, negative : FcType
 							Some(st): {
 								// OK, we found it. Check these dudes
 								t = combinePositiveAndNegative(env, positive, st, posPolarity, onError);
-								// Polarity: covariant prefers struct (lower), contravariant prefers union (upper)
-								if (posPolarity) arrayPush(t, negative) else concat([negative], t);
+								// Both the struct and union work
+								arrayPush(t, negative);
 
 
 							}
@@ -405,8 +405,8 @@ combinePositiveAndNegative(env : FcTypeEnv, positive : FcType, negative : FcType
 									Some(st): {
 										// OK, we found it. Check these dudes
 										t = combinePositiveAndNegative(env, st, negative, posPolarity, onError);
-										// Polarity: covariant prefers struct (lower), contravariant prefers union (upper)
-										if (posPolarity) arrayPush(t, positive) else concat([positive], t);
+										// TODO: Should we just ignore the result, or do more with it?
+										arrayPush(t, positive);
 
 
 									}

--- a/tools/flowc/typechecker/combine_types.flow
+++ b/tools/flowc/typechecker/combine_types.flow
@@ -6,7 +6,8 @@ export {
 	// For anonymous unions. Give us all the possible results. Error is only called if there is no solution
 	combineTypenames(env : FcTypeEnv, named : [FcType], onError : (string) -> void) -> [FcType];
 
-	combinePositiveAndNegative(env : FcTypeEnv, positive : FcType, negative : FcType, onError : (string) -> void) -> [FcType];
+	// posPolarity: true = covariant (prefer lower/struct), false = contravariant (prefer upper/union)
+	combinePositiveAndNegative(env : FcTypeEnv, positive : FcType, negative : FcType, posPolarity : bool, onError : (string) -> void) -> [FcType];
 
 	setTyvar(env : FcTypeEnv, tyvarid : int, type : FcType) -> void;
 }
@@ -196,7 +197,7 @@ getFcTypePars(t : FcType) -> [FcType] {
 
 
 
-combinePositiveAndNegative(env : FcTypeEnv, positive : FcType, negative : FcType, onError : (string) -> void) -> [FcType] {
+combinePositiveAndNegative(env : FcTypeEnv, positive : FcType, negative : FcType, posPolarity : bool, onError : (string) -> void) -> [FcType] {
 	if (isSameFcType(env, positive, negative, false)) [positive]
 	else {
 		error = \ -> {
@@ -221,7 +222,7 @@ combinePositiveAndNegative(env : FcTypeEnv, positive : FcType, negative : FcType
 			FcTypeArray(a1, __): {
 				switch (negative) {
 					FcTypeArray(a2, i2): {
-						ats = combinePositiveAndNegative(env, a1, a2, onError);
+						ats = combinePositiveAndNegative(env, a1, a2, posPolarity, onError);
 						map(ats, \at -> FcTypeArray(at, i2));
 					}
 					FcTypeVar(tid2, __): {
@@ -236,14 +237,14 @@ combinePositiveAndNegative(env : FcTypeEnv, positive : FcType, negative : FcType
 			FcTypeFunction(a1, r1, i1): {
 				switch (negative) {
 					FcTypeFunction(a2, r2, __): {
-						rts = combinePositiveAndNegative(env, r1, r2, onError);
+						rts = combinePositiveAndNegative(env, r1, r2, posPolarity, onError);
 						map(rts, \rt -> {
 							// Combine the arguments and so on
 							FcTypeFunction(
 								mapi(a1, \i, arg -> {
 									FcFunArg(
 										arg.name,
-										combinePositiveAndNegative(env, a2[i].type, arg.type, onError)[0],
+										combinePositiveAndNegative(env, a2[i].type, arg.type, !posPolarity, onError)[0],
 									)
 								}),
 								rt,
@@ -264,7 +265,7 @@ combinePositiveAndNegative(env : FcTypeEnv, positive : FcType, negative : FcType
 			FcTypeRef(r1, __): {
 				switch (negative) {
 					FcTypeRef(r2, i2): {
-						rts = combinePositiveAndNegative(env, r1, r2, onError);
+						rts = combinePositiveAndNegative(env, r1, r2, posPolarity, onError);
 						map(rts, \rt -> FcTypeRef(rt, i2));
 					}
 					FcTypeFlow(__): [negative];
@@ -293,7 +294,7 @@ combinePositiveAndNegative(env : FcTypeEnv, positive : FcType, negative : FcType
 					FcTypeStruct(ns, stp, sargs, si): {
 						if (ps == ns && length(ptp) == length(stp)) {
 							pargs_combined = filtermapi(pargs, \i, parg -> {
-								comb = combinePositiveAndNegative(env, parg.type, sargs[i].type, onError);
+								comb = combinePositiveAndNegative(env, parg.type, sargs[i].type, posPolarity, onError);
 								if (comb == []) None() else {
 									Some(FcStructArg(parg.name, comb[0], parg.ismutable))
 								}
@@ -303,7 +304,7 @@ combinePositiveAndNegative(env : FcTypeEnv, positive : FcType, negative : FcType
 									ns,
 									mapi(ptp, \i, pt -> {
 										if (i < length(stp)) {
-											ct = combinePositiveAndNegative(env, pt, stp[i], onError);
+											ct = combinePositiveAndNegative(env, pt, stp[i], posPolarity, onError);
 											if (ct != []) ct[0] else pt
 										} else pt
 									}),
@@ -349,9 +350,11 @@ combinePositiveAndNegative(env : FcTypeEnv, positive : FcType, negative : FcType
 							}
 							Some(st): {
 								// OK, we found it. Check these dudes
-								t = combinePositiveAndNegative(env, positive, st, onError);
-								// Both the struct and union work
-								arrayPush(t, negative);
+								t = combinePositiveAndNegative(env, positive, st, posPolarity, onError);
+								// Polarity: covariant prefers struct (lower), contravariant prefers union (upper)
+								if (posPolarity) arrayPush(t, negative) else concat([negative], t);
+
+
 							}
 						}
 					}
@@ -359,7 +362,7 @@ combinePositiveAndNegative(env : FcTypeEnv, positive : FcType, negative : FcType
 						i = getFcNamedType(env, env.program.acc.tyvarIdGroup, negative);
 						switch (i) {
 							FcTypeName(__, __, __): def();
-							default: combinePositiveAndNegative(env, positive, i, onError);
+							default: combinePositiveAndNegative(env, positive, i, posPolarity, onError);
 						}
 					}
 					FcTypeFlow(__): [negative];
@@ -401,9 +404,11 @@ combinePositiveAndNegative(env : FcTypeEnv, positive : FcType, negative : FcType
 									}
 									Some(st): {
 										// OK, we found it. Check these dudes
-										t = combinePositiveAndNegative(env, st, negative, onError);
-										// TODO: Should we just ignore the result, or do more with it?
-										arrayPush(t, positive);
+										t = combinePositiveAndNegative(env, st, negative, posPolarity, onError);
+										// Polarity: covariant prefers struct (lower), contravariant prefers union (upper)
+										if (posPolarity) arrayPush(t, positive) else concat([positive], t);
+
+
 									}
 								}
 
@@ -414,14 +419,14 @@ combinePositiveAndNegative(env : FcTypeEnv, positive : FcType, negative : FcType
 						i = getFcNamedType(env, env.program.acc.tyvarIdGroup, negative);
 						switch (i) {
 							FcTypeName(__, __, __): def();
-							default: combinePositiveAndNegative(env, positive, i, onError);
+							default: combinePositiveAndNegative(env, positive, i, posPolarity, onError);
 						}
 					}
 					FcTypeUnion(nun, ntp, ntn, ni): {
 						if (pun == nun && pun != "") {
 							tps = mapi(ntp, \i, tp -> {
 								if (i < length(ptp)) {
-									combinePositiveAndNegative(env, ptp[i], tp, onError)[0]
+									combinePositiveAndNegative(env, ptp[i], tp, posPolarity, onError)[0]
 								} else tp
 							});
 							[FcTypeUnion(nun, tps, ntn, pi)];
@@ -467,7 +472,7 @@ combinePositiveAndNegative(env : FcTypeEnv, positive : FcType, negative : FcType
 				i = getFcNamedType(env, env.program.acc.tyvarIdGroup, positive);
 				switch (i) {
 					FcTypeName(__, __, __): def();
-					default: combinePositiveAndNegative(env, i, negative, onError);
+					default: combinePositiveAndNegative(env, i, negative, posPolarity, onError);
 				}
 			}
 			FcTypeVoid(__): {

--- a/tools/flowc/typechecker/fautomaton.flow
+++ b/tools/flowc/typechecker/fautomaton.flow
@@ -21,6 +21,7 @@ buildFGraph(env : FEnv) -> FGraphEnv {
 			graph.env.tyvars,
 			makeTree(),	// We have to clear out the seen relations as well, so we will re-record any dependencies not resolved. See test 71
 			if (true) graph.env.tyvarDeps else makeTree(),
+			graph.env.autoGrownUpperBounds,
 		),
 		graph.graph,
 		graph.type2state,

--- a/tools/flowc/typechecker/fautomaton.flow
+++ b/tools/flowc/typechecker/fautomaton.flow
@@ -21,7 +21,7 @@ buildFGraph(env : FEnv) -> FGraphEnv {
 			graph.env.tyvars,
 			makeTree(),	// We have to clear out the seen relations as well, so we will re-record any dependencies not resolved. See test 71
 			if (true) graph.env.tyvarDeps else makeTree(),
-			graph.env.autoGrownUpperBounds,
+			graph.env.tyvarPolarity,
 		),
 		graph.graph,
 		graph.type2state,

--- a/tools/flowc/typechecker/ftype.flow
+++ b/tools/flowc/typechecker/ftype.flow
@@ -52,12 +52,12 @@ export {
 		// Unifications, joins, intersections
 		tyvarDeps : Tree<FType, [FUnifyType]>,
 
-		// Tyvars whose upper bound originated from auto-growth (FGrowRight: struct → parent union),
-		// as opposed to an explicit constraint. Used in setFTyvar to decide
-		// whether to pick the upper or lower bound when resolving FBounded.
-		// If a tyvar is in this set, prefer lower bound (most specific actual type).
-		// Otherwise prefer upper bound (most general required type).
-		autoGrownUpperBounds : Set<int>
+		// Per-tyvar polarity collected from constraint positions.
+		// +1 = covariant only (output/positive positions) → prefer lower bound
+		// -1 = contravariant only (input/negative positions) → prefer upper bound
+		//  0 = invariant (both positions) → prefer lower bound (safe default)
+		// Populated before finalization by collectTyvarPolarity.
+		tyvarPolarity : Tree<int, int>
 	);
 
 	FUnifyType(kind : FUnification, type : FType);

--- a/tools/flowc/typechecker/ftype.flow
+++ b/tools/flowc/typechecker/ftype.flow
@@ -50,7 +50,14 @@ export {
 		seen : Tree<Triple<FType, FUnification, FType>, FType>,
 
 		// Unifications, joins, intersections
-		tyvarDeps : Tree<FType, [FUnifyType]>
+		tyvarDeps : Tree<FType, [FUnifyType]>,
+
+		// Tyvars whose upper bound originated from auto-growth (FGrowRight: struct → parent union),
+		// as opposed to an explicit constraint. Used in setFTyvar to decide
+		// whether to pick the upper or lower bound when resolving FBounded.
+		// If a tyvar is in this set, prefer lower bound (most specific actual type).
+		// Otherwise prefer upper bound (most general required type).
+		autoGrownUpperBounds : Set<int>
 	);
 
 	FUnifyType(kind : FUnification, type : FType);

--- a/tools/flowc/typechecker/ftype2fctype.flow
+++ b/tools/flowc/typechecker/ftype2fctype.flow
@@ -29,10 +29,11 @@ setFTyvar(env : FEnv, tyvar : int, type : FType, onError : (string) -> void) -> 
 		false;
 	} else {
 		// fcPrintln("  set α" + i2s(tyvar) + " from " + ftype2string(env, type));
-		// Use negative polarity (false) to prefer upper bound (most general type)
-		// when resolving FBounded{struct .. union}. The upper bound satisfies all
-		// constraints since the tyvar may appear in both covariant and contravariant positions.
-		tts = ftype2fctype(env, type, makeSet1(tyvar), false, onError);
+		// If the tyvar's upper bound came from auto-growth (FGrowRight: struct → parent union),
+		// prefer lower bound (most specific actual type). Otherwise prefer upper bound
+		// (most general type satisfying all real constraints).
+		isAutoGrown = containsSet(env.autoGrownUpperBounds, tyvar);
+		tts = ftype2fctype(env, type, makeSet1(tyvar), isAutoGrown, onError);
 		n = length(tts);
 		if (n >= 1) {
 			if (false && n > 1) {

--- a/tools/flowc/typechecker/ftype2fctype.flow
+++ b/tools/flowc/typechecker/ftype2fctype.flow
@@ -32,8 +32,7 @@ setFTyvar(env : FEnv, tyvar : int, type : FType, onError : (string) -> void) -> 
 		// If the tyvar's upper bound came from auto-growth (FGrowRight: struct → parent union),
 		// prefer lower bound (most specific actual type). Otherwise prefer upper bound
 		// (most general type satisfying all real constraints).
-		isAutoGrown = containsSet(env.autoGrownUpperBounds, tyvar);
-		tts = ftype2fctype(env, type, makeSet1(tyvar), isAutoGrown, onError);
+		tts = ftype2fctype(env, type, makeSet1(tyvar), true, onError);
 		n = length(tts);
 		if (n >= 1) {
 			if (false && n > 1) {

--- a/tools/flowc/typechecker/ftype2fctype.flow
+++ b/tools/flowc/typechecker/ftype2fctype.flow
@@ -6,7 +6,9 @@ export {
 	setFTyvar(env : FEnv, tyvar : int, type : FType, onError : (string) -> void) -> bool;
 
 	// Convert FType to FcType. Returns an array because some types can resolve to multiple alternatives.
-	ftype2fctype(env : FEnv, type : FType, seen : Set<int>, onError : (string) -> void) -> [FcType];
+	// positive = true means covariant position (output), false means contravariant (input).
+	// Used to resolve FBounded: covariant picks lower bound, contravariant picks upper bound.
+	ftype2fctype(env : FEnv, type : FType, seen : Set<int>, positive : bool, onError : (string) -> void) -> [FcType];
 }
 
 setFTyvar(env : FEnv, tyvar : int, type : FType, onError : (string) -> void) -> bool {
@@ -27,7 +29,10 @@ setFTyvar(env : FEnv, tyvar : int, type : FType, onError : (string) -> void) -> 
 		false;
 	} else {
 		// fcPrintln("  set α" + i2s(tyvar) + " from " + ftype2string(env, type));
-		tts = ftype2fctype(env, type, makeSet1(tyvar), onError);
+		// Use negative polarity (false) to prefer upper bound (most general type)
+		// when resolving FBounded{struct .. union}. The upper bound satisfies all
+		// constraints since the tyvar may appear in both covariant and contravariant positions.
+		tts = ftype2fctype(env, type, makeSet1(tyvar), false, onError);
 		n = length(tts);
 		if (n >= 1) {
 			if (false && n > 1) {
@@ -45,7 +50,7 @@ setFTyvar(env : FEnv, tyvar : int, type : FType, onError : (string) -> void) -> 
 	}
 }
 
-ftype2fctype(env : FEnv, type : FType, seen : Set<int>, onError : (string) -> void) -> [FcType] {
+ftype2fctype(env : FEnv, type : FType, seen : Set<int>, positive : bool, onError : (string) -> void) -> [FcType] {
 	// fcPrintln("  ... " + ftype2string(env, type));
 	in = FcInfo2(0, 0);
 	switch (type : FType) {
@@ -64,7 +69,7 @@ ftype2fctype(env : FEnv, type : FType, seen : Set<int>, onError : (string) -> vo
 				switch (motype) {
 					None(): [FcTypeVar(id, in)];
 					Some(ot): {
-						ftype2fctype(env, ot, insertSet(seen, id), onError);
+						ftype2fctype(env, ot, insertSet(seen, id), positive, onError);
 					}
 				}
 			}
@@ -108,26 +113,28 @@ ftype2fctype(env : FEnv, type : FType, seen : Set<int>, onError : (string) -> vo
 			}
 		}
 		FFunction(args, rt): {
-			tt = ftype2fctype(env, rt, seen, onError);
+			// Return type keeps same polarity
+			tt = ftype2fctype(env, rt, seen, positive, onError);
 			if (tt == []) {
 				onError("Could not extract a function return type from " + ftype2string(env, type));
 				[]
 			} else {
 				[FcTypeFunction(
-					map(ftypes2fctypes(env, args, seen, onError), \t -> FcFunArg("", t)),
+					// Function arguments: flip polarity (contravariant)
+					map(ftypes2fctypes(env, args, seen, !positive, onError), \t -> FcFunArg("", t)),
 					tt[0],
 					in
 				)];
 			}
 		}
 		FUnion(name, args): {
-			[FcTypeName(name, ftypes2fctypes(env, args, seen, onError), in)];
+			[FcTypeName(name, ftypes2fctypes(env, args, seen, positive, onError), in)];
 		}
 		FStruct(name, args): {
-			[FcTypeName(name, ftypes2fctypes(env, args, seen, onError), in)];
+			[FcTypeName(name, ftypes2fctypes(env, args, seen, positive, onError), in)];
 		}
 		FArray(at): {
-			a = ftype2fctype(env, at, seen, onError);
+			a = ftype2fctype(env, at, seen, positive, onError);
 			if (a == []) {
 				onError("Could not extract an array type from " + ftype2string(env, type));
 			}
@@ -136,8 +143,8 @@ ftype2fctype(env : FEnv, type : FType, seen : Set<int>, onError : (string) -> vo
 			})
 		}
 		FRef(rtype, wtype): {
-			rt = ftype2fctype(env, rtype, seen, onError);
-			// wt = ftype2fctype(env, wtype, seen, onError);
+			rt = ftype2fctype(env, rtype, seen, positive, onError);
+			// wt = ftype2fctype(env, wtype, seen, positive, onError);
 			// TODO: Combine
 			if (rt == []) {
 				onError("Could not extract a ref type from " + ftype2string(env, type));
@@ -147,7 +154,7 @@ ftype2fctype(env : FEnv, type : FType, seen : Set<int>, onError : (string) -> vo
 			})
 		}
 		FUnnamedUnion(structs): {
-			types = ftypes2fctypes(env, structs, seen, onError);
+			types = ftypes2fctypes(env, structs, seen, positive, onError);
 
 			// TODO: We should roll our own, which can also consolidate the typars
 			ct = combineTypenames(env.env, types, onError);
@@ -157,9 +164,9 @@ ftype2fctype(env : FEnv, type : FType, seen : Set<int>, onError : (string) -> vo
 			ct
 		}
 		FBounded(lower, upper): {
-			if (upper == FTopBottom()) ftype2fctype(env, lower, seen, onError)
-			else if (lower == FTopBottom()) ftype2fctype(env, upper, seen, onError)
-			else frange2fctype(env, lower, upper, seen, onError);
+			if (upper == FTopBottom()) ftype2fctype(env, lower, seen, positive, onError)
+			else if (lower == FTopBottom()) ftype2fctype(env, upper, seen, positive, onError)
+			else frange2fctype(env, lower, upper, seen, positive, onError);
 		}
 		FTopBottom(): {
 			onError("Did not expect top or bottom here");
@@ -168,9 +175,9 @@ ftype2fctype(env : FEnv, type : FType, seen : Set<int>, onError : (string) -> vo
 	}
 }
 
-ftypes2fctypes(env: FEnv, args : [FType], seen : Set<int>, onError : (string) -> void) -> [FcType] {
+ftypes2fctypes(env: FEnv, args : [FType], seen : Set<int>, positive : bool, onError : (string) -> void) -> [FcType] {
 	fold(args, [], \acc, arg -> {
-		t = ftype2fctype(env, arg, seen, onError);
+		t = ftype2fctype(env, arg, seen, positive, onError);
 		if (t == []) {
 			onError("Could not get type for " + ftype2string(env, arg));
 			acc;
@@ -186,12 +193,12 @@ ftypes2fctypes(env: FEnv, args : [FType], seen : Set<int>, onError : (string) ->
 }
 
 
-frange2fctype(env : FEnv, output : FType, input : FType, seen : Set<int>, 
-		onError : (string) -> void) -> [FcType] {
+frange2fctype(env : FEnv, output : FType, input : FType, seen : Set<int>,
+		positive : bool, onError : (string) -> void) -> [FcType] {
 	lowererror = ref "";
-	lower = ftype2fctype(env, output, seen, \e -> lowererror := e);
+	lower = ftype2fctype(env, output, seen, positive, \e -> lowererror := e);
 	uppererror = ref "";
-	upper = ftype2fctype(env, input, seen, \e -> uppererror := e);
+	upper = ftype2fctype(env, input, seen, positive, \e -> uppererror := e);
 	if (lower == []) {
 		if (^uppererror == "") upper
 		else {
@@ -216,7 +223,7 @@ frange2fctype(env : FEnv, output : FType, input : FType, seen : Set<int>,
 				err2 = ref [];
 				rr = fold(combinations, [], \acc, com : [FcType] -> {
 					err = ref "";
-					ct = combinePositiveAndNegative(env.env, com[0], com[1], \e -> err := e);
+					ct = combinePositiveAndNegative(env.env, com[0], com[1], positive, \e -> err := e);
 					if (^err != "") {
 						err2 := arrayPush(^err2, ^err);
 						acc

--- a/tools/flowc/typechecker/ftype2fctype.flow
+++ b/tools/flowc/typechecker/ftype2fctype.flow
@@ -28,11 +28,12 @@ setFTyvar(env : FEnv, tyvar : int, type : FType, onError : (string) -> void) -> 
 		onError("Recursive type not allowed: " + ftype2string(env, type));
 		false;
 	} else {
-		// fcPrintln("  set α" + i2s(tyvar) + " from " + ftype2string(env, type));
-		// If the tyvar's upper bound came from auto-growth (FGrowRight: struct → parent union),
-		// prefer lower bound (most specific actual type). Otherwise prefer upper bound
-		// (most general type satisfying all real constraints).
-		tts = ftype2fctype(env, type, makeSet1(tyvar), true, onError);
+		// Use per-tyvar polarity: +1 (covariant) → prefer lower bound (positive=true)
+		// -1 (contravariant) → prefer upper bound (positive=false)
+		// 0 or unknown → prefer lower bound (safe default, positive=true)
+		tyvarPol = lookupTreeDef(env.tyvarPolarity, tyvar, 0);
+		positive = tyvarPol >= 0;  // covariant or invariant → true; contravariant → false
+		tts = ftype2fctype(env, type, makeSet1(tyvar), positive, onError);
 		n = length(tts);
 		if (n >= 1) {
 			if (false && n > 1) {
@@ -69,7 +70,10 @@ ftype2fctype(env : FEnv, type : FType, seen : Set<int>, positive : bool, onError
 				switch (motype) {
 					None(): [FcTypeVar(id, in)];
 					Some(ot): {
-						ftype2fctype(env, ot, insertSet(seen, id), positive, onError);
+						// Use this tyvar's own polarity for resolving its type
+						tyvarPol = lookupTreeDef(env.tyvarPolarity, id, 0);
+						idPositive = tyvarPol >= 0;
+						ftype2fctype(env, ot, insertSet(seen, id), idPositive, onError);
 					}
 				}
 			}

--- a/tools/flowc/typechecker/ftype_basic.flow
+++ b/tools/flowc/typechecker/ftype_basic.flow
@@ -281,8 +281,9 @@ setFTypeVar(env : FEnv, id : int, type : FType) -> FEnv {
 			env.verbose,
 			setTree(env.tyvars, id, type),
 			env.seen,
-			env.tyvarDeps
-		);	
+			env.tyvarDeps,
+			env.autoGrownUpperBounds
+		);
 	}
 }
 

--- a/tools/flowc/typechecker/ftype_basic.flow
+++ b/tools/flowc/typechecker/ftype_basic.flow
@@ -282,7 +282,7 @@ setFTypeVar(env : FEnv, id : int, type : FType) -> FEnv {
 			setTree(env.tyvars, id, type),
 			env.seen,
 			env.tyvarDeps,
-			env.autoGrownUpperBounds
+			env.tyvarPolarity
 		);
 	}
 }

--- a/tools/flowc/typechecker/ftype_finalize.flow
+++ b/tools/flowc/typechecker/ftype_finalize.flow
@@ -551,6 +551,15 @@ buildFTyvarInfos(env : FcTypeEnvLocal) -> Tree<int, [Pair<string, FcInfo2>]> {
 					treePushToArrayUnique(acc2, tv, Pair(desc, info))
 				});
 			}
+			FcGrowToFit(e1, e2, d, info, ex): {
+				tyvars1 = collectFcTyvars(env, e1, makeSet());
+				tyvars = collectFcTyvars(env, e2, tyvars1);
+				desc = d + " (" + fcexpDescription(ex) + ")";
+
+				foldSet(tyvars, acc, \acc2, tv -> {
+					treePushToArrayUnique(acc2, tv, Pair(desc, info))
+				});
+			}
 			FcExpectField(field, ftype, t, info, ex): {
 				tyvars1 = collectFcTyvars(env, ftype, makeSet());
 				tyvars = collectFcTyvars(env, t, tyvars1);
@@ -612,7 +621,7 @@ checkOneAnnotation(name : string, pos : FcPosition, env : FcTypeEnv, fenv : FEnv
 	exprFType = fctype2ftype(env, fenv.tyvarIdGroup, exprType);
 	// Convert back to FcType using ftype2fctype which resolves tyvars and finds named unions
 	errIgnore = \__ -> {};
-	exprFcTypes = ftype2fctype(fenv, exprFType, makeSet(), errIgnore);
+	exprFcTypes = ftype2fctype(fenv, exprFType, makeSet(), true, errIgnore);
 
 	if (exprFcTypes != []) {
 		exprFcType = exprFcTypes[0];

--- a/tools/flowc/typechecker/ftype_finalize.flow
+++ b/tools/flowc/typechecker/ftype_finalize.flow
@@ -204,7 +204,7 @@ clearSeen(env : FEnv) -> FEnv {
 		env.tyvars,
 		makeTree(),
 		env.tyvarDeps,
-		env.autoGrownUpperBounds,
+		env.tyvarPolarity,
 	);
 }
 
@@ -527,7 +527,7 @@ updateFTyvar(env : FEnv, tyvar : int, type : FType, explain : () -> string) -> F
 			nt,
 			env.seen,
 			env.tyvarDeps,
-			env.autoGrownUpperBounds,
+			env.tyvarPolarity,
 		)
 	}
 }

--- a/tools/flowc/typechecker/ftype_finalize.flow
+++ b/tools/flowc/typechecker/ftype_finalize.flow
@@ -204,6 +204,7 @@ clearSeen(env : FEnv) -> FEnv {
 		env.tyvars,
 		makeTree(),
 		env.tyvarDeps,
+		env.autoGrownUpperBounds,
 	);
 }
 
@@ -526,6 +527,7 @@ updateFTyvar(env : FEnv, tyvar : int, type : FType, explain : () -> string) -> F
 			nt,
 			env.seen,
 			env.tyvarDeps,
+			env.autoGrownUpperBounds,
 		)
 	}
 }

--- a/tools/flowc/typechecker/ftype_solve.flow
+++ b/tools/flowc/typechecker/ftype_solve.flow
@@ -103,7 +103,7 @@ ftypeSolve(name : string, tyvarIdGroup : IdGroup, pos : FcPosition, env : FcType
 		tyvarIdGroup, 
 		if (^(env.local.debugTyping) > 0 || getConfigParameter(env.program.acc.config.config, "verbose") == name) 3 else env.program.acc.config.verbose, 
 		typars, makeTree(), makeTree(),
-		makeSet()
+		makeTree()
 	);
 
 	if (be.verbose >= 2)  {
@@ -179,7 +179,10 @@ ftypeSolve(name : string, tyvarIdGroup : IdGroup, pos : FcPosition, env : FcType
 		}
 		re;
 	});
-	be2;
+
+	// Collect per-tyvar polarity from constraint positions
+	polarity = collectTyvarPolarity(expects, env);
+	FEnv(be2 with tyvarPolarity = polarity);
 }
 
 unifyType(env : FEnv, output : FType, input : FType, kind : FUnification, onError : (string) -> void) -> FEnvType {
@@ -205,13 +208,13 @@ unifyType(env : FEnv, output : FType, input : FType, kind : FUnification, onErro
 				}
 				// debugTydeps(env);
 
-				env2 = FEnv(env.env, env.tyvarIdGroup, env.verbose, env.tyvars, seen, env.tyvarDeps, env.autoGrownUpperBounds);
+				env2 = FEnv(env.env, env.tyvarIdGroup, env.verbose, env.tyvars, seen, env.tyvarDeps, env.tyvarPolarity);
 
 				rt : FEnvType = if (output == input) FEnvType(env2, output) else unifyAndRecurse(env2, output, input, kind, onError);
 
 				// Now, set the real type in the cache
 				seen2 = setTree(rt.env.seen, tr, rt.type);
-				env3 = FEnv(rt.env.env, rt.env.tyvarIdGroup, rt.env.verbose, rt.env.tyvars, seen2, rt.env.tyvarDeps, rt.env.autoGrownUpperBounds);
+				env3 = FEnv(rt.env.env, rt.env.tyvarIdGroup, rt.env.verbose, rt.env.tyvars, seen2, rt.env.tyvarDeps, rt.env.tyvarPolarity);
 
 				if (env.verbose >= 3)  {
 					printDedent(env.env, "Gave " + ftype2string(env3, rt.type));
@@ -668,17 +671,7 @@ growRightTyvar(env : FEnv, id : int, type : FType, left : bool, recordDep : bool
 			righty = if (left) type else FTypeVar(id);
 
 			nenv0 = setFTypeVar(resenv, id, restype);
-			// FGrowRight creates upper bounds from auto-growth (struct → parent union).
-			// Mark these so setFTyvar prefers the lower (actual) bound, not the grown upper.
-			nenv0b = switch (restype) {
-				FBounded(__, upper): {
-					if (upper != FTopBottom()) {
-						FEnv(nenv0 with autoGrownUpperBounds = insertSet(nenv0.autoGrownUpperBounds, id))
-					} else nenv0;
-				}
-				default: nenv0;
-			};
-			nenv = if (recordDep) addTyvarDependency(nenv0b, lefty, kind, righty) else nenv0b;
+			nenv = if (recordDep) addTyvarDependency(nenv0, lefty, kind, righty) else nenv0;
 			FEnvType(
 				nenv,
 				righty
@@ -771,7 +764,106 @@ addTyvarDependency(env : FEnv, left : FType, kind : FUnification, right : FType)
 			env.tyvars,
 			env.seen,
 			setTree(env.tyvarDeps, left, arrayPush(deps, ut)),
-			env.autoGrownUpperBounds
+			env.tyvarPolarity
 		);
+	}
+}
+
+// Collect per-tyvar polarity from the constraint positions.
+// Walks all FcLessOrEqual/FcGrowToFit constraints:
+//   output position → covariant (+1)
+//   input position  → contravariant (-1)
+// Function arg positions flip polarity. Ref positions make invariant (0).
+// If a tyvar appears in both covariant and contravariant positions, it becomes invariant (0).
+collectTyvarPolarity(expects : List<FcTypeExpect>, env : FcTypeEnv) -> Tree<int, int> {
+	foldList(expects, makeTree(), \acc, e -> {
+		switch (e : FcTypeExpect) {
+			FcLessOrEqual(output, input, __, __, __): {
+				re1 = getResolvedFcType(env.local, output);
+				re2 = getResolvedFcType(env.local, input);
+				acc1 = collectFcTypePolarity(re1, 1, acc);  // output = covariant
+				collectFcTypePolarity(re2, -1, acc1);         // input = contravariant
+			}
+			FcGrowToFit(output, input, __, __, __): {
+				re1 = getResolvedFcType(env.local, output);
+				re2 = getResolvedFcType(env.local, input);
+				acc1 = collectFcTypePolarity(re1, 1, acc);
+				collectFcTypePolarity(re2, -1, acc1);
+			}
+			FcVerifyType(e1, e2, __, __, __): {
+				// Verify uses both directions, so both are invariant
+				re1 = getResolvedFcType(env.local, e1);
+				re2 = getResolvedFcType(env.local, e2);
+				acc1 = collectFcTypePolarity(re1, 0, acc);
+				collectFcTypePolarity(re2, 0, acc1);
+			}
+			FcExpectField(__, fieldType, t, __, __): {
+				// Field access: t is covariant, fieldType is covariant
+				rt = getResolvedFcType(env.local, t);
+				rf = getResolvedFcType(env.local, fieldType);
+				acc1 = collectFcTypePolarity(rt, 1, acc);
+				collectFcTypePolarity(rf, 1, acc1);
+			}
+			FcSetMutableField(struct, __, ftype, __): {
+				// Mutable set: struct covariant, ftype contravariant
+				rs = getResolvedFcType(env.local, struct);
+				rf = getResolvedFcType(env.local, ftype);
+				acc1 = collectFcTypePolarity(rs, 1, acc);
+				collectFcTypePolarity(rf, -1, acc1);
+			}
+		}
+	});
+}
+
+// Walk an FcType, collecting tyvar polarities.
+// polarity: +1 = covariant, -1 = contravariant, 0 = invariant
+collectFcTypePolarity(type : FcType, polarity : int, acc : Tree<int, int>) -> Tree<int, int> {
+	switch (type) {
+		FcTypeVar(id, __): mergeTyvarPolarity(acc, id, polarity);
+		FcTypeArray(t, __): collectFcTypePolarity(t, polarity, acc);
+		FcTypeFunction(args, returnType, __): {
+			// Args are contravariant (flip polarity), return is covariant (keep)
+			acc1 = fold(args, acc, \a, arg -> collectFcTypePolarity(arg.type, -polarity, a));
+			collectFcTypePolarity(returnType, polarity, acc1);
+		}
+		FcTypeRef(t, __): {
+			// Refs are both read and written, so invariant
+			collectFcTypePolarity(t, 0, acc);
+		}
+		FcTypeName(__, typeparameters, __): {
+			fold(typeparameters, acc, \a, tp -> collectFcTypePolarity(tp, polarity, a));
+		}
+		FcTypeStruct(__, typars, args, __): {
+			acc1 = fold(typars, acc, \a, tp -> collectFcTypePolarity(tp, polarity, a));
+			fold(args, acc1, \a, arg -> {
+				if (arg.ismutable) collectFcTypePolarity(arg.type, 0, a)
+				else collectFcTypePolarity(arg.type, polarity, a)
+			});
+		}
+		FcTypeUnion(__, typeparameters, __, __): {
+			fold(typeparameters, acc, \a, tp -> collectFcTypePolarity(tp, polarity, a));
+		}
+		FcTypeParameter(__, __): acc;
+		// Base types have no tyvars
+		FcTypeVoid(__): acc;
+		FcTypeBool(__): acc;
+		FcTypeInt(__): acc;
+		FcTypeDouble(__): acc;
+		FcTypeString(__): acc;
+		FcTypeNative(__): acc;
+		FcTypeFlow(__): acc;
+	}
+}
+
+// Merge a polarity observation for a tyvar.
+// If the tyvar already has the same polarity, keep it.
+// If it has the opposite polarity (or either is 0), set to 0 (invariant).
+mergeTyvarPolarity(acc : Tree<int, int>, id : int, polarity : int) -> Tree<int, int> {
+	switch (lookupTree(acc, id)) {
+		None(): setTree(acc, id, polarity);
+		Some(existing): {
+			if (existing == polarity) acc
+			else setTree(acc, id, 0);  // conflicting or invariant → invariant
+		}
 	}
 }

--- a/tools/flowc/typechecker/ftype_solve.flow
+++ b/tools/flowc/typechecker/ftype_solve.flow
@@ -138,6 +138,11 @@ ftypeSolve(name : string, tyvarIdGroup : IdGroup, pos : FcPosition, env : FcType
 				re2 = getResolvedFcType(env.local, e2);
 				funify(acc, re1, re2, info, FUnifyLeft(), \ -> d + ": " + fcexpDescription(ex));
 			}
+			FcGrowToFit(e1, e2, d, info, ex): {
+				re1 = getResolvedFcType(env.local, e1);
+				re2 = getResolvedFcType(env.local, e2);
+				funify(acc, re1, re2, info, FGrowRight(), \ -> d + ": " + fcexpDescription(ex));
+			}
 			FcVerifyType(e1, e2, d, info, ex): {
 				re1 = getResolvedFcType(env.local, e1);
 				re2 = getResolvedFcType(env.local, e2);

--- a/tools/flowc/typechecker/ftype_solve.flow
+++ b/tools/flowc/typechecker/ftype_solve.flow
@@ -102,7 +102,8 @@ ftypeSolve(name : string, tyvarIdGroup : IdGroup, pos : FcPosition, env : FcType
 		env, 
 		tyvarIdGroup, 
 		if (^(env.local.debugTyping) > 0 || getConfigParameter(env.program.acc.config.config, "verbose") == name) 3 else env.program.acc.config.verbose, 
-		typars, makeTree(), makeTree()
+		typars, makeTree(), makeTree(),
+		makeSet()
 	);
 
 	if (be.verbose >= 2)  {
@@ -204,13 +205,13 @@ unifyType(env : FEnv, output : FType, input : FType, kind : FUnification, onErro
 				}
 				// debugTydeps(env);
 
-				env2 = FEnv(env.env, env.tyvarIdGroup, env.verbose, env.tyvars, seen, env.tyvarDeps);
+				env2 = FEnv(env.env, env.tyvarIdGroup, env.verbose, env.tyvars, seen, env.tyvarDeps, env.autoGrownUpperBounds);
 
 				rt : FEnvType = if (output == input) FEnvType(env2, output) else unifyAndRecurse(env2, output, input, kind, onError);
 
 				// Now, set the real type in the cache
 				seen2 = setTree(rt.env.seen, tr, rt.type);
-				env3 = FEnv(rt.env.env, rt.env.tyvarIdGroup, rt.env.verbose, rt.env.tyvars, seen2, rt.env.tyvarDeps);
+				env3 = FEnv(rt.env.env, rt.env.tyvarIdGroup, rt.env.verbose, rt.env.tyvars, seen2, rt.env.tyvarDeps, rt.env.autoGrownUpperBounds);
 
 				if (env.verbose >= 3)  {
 					printDedent(env.env, "Gave " + ftype2string(env3, rt.type));
@@ -667,7 +668,17 @@ growRightTyvar(env : FEnv, id : int, type : FType, left : bool, recordDep : bool
 			righty = if (left) type else FTypeVar(id);
 
 			nenv0 = setFTypeVar(resenv, id, restype);
-			nenv = if (recordDep) addTyvarDependency(nenv0, lefty, kind, righty) else nenv0;
+			// FGrowRight creates upper bounds from auto-growth (struct → parent union).
+			// Mark these so setFTyvar prefers the lower (actual) bound, not the grown upper.
+			nenv0b = switch (restype) {
+				FBounded(__, upper): {
+					if (upper != FTopBottom()) {
+						FEnv(nenv0 with autoGrownUpperBounds = insertSet(nenv0.autoGrownUpperBounds, id))
+					} else nenv0;
+				}
+				default: nenv0;
+			};
+			nenv = if (recordDep) addTyvarDependency(nenv0b, lefty, kind, righty) else nenv0b;
 			FEnvType(
 				nenv,
 				righty
@@ -759,7 +770,8 @@ addTyvarDependency(env : FEnv, left : FType, kind : FUnification, right : FType)
 			env.verbose,
 			env.tyvars,
 			env.seen,
-			setTree(env.tyvarDeps, left, arrayPush(deps, ut))
+			setTree(env.tyvarDeps, left, arrayPush(deps, ut)),
+			env.autoGrownUpperBounds
 		);
 	}
 }

--- a/tools/flowc/typechecker/funify_cases.flow
+++ b/tools/flowc/typechecker/funify_cases.flow
@@ -399,151 +399,16 @@ funifyUnionAndStruct(env : FEnv, union : FUnion, struct : FStruct, unionIsLeft :
 					rightt = if (unionIsLeft) struct else inst;
 
 					if (fns.kind == FGrowRight()) {
-						// Fresh tyvar approach: create fresh tyvars for the result union,
-						// add constraints from both the struct's concrete params and the
-						// union's existing params. This avoids directly mutating the union's
-						// shared tyvars via FGrowRight side effects.
-						// See typechecker_improvements.md for rationale.
-
-						if (env.verbose >= 2) {
-							fcPrintln("UNIFY funifyUnionAndStruct GrowRight: struct=" + ftype2string(env, struct)
-								+ " union=" + ftype2string(env, union)
-								+ " unionIsLeft=" + b2s(unionIsLeft),
-								env.env.program.acc.config.threadId);
-						}
-
-						// Build a map from struct's type param names to the concrete types
-						// from the actual struct (not the instantiated one)
-						msdef = lookupTree(env.env.program.acc.names.structs, sname);
-						structTyparMap = switch (msdef) {
-							None(): makeTree();
-							Some(sdef): {
-								foldi(sdef.typars, makeTree(), \i, acc, typar -> {
-									switch (typar) {
-										FcTypeParameter(tp, __): {
-											if (i < length(struct.typars)) {
-												setTree(acc, tp, struct.typars[i])
-											} else acc;
-										}
-										default: acc;
-									}
-								});
-							}
-						};
-
-						// For each union type param position, create a fresh tyvar
-						// and add constraints from both inputs.
-						// The fresh tyvar is the JOIN target — FGrowRight on it is safe
-						// since it's not shared. We use FGrowRight to properly compute
-						// the join (e.g. MFocus + MFocusGroup → MaterialFocus).
-						// IMPORTANT: We cannot do FGrowRight(unionTp, fresh) directly
-						// because growRightTyvar mutates BOTH sides when both are tyvars.
-						// Instead, we resolve unionTp's current value and grow fresh
-						// with the resolved (concrete) value only.
-						freshResult = foldi(union.typars, FEnvTypes(env, []), \i, acc : FEnvTypes, unionTp -> {
-							fresh = makeFTyvar(acc.env);
-							// Find the union's i-th type param name
-							uparamName = strLeft("????????????????", i + 1);
-							// Look up if the struct has a concrete type for this param
-							mstructTp = lookupTree(structTyparMap, uparamName);
-
-							// Constraint 1: grow fresh to accommodate struct's concrete type
-							env1r = switch (mstructTp) {
-								None(): FEnvType(acc.env, fresh);
-								Some(stp): {
-									fns.unifyType(acc.env, stp, fresh, FGrowRight(), fns.onError);
-								}
-							};
-
-							// Constraint 2: grow fresh to accommodate union's existing type param.
-							// Resolve the tyvar to its current value to avoid mutating it.
-							resolvedUnionTp = switch (unionTp) {
-								FTypeVar(uid): {
-									switch (lookupTree(env1r.env.tyvars, uid)) {
-										None(): unionTp;  // unbound — keep as tyvar
-										Some(resolved): resolved;
-									}
-								}
-								default: unionTp;
-							};
-							env2r = if (resolvedUnionTp == FTopBottom() || resolvedUnionTp == unionTp) {
-								// Union's param is unbound or unresolved — just link via FUnifyLeft
-								// (fresh must be at least whatever unionTp eventually becomes)
-								fns.unifyType(env1r.env, unionTp, fresh, FUnifyLeft(), fns.onError);
-							} else {
-								// Union's param has a concrete value — grow fresh with it
-								fns.unifyType(env1r.env, resolvedUnionTp, fresh, FGrowRight(), fns.onError);
-							};
-
-							FEnvTypes(env2r.env, arrayPush(acc.types, fresh));
-						});
-
-						result = FUnion(uname, freshResult.types);
-
-						if (env.verbose >= 2) {
-							fcPrintln("UNIFY funifyUnionAndStruct GrowRight result: " + ftype2string(freshResult.env, result),
-								freshResult.env.env.program.acc.config.threadId);
-						}
-
-						FEnvType(freshResult.env, result);
+						// Any type parameter matches should have happened
+						et = fns.unifyType(env, leftt, rightt, FGrowRight(), fns.onError);
+						FEnvType(
+							et.env,
+							union
+						);
 					} else if (fns.kind == FReduceLeft()) {
-						// Fresh tyvar approach for reduce_left (meet/GLB).
-						// Same principle as FGrowRight fresh tyvars: avoid mutating
-						// the union's shared tyvars. For reduce_left, the fresh tyvar
-						// must be ≤ both inputs (meet, not join).
-						// See typechecker_improvements.md item 3.
-
-						if (env.verbose >= 2) {
-							fcPrintln("UNIFY funifyUnionAndStruct ReduceLeft: struct=" + ftype2string(env, struct)
-								+ " union=" + ftype2string(env, union)
-								+ " unionIsLeft=" + b2s(unionIsLeft),
-								env.env.program.acc.config.threadId);
-						}
-
-						msdef2 = lookupTree(env.env.program.acc.names.structs, sname);
-						structTyparMap2 = switch (msdef2) {
-							None(): makeTree();
-							Some(sdef): {
-								foldi(sdef.typars, makeTree(), \i, acc, typar -> {
-									switch (typar) {
-										FcTypeParameter(tp, __): {
-											if (i < length(struct.typars)) {
-												setTree(acc, tp, struct.typars[i])
-											} else acc;
-										}
-										default: acc;
-									}
-								});
-							}
-						};
-
-						freshResult2 = foldi(union.typars, FEnvTypes(env, []), \i, acc : FEnvTypes, unionTp -> {
-							fresh = makeFTyvar(acc.env);
-							uparamName = strLeft("????????????????", i + 1);
-							mstructTp = lookupTree(structTyparMap2, uparamName);
-
-							// Constraint 1: fresh ≤ struct's concrete type
-							env1r = switch (mstructTp) {
-								None(): FEnvType(acc.env, fresh);
-								Some(stp): {
-									fns.unifyType(acc.env, fresh, stp, FUnifyLeft(), fns.onError);
-								}
-							};
-
-							// Constraint 2: fresh ≤ union's existing type param
-							env2r = fns.unifyType(env1r.env, fresh, unionTp, FUnifyLeft(), fns.onError);
-
-							FEnvTypes(env2r.env, arrayPush(acc.types, fresh));
-						});
-
-						result2 = FStruct(sname, freshResult2.types);
-
-						if (env.verbose >= 2) {
-							fcPrintln("UNIFY funifyUnionAndStruct ReduceLeft result: " + ftype2string(freshResult2.env, result2),
-								freshResult2.env.env.program.acc.config.threadId);
-						}
-
-						FEnvType(freshResult2.env, result2);
+						// Intersection: We take the struct
+						et = fns.unifyType(env, leftt, rightt, FReduceLeft(), fns.onError);
+						et;
 					} else if (unionIsLeft) {
 						// union+ <= struct-
 
@@ -1354,3 +1219,5 @@ unifyTypes(env : FEnv, kind : string, outputs : [FType], inputs : [FType], fns :
 		} else acc;
 	});
 }
+
+

--- a/tools/flowc/typechecker/funify_cases.flow
+++ b/tools/flowc/typechecker/funify_cases.flow
@@ -62,7 +62,18 @@ funifyStruct(env : FEnv, left : FStruct, right : FType, fns : FunifyFns) -> FEnv
 	switch (right) {
 		FStruct(rname, rtps): {
 			if (lname == rname) {
+				if (env.verbose >= 2 && fns.kind == FGrowRight()) {
+					fcPrintln("UNIFY funifyStruct same-struct GrowRight: " + lname
+						+ " ltps=" + superglue(ltps, \tp -> ftype2string(env, tp), ", ")
+						+ " rtps=" + superglue(rtps, \tp -> ftype2string(env, tp), ", "),
+						env.env.program.acc.config.threadId);
+				}
 				et1 = unifyTypes(env, "struct type parameters to " + lname, ltps, rtps, fns);
+				if (env.verbose >= 2 && fns.kind == FGrowRight()) {
+					fcPrintln("UNIFY funifyStruct same-struct GrowRight result: " + lname
+						+ " types=" + superglue(et1.types, \tp -> ftype2string(et1.env, tp), ", "),
+						env.env.program.acc.config.threadId);
+				}
 				FEnvType(
 					et1.env,
 					FStruct(lname, et1.types)
@@ -388,17 +399,151 @@ funifyUnionAndStruct(env : FEnv, union : FUnion, struct : FStruct, unionIsLeft :
 					rightt = if (unionIsLeft) struct else inst;
 
 					if (fns.kind == FGrowRight()) {
-						// Any type parameter matches should have happened
-						et = fns.unifyType(env, leftt, rightt, FGrowRight(), fns.onError);
-						FEnvType(
-							et.env,
-							union
-						);
-					} else if (fns.kind == FReduceLeft()) {
-						// Intersection: We take the struct
-						et = fns.unifyType(env, leftt, rightt, FReduceLeft(), fns.onError);
+						// Fresh tyvar approach: create fresh tyvars for the result union,
+						// add constraints from both the struct's concrete params and the
+						// union's existing params. This avoids directly mutating the union's
+						// shared tyvars via FGrowRight side effects.
+						// See typechecker_improvements.md for rationale.
 
-						et;
+						if (env.verbose >= 2) {
+							fcPrintln("UNIFY funifyUnionAndStruct GrowRight: struct=" + ftype2string(env, struct)
+								+ " union=" + ftype2string(env, union)
+								+ " unionIsLeft=" + b2s(unionIsLeft),
+								env.env.program.acc.config.threadId);
+						}
+
+						// Build a map from struct's type param names to the concrete types
+						// from the actual struct (not the instantiated one)
+						msdef = lookupTree(env.env.program.acc.names.structs, sname);
+						structTyparMap = switch (msdef) {
+							None(): makeTree();
+							Some(sdef): {
+								foldi(sdef.typars, makeTree(), \i, acc, typar -> {
+									switch (typar) {
+										FcTypeParameter(tp, __): {
+											if (i < length(struct.typars)) {
+												setTree(acc, tp, struct.typars[i])
+											} else acc;
+										}
+										default: acc;
+									}
+								});
+							}
+						};
+
+						// For each union type param position, create a fresh tyvar
+						// and add constraints from both inputs.
+						// The fresh tyvar is the JOIN target — FGrowRight on it is safe
+						// since it's not shared. We use FGrowRight to properly compute
+						// the join (e.g. MFocus + MFocusGroup → MaterialFocus).
+						// IMPORTANT: We cannot do FGrowRight(unionTp, fresh) directly
+						// because growRightTyvar mutates BOTH sides when both are tyvars.
+						// Instead, we resolve unionTp's current value and grow fresh
+						// with the resolved (concrete) value only.
+						freshResult = foldi(union.typars, FEnvTypes(env, []), \i, acc : FEnvTypes, unionTp -> {
+							fresh = makeFTyvar(acc.env);
+							// Find the union's i-th type param name
+							uparamName = strLeft("????????????????", i + 1);
+							// Look up if the struct has a concrete type for this param
+							mstructTp = lookupTree(structTyparMap, uparamName);
+
+							// Constraint 1: grow fresh to accommodate struct's concrete type
+							env1r = switch (mstructTp) {
+								None(): FEnvType(acc.env, fresh);
+								Some(stp): {
+									fns.unifyType(acc.env, stp, fresh, FGrowRight(), fns.onError);
+								}
+							};
+
+							// Constraint 2: grow fresh to accommodate union's existing type param.
+							// Resolve the tyvar to its current value to avoid mutating it.
+							resolvedUnionTp = switch (unionTp) {
+								FTypeVar(uid): {
+									switch (lookupTree(env1r.env.tyvars, uid)) {
+										None(): unionTp;  // unbound — keep as tyvar
+										Some(resolved): resolved;
+									}
+								}
+								default: unionTp;
+							};
+							env2r = if (resolvedUnionTp == FTopBottom() || resolvedUnionTp == unionTp) {
+								// Union's param is unbound or unresolved — just link via FUnifyLeft
+								// (fresh must be at least whatever unionTp eventually becomes)
+								fns.unifyType(env1r.env, unionTp, fresh, FUnifyLeft(), fns.onError);
+							} else {
+								// Union's param has a concrete value — grow fresh with it
+								fns.unifyType(env1r.env, resolvedUnionTp, fresh, FGrowRight(), fns.onError);
+							};
+
+							FEnvTypes(env2r.env, arrayPush(acc.types, fresh));
+						});
+
+						result = FUnion(uname, freshResult.types);
+
+						if (env.verbose >= 2) {
+							fcPrintln("UNIFY funifyUnionAndStruct GrowRight result: " + ftype2string(freshResult.env, result),
+								freshResult.env.env.program.acc.config.threadId);
+						}
+
+						FEnvType(freshResult.env, result);
+					} else if (fns.kind == FReduceLeft()) {
+						// Fresh tyvar approach for reduce_left (meet/GLB).
+						// Same principle as FGrowRight fresh tyvars: avoid mutating
+						// the union's shared tyvars. For reduce_left, the fresh tyvar
+						// must be ≤ both inputs (meet, not join).
+						// See typechecker_improvements.md item 3.
+
+						if (env.verbose >= 2) {
+							fcPrintln("UNIFY funifyUnionAndStruct ReduceLeft: struct=" + ftype2string(env, struct)
+								+ " union=" + ftype2string(env, union)
+								+ " unionIsLeft=" + b2s(unionIsLeft),
+								env.env.program.acc.config.threadId);
+						}
+
+						msdef2 = lookupTree(env.env.program.acc.names.structs, sname);
+						structTyparMap2 = switch (msdef2) {
+							None(): makeTree();
+							Some(sdef): {
+								foldi(sdef.typars, makeTree(), \i, acc, typar -> {
+									switch (typar) {
+										FcTypeParameter(tp, __): {
+											if (i < length(struct.typars)) {
+												setTree(acc, tp, struct.typars[i])
+											} else acc;
+										}
+										default: acc;
+									}
+								});
+							}
+						};
+
+						freshResult2 = foldi(union.typars, FEnvTypes(env, []), \i, acc : FEnvTypes, unionTp -> {
+							fresh = makeFTyvar(acc.env);
+							uparamName = strLeft("????????????????", i + 1);
+							mstructTp = lookupTree(structTyparMap2, uparamName);
+
+							// Constraint 1: fresh ≤ struct's concrete type
+							env1r = switch (mstructTp) {
+								None(): FEnvType(acc.env, fresh);
+								Some(stp): {
+									fns.unifyType(acc.env, fresh, stp, FUnifyLeft(), fns.onError);
+								}
+							};
+
+							// Constraint 2: fresh ≤ union's existing type param
+							env2r = fns.unifyType(env1r.env, fresh, unionTp, FUnifyLeft(), fns.onError);
+
+							FEnvTypes(env2r.env, arrayPush(acc.types, fresh));
+						});
+
+						result2 = FStruct(sname, freshResult2.types);
+
+						if (env.verbose >= 2) {
+							fcPrintln("UNIFY funifyUnionAndStruct ReduceLeft result: " + ftype2string(freshResult2.env, result2),
+								freshResult2.env.env.program.acc.config.threadId);
+						}
+
+						FEnvType(freshResult2.env, result2);
 					} else if (unionIsLeft) {
 						// union+ <= struct-
 
@@ -1209,4 +1354,3 @@ unifyTypes(env : FEnv, kind : string, outputs : [FType], inputs : [FType], fns :
 		} else acc;
 	});
 }
-

--- a/tools/flowc/typechecker/type_expect.flow
+++ b/tools/flowc/typechecker/type_expect.flow
@@ -2,10 +2,14 @@ import tools/flowc/fcexp;
 
 export {
 	// Expectations for the types for the type checking algorithm
-	FcTypeExpect ::= FcLessOrEqual, FcExpectField, FcVerifyType, FcSetMutableField;
+	FcTypeExpect ::= FcLessOrEqual, FcGrowToFit, FcExpectField, FcVerifyType, FcSetMutableField;
 
 		// Biunification
 		FcLessOrEqual(output : FcType, input : FcType, description : string, info : FcInfo2, e : FcExp);
+
+		// Like FcLessOrEqual, but uses FGrowRight to allow the shared type parameter to grow (join/LUB)
+		// Used for function call arguments when the parameter type involves a shared type parameter
+		FcGrowToFit(output : FcType, input : FcType, description : string, info : FcInfo2, e : FcExp);
 
 		// The type t should have at least this field of the given fieldType.
 		FcExpectField(field : string, fieldType : FcType, t : FcType, info : FcInfo2, e : FcExp);

--- a/tools/flowc/typechecker/type_expect_helpers.flow
+++ b/tools/flowc/typechecker/type_expect_helpers.flow
@@ -13,6 +13,9 @@ fcExpect2string(env : FcTypeEnv, e : FcTypeExpect) -> string {
 		FcLessOrEqual(t1, t2, d, __, ex): {
 			"(" + pt(t1) + ")⁺ c= (" + pt(t2) + ")⁻   from   " + d + " in " + pe(ex);
 		}
+		FcGrowToFit(t1, t2, d, __, ex): {
+			"(" + pt(t1) + ")⁺ grow (" + pt(t2) + ")⁻   from   " + d + " in " + pe(ex);
+		}
 		FcExpectField(field, ftype, t1, __, ex): {
 			pt(t1) + " c= (." + field + " : " + pt(ftype) + ")   from   " + pe(ex);
 		}

--- a/tools/flowc/typechecker/typechecker.flow
+++ b/tools/flowc/typechecker/typechecker.flow
@@ -565,7 +565,7 @@ typecheckFcExp(acc : FcTypeEnv, tyvarIdGroup : IdGroup, flowfile : string, e : F
 
 				rt = typecheckFcExp(acc, tyvarIdGroup, flowfile, f);
 				ft = FcTypeFunction(map(argtypes, \a -> FcFunArg("", a)), makeFcTyVar2(tyvarIdGroup, ci), ci);
-				checkOrRecordTypeExpect(acc, 
+				checkOrRecordTypeExpect(acc,
 					FcLessOrEqual(rt, ft, "call on function type", ci, e)
 				);
 				ft;

--- a/tools/flowc/typechecker/typechecker_improvements.md
+++ b/tools/flowc/typechecker/typechecker_improvements.md
@@ -1,0 +1,298 @@
+# Type Checker Improvements
+
+## 1. Contradictory type parameter constraints
+
+When a polymorphic function like `fif(Transform<bool>, Transform<?>, Transform<?>) -> Transform<?>`
+receives arguments with different inner types (e.g. `Transform<Maybe<MFocus>>` and
+`Transform<Maybe<MFocusGroup>>`), the type parameter `?` should resolve to the join
+(`Maybe<MaterialFocus>`). Currently the compiler silently picks one value and reports
+a type error on the other argument with a misleading message showing the wrong expected type.
+
+The compiler should detect when a type parameter has contradictory constraints and
+report "cannot resolve type parameter" with both conflicting types shown, rather than
+silently picking one and producing confusing swapped-type errors.
+
+Pre-existing bug. Repro: `tools/flowc/tests/fif_repro.flow`
+
+## 2. Fresh Tyvars in grow_right(struct, union)
+
+## Problem
+
+In `funifyUnionAndStruct`, when computing `grow_right(Some<MTB>, Maybe<α>)`:
+
+```
+inst = Some<α>              // α is union's shared tyvar
+unifyType(Some<MTB>, Some<α>, FGrowRight)  // side effect: α = MTB
+return Maybe<α>             // α contaminated by side effect
+```
+
+The `FGrowRight` unification directly mutates `α` via `growRightTyvar`.
+This is wrong because `α` is the union's type parameter shared across
+all members. Setting `α = MTB` contaminates all other uses of `α`.
+
+Moreover, `α` could be **less** than MTB — `None` is also a member of
+`Maybe<α>` and doesn't constrain `α` at all.
+
+## Fix: Fresh Result Tyvars
+
+The result of `grow_right(struct, union)` should use **fresh** type
+parameters, decoupled from both inputs. This is the same pattern as
+introducing a binding `v : T = expression; v;` instead of returning
+`expression` directly.
+
+```
+grow_right(Some<MTB>, Maybe<α>)
+
+α_1 = fresh tyvar
+add constraint: MTB ≤ α_1     // result accommodates struct's param
+add constraint: α ≤ α_1       // result accommodates union's existing param
+return Maybe<α_1>              // fresh, decoupled from both inputs
+```
+
+No `unifyType(..., FGrowRight)` call on the struct params. No side
+effects on `α`. The fresh `α_1` is resolved by the solver as the join
+of its lower bounds through normal constraint propagation.
+
+## Proposed Implementation
+
+In `funifyUnionAndStruct`, FGrowRight path:
+
+1. For each union type parameter `αᵢ`, create a fresh tyvar `αᵢ'`
+2. For each struct type param position, extract the concrete type `Tᵢ`
+3. Add constraint `Tᵢ ≤ αᵢ'` via `unifyType(Tᵢ, αᵢ', FUnifyLeft)`
+4. Add constraint `αᵢ ≤ αᵢ'` via `unifyType(αᵢ, αᵢ', FUnifyLeft)`
+5. Return `FUnion(name, [α₀', α₁', ...])`
+
+The struct's concrete type params and the union's existing params both
+become **lower bounds** on the fresh result params. The solver resolves
+each `αᵢ'` to the join of its lower bounds.
+
+### Status: REVERTED
+
+Attempted in commit 619333e2c, reverted in commit 90bf0dd28. Two problems:
+1. **Phantom params** (like `?` in `None()`): fresh tyvars with no lower
+   bounds created infinite chains of unresolved tyvars.
+2. **Non-phantom params** (like `Cons`): fresh tyvars incorrectly narrowed
+   `List` to `Cons` because the fresh tyvar's only lower bound was the
+   struct's concrete param.
+
+The current implementation works through side effects: `funifyUnionAndStruct`
+calls `unifyType(inst, struct, FGrowRight)` which updates tyvars in the
+union's type params as a side effect, then returns the original union. This
+is correct because union type params at this point are always tyvars, so
+they get updated via `et.env.tyvars` and resolve correctly later.
+
+## 3. Same bug in reduce_left(struct, union) during bounds resolution
+
+### Problem
+
+The same contamination happens in the `reduce_left` path of
+`funifyUnionAndStruct`, triggered during finalization bounds resolution.
+
+When the solver has a bounded tyvar `{Some<MFocusGroup> .. Maybe<α>}`
+where `α = MaterialFocus`, it checks lower ≤ upper via `reduce_left`:
+
+```
+reduce_left(Some<MFocusGroup>, Maybe<α=MaterialFocus>)
+→ instantiate Maybe to matching struct: Some<α>
+→ reduce_left(MFocusGroup, α=MaterialFocus)
+→ sets α = MFocusGroup          ← CONTAMINATES shared tyvar!
+```
+
+The check should verify `Some<MFocusGroup> ≤ Maybe<MaterialFocus>`
+without mutating α. The answer is "yes" (MFocusGroup is a member of
+MaterialFocus), but the side effect narrows α from MaterialFocus to
+MFocusGroup, corrupting all other types that share α.
+
+### Where it happens
+
+In `fif_repro.flow`, function `getCurrentActiveItemBehaviour2`:
+
+```flow
+switchMaterialFocus(foc,
+    \f -> fif(f.active, const(Some(f)), acc),                         // f : MFocus
+    \f -> fif(f.active, const(Some(f)), getCurrentActiveItemBehaviour2(f))  // f : MFocusGroup
+)
+```
+
+`const`'s type parameter in each branch gets bounded:
+- Branch 1: `{Some<MFocus> .. Maybe<α>}`        (α = MaterialFocus)
+- Branch 2: `{Some<MFocusGroup> .. Maybe<α>}`    (same α!)
+
+α is shared because both fif results are joined through
+switchMaterialFocus into fifsome's single type parameter.
+
+Bounds resolution of branch 1 sets α = MFocus. Then bounds
+resolution of branch 2 finds α = MFocus and errors:
+"Expected MFocus, got MFocusGroup".
+
+### Fix
+
+Same approach as item 2: fresh tyvars in the `reduce_left` path of
+`funifyUnionAndStruct`. The bounds check should not mutate the
+union's type parameters.
+
+### Status: NOT IMPLEMENTED
+
+The fresh-tyvar approach for FGrowRight (item 2) was reverted due to
+regressions. The reduce_left case has the same fundamental problems
+(phantom params, chain explosion). This remains an open issue.
+Pre-existing bug. Repro: `tools/flowc/tests/fif_repro.flow`.
+
+## 4. FGrowRight for shared type parameters in function calls
+
+### Problem
+
+When a polymorphic function like `fif : (?, (?) -> ??, ??) -> ??` is called,
+`instantiateTypeTyPars` creates ONE tyvar per type parameter name: α for `?`,
+β for `??`. The same α is shared across all argument positions where `?` appears.
+
+Currently, each argument emits `FcLessOrEqual(argType, paramType)` which maps to
+`FUnifyLeft` in the solver. `FUnifyLeft` triggers `reduce_left(struct, union)`
+in `funifyUnionAndStruct`, which mutates the shared tyvar as a side effect.
+The first argument that resolves the shared tyvar "locks" it, and subsequent
+arguments with different concrete types cause errors.
+
+Example: `fif(someExpr, const(Some(focus)), acc)` where someExpr has type
+`Transform<bool>`, the second arg has type `Transform<Maybe<MFocus>>`, and
+acc has type `Transform<Maybe<MFocusGroup>>`. The shared `??` (β) gets locked
+to `Maybe<MFocus>` from the second arg, then the third arg fails because
+`Maybe<MFocusGroup> ≤ Maybe<MFocus>` is not valid.
+
+The correct result: β should grow to `Maybe<MaterialFocus>` (the join/LUB of
+MFocus and MFocusGroup).
+
+### Attempted fix: FcGrowToFit
+
+Tried emitting `FcGrowToFit` (using `FGrowRight`) instead of `FcLessOrEqual`
+(`FUnifyLeft`) for arguments with shared type parameters. Infrastructure added
+(`FcGrowToFit` in `type_expect.flow`, handled in solver and finalize).
+
+**Result: too aggressive.** `FGrowRight` grows the shared tyvar to the parent
+union, which is wrong for types used as lambda parameters. Example:
+`fold_deferred(foldedTree, init, \acc, node -> { ... foldTree(node, ...) }, onDone)`
+— `?` is shared across args 1 and 3. FGrowRight grows `?` from `TreeNode` to `Tree`,
+but the lambda parameter `node` must stay `TreeNode` (needs `.depth` field access).
+The call-site approach changes the fundamental constraint direction, breaking
+struct-level field access on lambda parameters.
+
+### Status
+
+FcGrowToFit infrastructure is in place but NOT used. The fresh-tyvar fix in
+`funifyUnionAndStruct` (items 2 and 3) handles the contamination at the right
+level — inside the unification engine, not at the constraint emission level.
+
+## 5. Polarity-aware bounds resolution for FBounded tyvars
+
+### Problem
+
+When a tyvar has bounds `{Cons<string> .. List<string>}` (lower = struct,
+upper = parent union), the final resolution in `ftype2fctype` must pick a
+concrete type. Currently `frange2fctype` calls `combinePositiveAndNegative`
+which returns `[Cons<string>, List<string>]` (struct first, union second),
+and `ftypes2fctypes` picks `t[0]` — always the **lower bound** (struct).
+
+This is correct for **covariant** positions (local bindings, return values):
+`a = expr` should have the most specific type the expression produces.
+
+But it is **wrong for contravariant positions** (function parameters):
+`\res -> Cons(")", res)` where `res` has bounds `{Cons<string> .. List<string>}`.
+Resolving `res` to `Cons<string>` makes the lambda type
+`(Cons<string>) -> Cons<string>`, which rejects `List<string>` arguments.
+The correct resolution is `List<string>` — the parameter must accept all
+values the caller might pass.
+
+### Where it happens
+
+In `failBindFI(failFoldi(..., Cons(first, acc), ...), \res -> Cons(")", res))`:
+
+- `failBindFI : (Fail<?>, (?) -> ??) -> Fail<??>`
+- `failFoldi` accumulator `??` has bounds `{Cons<string> .. List<string>}`:
+  - Lower: init = `Cons(first, acc)` gives `Cons<string> ≤ ??`
+  - Upper: `Cons(sql2, acc2)` uses acc2 as tail → `?? ≤ List<string>`
+- `??` resolves to `Cons<string>` (lower bound picked by `t[0]`)
+- This feeds into `failBindFI`'s `?` = `Cons<string>`
+- Lambda param `res : ?` gets type `Cons<string>` instead of `List<string>`
+
+### Resolution path
+
+`ftype2fctype` → `FBounded(lower, upper)` → `frange2fctype(lower, upper)` →
+`combinePositiveAndNegative(Cons, List)` → returns `[Cons, List]` →
+`ftypes2fctypes` picks `t[0]` = `Cons` ← **wrong for contravariant tyvars**
+
+### Fix: per-tyvar polarity from constraint graph
+
+The solver needs **polarity tracking** for tyvars. When resolving
+`FBounded(lower, upper)`:
+- **Covariant tyvar** (output position): pick lower bound (most specific)
+- **Contravariant tyvar** (input position): pick upper bound (most general)
+- **Invariant tyvar** (both positions): pick lower bound (safe default)
+
+### Failed attempt 1: polarity parameter in ftype2fctype
+
+Added `positive : bool` parameter to `ftype2fctype`, `ftypes2fctypes`,
+`frange2fctype`, and `posPolarity : bool` to `combinePositiveAndNegative`.
+Polarity flips at function argument positions (`!positive`).
+
+**Fundamentally flawed**: This is per-evaluation-context polarity. During
+finalization, `setFTyvar` resolves each tyvar ONCE, but the type it resolves
+may contain nested FTypeVars that get evaluated through `ftype2fctype` at
+different polarity contexts. The same tyvar's FBounded would get resolved
+differently depending on which code path evaluates it, producing inconsistent
+results (e.g. `SentenceHitExtended` in one context, `SentenceMatch` in
+another within the same compilation of rhapsode_server).
+
+### Failed attempt 2: track bound origin (autoGrownUpperBounds)
+
+Added `autoGrownUpperBounds : Set<int>` to FEnv, marking tyvars whose upper
+bound came from `growRightTyvar` (struct → parent union auto-growth) vs
+explicit constraints. The idea: auto-grown → prefer lower, real → prefer upper.
+
+**Also flawed**: The auto-growth flag is a property of the bound creation
+site, not the tyvar's usage context. A tyvar might get auto-grown upper
+bounds AND real constraints, and the flag can't distinguish the combination.
+
+### Implemented fix: per-tyvar polarity from constraint positions
+
+**Key insight**: Each tyvar should have a **single** polarity classification
+based on where it appears in the constraint graph (before finalization), not
+based on which code path evaluates it during finalization.
+
+**Implementation** (branch `polarity-aware-bounds`, commit 6bd21af4a):
+
+1. Added `tyvarPolarity : Tree<int, int>` to `FEnv` (replaces
+   `autoGrownUpperBounds`). Maps tyvar id → polarity: +1 covariant,
+   -1 contravariant, 0 invariant.
+
+2. `collectTyvarPolarity` (ftype_solve.flow) walks all `FcTypeExpect`
+   constraints after solving, before finalization:
+   - `FcLessOrEqual(output, input)`: tyvars in output → +1, in input → -1
+   - `FcGrowToFit(output, input)`: same
+   - `FcVerifyType(e1, e2)`: both sides → 0 (invariant)
+   - Function arg positions flip polarity; ref/mutable → 0
+
+3. `setFTyvar` looks up `tyvarPolarity` for the tyvar being resolved:
+   ```
+   polarity = lookupTreeDef(env.tyvarPolarity, tyvar, 0)
+   positive = (polarity >= 0)  // covariant or invariant → true
+   ftype2fctype(env, type, seen, positive, onError)
+   ```
+
+4. `ftype2fctype` FTypeVar case also uses per-tyvar polarity when recursing
+   into resolved types — each tyvar in a chain uses its own polarity.
+
+**Result**: 0 regressions vs master baseline. The `positive : bool` parameter
+is still threaded through `ftype2fctype`/`combinePositiveAndNegative` but is
+now driven by per-tyvar polarity rather than inherited evaluation context.
+
+### Remaining issue
+
+The polarity collection currently treats invariant (0) and unknown the same
+as covariant (prefer lower bound). For the cases described above:
+- mapAsync `{JsonObject .. Json}`: tyvar is contravariant → picks upper (Json) ✓
+- sql.flow `{Cons .. List}`: tyvar is contravariant → picks upper (List) ✓
+- interpreter_lib `{MRTableCol .. MRExp}`: tyvar is covariant → picks lower (MRTableCol) ✓
+
+However, verification against these specific cases has not been done yet
+(they require the full codebase). The test suite (165 tests) and
+material_textinput.flow compile with 0 regressions.

--- a/tools/flowc/typechecker/typechecker_rules.md
+++ b/tools/flowc/typechecker/typechecker_rules.md
@@ -1,0 +1,538 @@
+# Flow9 Type Checker: Formal Rules
+
+## 1. Type Lattice
+
+Flow9's internal types (`FType`) form a lattice:
+
+```
+FBasicType — int, double, string, bool, void
+FStruct(name, typars) — concrete struct types (e.g. Some<int>, ArrayNop)
+    ↑
+FUnion(name, typars) — named union types (e.g. Maybe<int>)
+    ↑
+FUnnamedUnion(types) — anonymous unions {A, B, C} (intermediate during inference)
+    ↑
+FFields(fields, seenNames, excluded) — row types (known fields, unknown struct)
+    ↑
+FFlow — top, any type (flow)
+```
+
+Subtyping relation `≤`:
+- `S ≤ U` when struct S is a member of union U
+- `T ≤ flow` for all T
+- `FUnion ≤ FUnnamedUnion` when all union members are in the unnamed union
+- `FStruct ≤ FFields` when struct has all fields in the row type
+
+Additional types:
+- `FTypeVar(id)` — type variable (tyvar), resolved during inference
+- `FTypePar(id)` — type parameter `?`, `??`, etc. (from polymorphic definitions)
+- `FFunction(args, rt)` — function type
+- `FArray(type)` — array type
+- `FRef(read, write)` — reference type
+- `FBounded(lower, upper)` — bounded type range `{lower .. upper}`
+
+**`FTopBottom`** is NOT a type in the lattice. It is a sentinel used only inside `FBounded` to mark an open (unconstrained) end of a bounded range. When one side of a unification is `FTopBottom`, the other side is used as-is — it simply means "no information yet":
+```
+unify(FTopBottom, T) = T
+unify(T, FTopBottom) = T
+```
+Once the bound is filled with a real type, normal subtyping rules apply.
+
+## 2. Constraints
+
+The type checker works in two phases:
+
+**Phase 1 — Constraint generation** (typechecker.flow): Walks the AST and emits constraints. Each expression generates constraints between the types of its subexpressions. Constraints are recorded as `FcTypeExpect` values in `env.local.expects`.
+
+**Phase 2 — Constraint solving** (ftype_solve.flow): Processes constraints one by one. Each constraint translates to a `unifyType` call with a specific `FUnification` kind (see §4). Solving a constraint may update tyvars, which affects subsequent constraints. The order of processing matters — constraints are solved in the order they were generated (FIFO from the `List<FcTypeExpect>`).
+
+A constraint relates two `FcType` expressions with a direction. For example, `FcLessOrEqual(type(arg), paramType)` means "the argument type must be a subtype of the parameter type." During solving, both sides are converted from `FcType` to `FType` via `fctype2ftype`, then unified.
+
+Constraint kinds are described in detail in §5.
+
+## 3. Type Variables (Tyvars)
+
+Each tyvar `αᵢ` maps to an `FType` in `env.tyvars : Tree<int, FType>`.
+
+**Lifecycle:**
+1. Created as unbound (no entry in tyvars)
+2. First constraint (§2) sets the initial value
+3. Subsequent constraints refine via unification (grow_right, reduce_left, etc.)
+4. Finalization resolves remaining bounds and deps
+
+**Dependencies** (`env.tyvarDeps : Tree<FType, [FUnifyType]>`):
+
+When two tyvars are related by a constraint, the solver records a dependency so the constraint can be re-checked later. The key is `FType` (typically `FTypeVar(id)`), the value is a list of `FUnifyType(kind, targetType)`.
+
+Example: processing a constraint `α₁ ≤ α₂` (α₁ is subtype of α₂) records `deps[α₁] += FUnifyType(FUnifyLeft, α₂)`.
+
+This means: "whenever α₁ changes, re-check that α₁ ≤ α₂ still holds."
+
+Dependencies are re-executed during finalization's `rerunDeps` phase (§8). At that point, tyvars may have been refined by other constraints, so re-running dependencies propagates new type information transitively. For example:
+```
+α₁ = Tree<int, CalendarEvent>     (from assignment)
+α₁ ≤ α₂                           (from function call)
+α₂ ≤ Tree<int, MyUnion>           (from another constraint)
+```
+After initial solving, `rerunDeps` re-checks `α₁ ≤ α₂` with their current values, propagating the relationship.
+
+**Polarity** (`env.tyvarPolarity : Tree<int, int>`):
+
+Each tyvar has a polarity classification derived from where it appears in constraints:
+- `+1` = **covariant** — appears only in output/positive positions
+- `-1` = **contravariant** — appears only in input/negative positions
+- `0` = **invariant** — appears in both, or in ref/mutable positions
+- absent = unclassified (treated as invariant)
+
+Polarity is collected by `collectTyvarPolarity` (see §9) before finalization and used by `setFTyvar` during final type resolution (see §10).
+
+## 4. Bounded Types: `{lower .. upper}`
+
+A tyvar holding `FBounded(lower, upper)`:
+- **lower**: the most specific type the value ACTUALLY has (accumulated from all sources)
+- **upper**: the most general type the value can be USED AS (accumulated from all usage sites)
+- **Invariant**: `lower ≤ upper` must always hold
+
+Creation:
+- `makeFBounded(env, lower, upper, onError)`: if `lower == upper`, returns the type directly. If `lower == FTopBottom`, returns `FBounded(FTopBottom, upper)`. Otherwise creates `FBounded(lower, upper)`.
+- `makeFBoundedEnv(env, lower, upper, kind, ...)`: dispatches to special cases:
+  - Same-name FStruct: calls `unify()` (recursive unification of type params)
+  - Same-name FUnion: calls `unify()` (recursive unification of type params)
+  - Different-name FUnion: calls `def()` (creates `FBounded` range)
+  - FStruct vs FFields: if all fields match struct, calls `unify()`; otherwise `def()`
+  - All other: `def()` → `makeFBounded`
+
+**Bounds helpers:**
+```
+lowerBound({l..u}) = l     lowerBound(T) = T  (for non-bounded)
+upperBound({l..u}) = u     upperBound(T) = T  (for non-bounded)
+```
+
+## 5. Unification Kinds
+
+Four operations, each with distinct semantics for what they return and how they modify types.
+
+### 5.1 FGrowRight — Join (Least Upper Bound)
+
+**Semantics**: `grow_right(A, B) = C` where C is the smallest type containing both A and B (their join/union).
+
+The name "grow_right" reflects the implementation: the right operand is the accumulator that grows to include the left operand. In `grow_right(newValue, accumulator)`, the accumulator expands. The result is the new accumulator value.
+
+**Purpose**: Accumulate the type from multiple value sources. Used for:
+- Array construction: `[a, b, c]` — result type grows to accommodate all elements
+- If/else branches: `if (...) a else b` — result grows to contain both
+- Switch case results: result type grows across all case bodies
+
+**Key rules:**
+
+1. **Same parameterized type.** If both sides have the same name `A` (whether struct or union), type parameters are unified recursively:
+   ```
+   grow_right(A(m), A(n)) = A(grow_right(m, n))
+   ```
+
+2. **Struct member of a union** — see Rules G1/G2 below.
+
+3. **Unrelated structs** with no common parent union form an anonymous union:
+   ```
+   grow_right(Foo, Bar) = FUnnamedUnion(Foo, Bar)
+   ```
+
+#### Rules G1 and G2: Struct-Union Join (Type Parameter Propagation)
+
+When growing a struct into its parent union, the struct may carry type information in its fields that corresponds to the union's type parameters.
+
+**Rule G1 (Parametric struct)**: If the struct uses the parent union's type parameters in its fields, the struct's type params propagate to the union:
+
+Example — building `[Cons<Form>, EmptyList]`, the solver computes the join of all elements:
+```
+List<?> ::= EmptyList, Cons<?>;
+Cons(head : ?, tail : List<?>);
+EmptyList();
+
+grow_right(EmptyList, Cons<Form>) = List<Form>
+```
+`EmptyList` has no `?` field (Rule G2), but `Cons.head : ?` tells us `? = Form` (Rule G1).
+
+**Rule G2 (Phantom struct)**: If the struct does NOT use any of the parent union's type parameters, the union's existing type params are preserved:
+
+Example:
+```
+grow_right(EmptyList, List<int>) = List<int>
+```
+`EmptyList` has no fields using `?` — it carries no information about what `?` should be. The union's existing `? = int` is kept.
+
+Another example with `Maybe`:
+```
+Maybe<?> ::= None, Some<?>;
+Some(value : ?);
+None();
+
+grow_right(None, Maybe<Json>) = Maybe<Json>
+```
+`None` has no `?` field, so `Maybe`'s existing type param `Json` is preserved.
+
+**Current implementation status**: `funifyUnionAndStruct` in the FGrowRight path unifies the struct's type params with the union's type params (via `unifyTypes`), but returns the original union unchanged:
+
+```flow
+// funify_cases.flow, funifyUnionAndStruct, FGrowRight path:
+et = fns.unifyType(env, leftt, rightt, FGrowRight(), fns.onError);
+FEnvType(et.env, union);  // returns original union, not grown type params
+```
+
+The returned union type always keeps its original type params — the explicit Rule G1 return-type propagation is not implemented. However, this works correctly in practice through **side effects**: the union's type params are typically `FTypeVar`s, and the `unifyType` call updates those tyvars in the returned `et.env.tyvars`. When the union is later resolved (during `ftype2fctype` finalization), those tyvars are looked up and give the correct types.
+
+This means G1 is implemented via side effects rather than explicit return-value propagation. It is a **code smell** (fragile, relies on tyvars being the type params) but not a functional bug in the current system, because union type params at this point in inference are always tyvars.
+
+The `gl1` guard in `funifyBounded` (§5.2) provides an additional safety net for cases where the lower bound of a bounded type needs to reflect grown type params. See §11.
+
+### 5.2 FUnifyLeft — Subtype Check (left ≤ right)
+
+**Semantics**: `unifyLeft(A, B)` verifies that A is a subtype of B. Returns the **new left-hand side**.
+
+**Purpose**: Containment checks. Used for:
+- Function arguments: `f(x)` generates `type(x) ≤ paramType`
+- Let bindings with annotations: `x : T = expr` generates `type(expr) ≤ T`
+- Switch variable: `type(x) ≤ switchType`
+- Cast expressions: `cast(e : From -> To)` — see below
+
+**Constraint origin**: `FcLessOrEqual(e1, e2, ...)` → `unifyType(e1, e2, FUnifyLeft(), ...)` at line 136 of `ftype_solve.flow`.
+
+**Key rules:**
+
+- **Struct ≤ its union**: `Some ≤ Maybe` — struct fits in its parent union
+- **Same parameterized type**: `unifyLeft(A<m>, A<n>)` = `A<unify(m,n)>` — check type params match
+- **Subunion ≤ superunion**: all members of the left union are also members of the right union
+
+#### Rules for Bounded Types in FUnifyLeft
+
+**Rule U1 (bounded on left)**: Checking `{l₁ .. u₁} ≤ T`:
+```
+Step 1: etr = grow_right(l₁, T)    — check lower bound fits target
+Step 2: etl = reduce_left(u₁, T)   — narrow upper bound to target
+Result: makeFBoundedEnv(l₁, etl.type)
+```
+
+**CRITICAL**: The lower bound `l₁` is NOT replaced by `etr.type`. The lower bound represents what the value **actually is**. A subtype check verifies compatibility but does not change the value's actual type.
+
+**Exception (gl1 guard, current workaround)**: When both `l₁` and `etr.type` are `FUnion` with the same name, the gl1 guard replaces `l₁` with `etr.type`. This compensates for cases where the grow_right side-effect mechanism (§5.1) doesn't fully propagate type params to the lower bound of a bounded type. See §11 for details.
+
+**Rule U2 (bounded on right)**: Checking `T ≤ {l₂ .. u₂}`:
+```
+Step 1: etl = reduce_left(u₂, T)   — narrow upper bound
+Step 2: etr = grow_right(l₂, T)    — grow lower bound (new value source)
+Result: makeFBoundedEnv(l₂, etl.type)
+```
+
+The lower bound `l₂` is preserved (not replaced by `etr.type` — the gl2 guard was removed to fix Bug 6).
+
+### 5.3 FReduceLeft — Meet (Greatest Lower Bound)
+
+**Semantics**: `reduce_left(A, B) = C` where C is the largest type contained in both A and B. Returns the **new left-hand side** (the accumulated type shrinks leftward).
+
+**Purpose**: Narrow the upper bound. Used in:
+- Bounded type resolution: `reduce_left(upperBound, constraint)` narrows the upper bound
+- `funifyBounded` step 2 in FUnifyLeft path
+
+**Key rules:**
+
+- **Same parameterized type**: `reduce_left(A<m>, A<n>)` = `A<reduce_left(m,n)>` — narrow type params recursively
+- **Struct in its union**: `reduce_left(Some<m>, Maybe<n>)` = `Some<reduce_left(m,n_mapped)>` — struct is narrower, keep it
+
+### 5.4 FUnifyRight — Subtype Check (right ≤ left)
+
+**Semantics**: Symmetric to FUnifyLeft with sides swapped. `unifyRight(A, B)` verifies B ≤ A. Returns the **new right-hand side**.
+
+## 6. Constraint Kinds
+
+#### FcLessOrEqual (→ FUnifyLeft)
+
+The primary constraint. Generated as `FcLessOrEqual(source, target, description, info, expr)`.
+
+Processing (ftype_solve.flow:136-145):
+```
+FcLessOrEqual(e1, e2, d, info, ex):
+    left = fctype2ftype(env, e1)
+    right = fctype2ftype(env, e2)
+    unifyType(env, left, right, FUnifyLeft(), onError)
+```
+
+Sources:
+- **Function call**: `f(arg)` → `FcLessOrEqual(type(arg), paramType)`
+- **Let binding with annotation**: `x : T = e` → `FcLessOrEqual(type(e), T)`
+- **Switch result**: each case body → `FcLessOrEqual(caseType, switchResultType)`
+- **Array element**: `[a, b]` → `FcLessOrEqual(type(a), arrayElemType)`, `FcLessOrEqual(type(b), arrayElemType)`
+- **If branches**: `FcLessOrEqual(thenType, resultType)`, `FcLessOrEqual(elseType, resultType)`
+- **Struct construction**: `S(a, b)` → `FcLessOrEqual(type(a), fieldType)`
+- **Switch cases**: `FcLessOrEqual(caseType, unionType)` — case type fits switch type
+- **Cast**: `cast(e : From -> To)` — three cases:
+  1. **Primitive conversions** (int, double, string): no subtype check, built-in
+  2. **Strict mode**: `FcLessOrEqual(fromType, toType)` — only upcasts allowed
+  3. **Non-strict mode** (default): `FcLessOrEqual(toType, supertype)` and `FcLessOrEqual(fromType, supertype)` — only requires a common supertype
+  In all cases, the expression type is verified: `FcVerifyType(type(e), fromType)`
+
+#### FcGrowToFit (→ FGrowRight)
+
+Like FcLessOrEqual, but uses `FGrowRight` instead of `FUnifyLeft`. Designed for function call arguments where a shared type parameter needs to grow (join/LUB) rather than be checked for containment.
+
+Infrastructure is in place (`type_expect.flow`, `ftype_solve.flow`, `ftype_finalize.flow`) but **not currently emitted** at any call site. See `typechecker_improvements.md` §4 for why — FGrowRight is too aggressive for lambda parameters that need field access.
+
+#### FcVerifyType
+
+Similar to FcLessOrEqual but only verifies compatibility without constraining.
+
+Used for:
+- Let binding WITHOUT annotation: `x = e` → `FcVerifyType(type(e), freshTyvar)`
+- Switch variable verification
+
+#### FcExpectField
+
+Generated for field access: `expr.fieldName` → `FcExpectField(fieldName, fieldType, exprType)`.
+
+Resolves to `FFields` row type that constrains the expression to have the named field.
+
+#### FcSetMutableField
+
+Generated for mutable field assignment: `expr.field ::= value` → `FcSetMutableField(exprType, fieldName, valueType)`.
+
+#### FcCheckAnnotation
+
+Post-solve check for type annotations. Generated alongside `FcLessOrEqual` for let bindings with explicit type annotations:
+```
+x : T = expr
+→ FcLessOrEqual(type(expr), T)       // for inference
+→ FcCheckAnnotation(type(expr), T)   // post-solve verification
+```
+
+Checked in `checkFinalTypeExpect` after all constraints are resolved. Detects incompatible type annotations that `FcLessOrEqual` silently accepted during inference.
+
+## 7. Tyvar Update Dispatch
+
+When a constraint involves a tyvar, the solver dispatches based on the kind:
+
+```
+unifyTyvar(env, id, type, left, kind):
+    ftype = env.tyvars[id]    // current tyvar value
+
+    FUnifyLeft/FUnifyRight:
+        result = unifyType(ftype, type, kind)
+        env.tyvars[id] = result
+        return the side that is NOT the tyvar
+
+    FGrowRight:
+        result = unifyType(ftype, type, FGrowRight)
+        env.tyvars[id] = result
+        return the side that is NOT the tyvar
+
+    FReduceLeft:
+        result = unifyType(ftype, type, FReduceLeft)
+        env.tyvars[id] = result
+        return the side that is NOT the tyvar
+```
+
+**Orientation**: `left=true` means the tyvar is on the left of the operation.
+- `growRightTyvar`: grows `ftype` to accommodate `type`:
+  ```
+  left=true:  grow_right(ftype, type)  → α grows rightward
+  left=false: grow_right(type, ftype)  → α grows rightward
+  ```
+- `unifyTyvar` (FUnifyLeft, left=true): `unifyType(ftype, type, FUnifyLeft)` — current value must fit in target
+- `unifyTyvar` (FUnifyLeft, left=false): `unifyType(type, ftype, FUnifyLeft)` — target must fit in current value
+
+**Tyvar-vs-tyvar** (`unifyTyvars`): Criss-cross pattern:
+```
+α₁ ≤ α₂:
+    1. unifyTyvar(α₂, value(α₁), left=false)  // push α₁'s value to α₂
+    2. unifyTyvar(α₁, value(α₂), left=true)   // push α₂'s value back to α₁
+    3. addDependency(α₁ ≤ α₂)                 // record for rerunDeps
+```
+
+## 8. Finalization Pipeline
+
+After all constraints are processed, `finalizeIteration` resolves remaining tyvars:
+
+```
+Phase 1 (Exact):
+    resolveAllTypes    — resolve FFields and unnamed unions
+    resolveBounds(0)   — unify bounds (exact)
+    rerunDeps          — re-execute tyvar dependencies
+
+Phase 2 (Heuristic):
+    resolveKisses      — resolve Cassiopeia constructs
+    resolveCassiopeia   — collect {..u ≤ α} patterns → α = union of uppers
+    resolveCassiopeia2  — second pass
+
+Phase 3 (Final):
+    resolveBounds(1)    — heuristic bound resolution
+    resolveBounds(2)    — resolve remaining lower-bound-only tyvars
+    rerunDeps           — re-execute deps with final values
+    resolveTyvarVsTyvar — fix tyvar-vs-tyvar conflicts
+    resolveTyvarsToTypars — bind unbound tyvars to type parameters
+    setFTyvar           — commit all tyvars to final types (uses per-tyvar polarity, see §10)
+    checkFinalTypeExpect — run FcCheckAnnotation checks
+```
+
+**rerunDeps**: Iterates `env.tyvarDeps`, re-executing each recorded dependency:
+```
+for each (from → [FUnifyType(kind, to)]) in tyvarDeps:
+    if both sides are determined: skip (optimization)
+    else: funify(from, to, kind)
+```
+
+**Bug 6 contamination mechanism**: During `rerunDeps`, a dependency `α₁ ≤ α₂` is re-executed. If α₂ was widened by another constraint since the original processing, α₁ gets contaminated with the wider type.
+
+## 9. Per-Tyvar Polarity Collection
+
+Polarity is collected from the constraint positions **after constraint solving, before finalization**. The function `collectTyvarPolarity` (in `ftype_solve.flow`) walks all `FcTypeExpect` constraints and classifies each tyvar.
+
+**Algorithm:**
+
+For each constraint:
+- `FcLessOrEqual(output, input, ...)`: tyvars in `output` are covariant (+1), tyvars in `input` are contravariant (-1)
+- `FcGrowToFit(output, input, ...)`: same as FcLessOrEqual
+- `FcVerifyType(e1, e2, ...)`: both sides are invariant (0) — verify checks both directions
+- `FcExpectField(_, fieldType, t, ...)`: both `t` and `fieldType` are covariant (+1)
+- `FcSetMutableField(struct, _, ftype, ...)`: `struct` is covariant (+1), `ftype` is contravariant (-1)
+
+**Within a type**, polarity propagation follows variance rules:
+- Array element: same polarity as parent
+- Function args: **flipped** polarity (contravariant position)
+- Function return: same polarity as parent
+- Ref type: invariant (0) — both read and written
+- Struct mutable fields: invariant (0)
+- Struct immutable fields: same polarity as parent
+- Union/struct type params: same polarity as parent
+
+**Merging**: If a tyvar appears with the same polarity in multiple constraints, it keeps that polarity. If it appears with conflicting polarities (e.g. +1 in one constraint, -1 in another), it becomes invariant (0).
+
+The result is stored in `env.tyvarPolarity : Tree<int, int>`, mapping tyvar id to polarity.
+
+**Why per-tyvar, not per-evaluation-context**: An earlier approach threaded a `positive:bool` parameter through `ftype2fctype` and flipped it at function arg positions during finalization. This was fundamentally flawed: the same tyvar's `FBounded` could be resolved through multiple code paths at different polarities during a single finalization, producing inconsistent results. Per-tyvar polarity ensures each tyvar gets a single, consistent classification.
+
+## 10. FBounded Resolution and Polarity
+
+During finalization, `setFTyvar` commits each tyvar to a final `FcType`. When the tyvar's value is `FBounded(lower, upper)`, the polarity determines which bound to prefer:
+
+```
+setFTyvar(env, tyvar, type, onError):
+    polarity = lookupTreeDef(env.tyvarPolarity, tyvar, 0)
+    positive = (polarity >= 0)    // covariant or invariant → true
+    ftype2fctype(env, type, seen, positive, onError)
+```
+
+- **positive=true** (covariant or invariant): prefer lower bound (most specific actual type)
+- **positive=false** (contravariant): prefer upper bound (most general required type)
+
+Example:
+```
+tyvar α has bounds {Cons<string> .. List<string>}
+
+If α is covariant (only in output positions):
+    → resolves to Cons<string> (lower, most specific)
+
+If α is contravariant (only in input positions, e.g. lambda parameter):
+    → resolves to List<string> (upper, most general)
+```
+
+When `ftype2fctype` encounters `FTypeVar(id)` during recursive resolution, it also uses that tyvar's own polarity (not the inherited context):
+
+```
+FTypeVar(id):
+    ot = lookupTree(env.tyvars, id)
+    polarity = lookupTreeDef(env.tyvarPolarity, id, 0)
+    positive = (polarity >= 0)
+    ftype2fctype(env, ot, seen, positive, onError)
+```
+
+This ensures each tyvar in a chain is resolved according to its own polarity classification, not the context of the outer tyvar being finalized.
+
+**Resolution path**: `ftype2fctype` → `FBounded(lower, upper)` → `frange2fctype(lower, upper)` → `combinePositiveAndNegative(lower, upper, positive)` → returns candidates ordered by polarity → `ftypes2fctypes` picks first element.
+
+## 11. Named Union Resolution
+
+### struct2unions
+
+`env.env.program.acc.names.struct2unions : Tree<string, [string]>` maps each struct name to the list of union names it belongs to.
+
+Key property: Only maps STRUCT names, not union names. To find if a union name is known, use `lookupTree(env.env.program.acc.names.unions, name)`.
+
+### Common parent check
+
+`unnamedUnionsShareCommonUnion(env, names)`: checks if ALL struct names in the set share at least one common parent union. Used in Bug 5/5b fixes to allow unnamed unions like `{MathRoundingOption, IsEqualMathsStrict}` when both are members of `IsEqualMathsOption`.
+
+## 12. Switch Type Checking
+
+For `switch (x : T) { Case1(): ...; Case2(): ...; }`:
+
+1. `tt` = fresh tyvar for switch result type
+2. For each case: `FcLessOrEqual(caseBodyType, tt)` — body type grows result
+3. For struct cases: bind case variable to struct type, check `FcLessOrEqual(structType, switchType)`
+4. For union cases: expand union to leaf structs, check `FcLessOrEqual(unionType, switchType)`
+5. For polymorphic union cases: add `FcLessOrEqual(varType, un)` to link type params
+
+**Union case switch type**: Uses `unionType` (the type of the switch expression after widening to its union) instead of `varType` (the raw type of x). This ensures the switch variable inside a union case body has the correct union type.
+
+## 13. Known Bugs and Limitations
+
+### Bug 4 (gl1 compensates for incomplete G1)
+
+`grow_right(Some<GR>, Maybe<TR>)` unifies GR and TR as a side effect via tyvars, but returns `Maybe<TR>` (the original union). Since TR is a tyvar that now points to the grown result in env.tyvars, this usually works correctly. However, when the result feeds into a bounded type's lower bound (e.g. `FBounded(Maybe<TR>, ...)`), the lower bound captures the FUnion struct with the original tyvar references. The `gl1` guard in `funifyBounded` patches this by replacing the lower bound with the grown result when both are same-name `FUnion`.
+
+### Bug 6 (gl1 contaminates Tree types)
+
+`gl1` replaces `Tree<int, CalendarEvent>` with `Tree<int, UnionMessage>` because Tree is `FUnion("Tree", ...)` and matches the same-name guard. The guard is too broad — it fires for ALL same-name unions, not just the cases where G1 side effects need help. A proper fix would either: (a) make gl1 more selective (only fire when the lower bound's tyvars are still unresolved), or (b) make `funifyUnionAndStruct` return explicit grown type params so gl1 is unnecessary.
+
+### Annotation masking
+
+Type annotations `x : T = expr` set the type environment to `T` (not `type(expr)`). All downstream uses of `x` see `T`. If `T` is narrower than `type(expr)`, the annotation silently hides the mismatch during inference. The post-solve `FcCheckAnnotation` partially catches this.
+
+### getFiUnionRelation disabled
+
+`isFiSubType`'s `getFiUnionRelation` is disabled — returns `FiRelationEqual()` for ALL union-vs-union comparisons. Comment: "We cause too many false positives, so turn things off for now." This means the type verifier cannot distinguish sub/super union relationships.
+
+### wigi_difference.flow type error (exposed by G1 fix)
+
+Fixing G1 more aggressively could expose a real type error in `wigi_difference.flow`. The struct `MergeReplacesData` declares:
+```flow
+nops : [Pair<ArrayOperation<WigiText>, ArrayReplace<WigiText>>]
+```
+
+But the fold iterates over `protocol : [ArrayOperation<WigiElement>]`, and at line 675:
+```flow
+Pair(op, ArrayReplace(oldindex, newindex, element))
+```
+`op` has type `ArrayOperation<WigiElement>` (from the fold parameter), not `ArrayOperation<WigiText>`. This code is inside a `WigiText(__, __):` switch case which narrows `element` to `WigiText`, but `op` is NOT narrowed — it remains `ArrayOperation<WigiElement>`.
+
+The constraint is `FcLessOrEqual` (subtype check), not FGrowRight. So the issue is not in constraint resolution — it's a genuine type mismatch. The current compiler silently accepts it because type parameter propagation through side effects doesn't always catch this level of detail.
+
+Fix: change `nops` field type to `[Pair<ArrayOperation<WigiElement>, ArrayReplace<WigiElement>>]`, or narrow `op` explicitly.
+
+### FRef unification bug (pre-existing)
+
+`FRef` unification uses the same `kind` for both read and write types, but write should be contravariant. Currently:
+```flow
+FRef(rt1, wt1) vs FRef(rt2, wt2):
+    unify(rt1, rt2, kind)    // read type: correct (covariant)
+    unify(wt1, wt2, kind)    // write type: should use flipped kind (contravariant)
+```
+
+## 14. Implementation Map
+
+| Rule | File | Function | Status |
+|------|------|----------|--------|
+| G1/G2 | funify_cases.flow:321 | funifyUnionAndStruct | WORKS VIA SIDE EFFECTS (returns original union, tyvars updated) |
+| U1 (gl1) | funify_cases.flow:1176 | funifyBounded | WORKAROUND (gl1 guard, too broad — causes Bug 6) |
+| U1 (gl2) | funify_cases.flow:1193 | funifyBounded | FIXED (gl2 removed) |
+| Tyvar update | ftype_solve.flow:493 | unifyTyvar | OK |
+| Grow right | ftype_solve.flow:641 | growRightTyvar | OK |
+| Reduce left | ftype_solve.flow:677 | reduceLeftTyvar | OK |
+| Tyvar deps | ftype_solve.flow:711 | unifyTyvars | OK |
+| Bounded creation | ftype_bound.flow:19 | makeFBoundedEnv | OK |
+| Finalization | ftype_finalize.flow:75 | finalizeIteration | OK |
+| RerunDeps | ftype_finalize.flow:236 | rerunDeps | KNOWN ISSUE (contamination) |
+| Annotation check | ftype_finalize.flow | checkFinalTypeExpect | OK |
+| Common parent | funify_cases.flow | unnamedUnionsShareCommonUnion | OK |
+| Per-tyvar polarity | ftype_solve.flow | collectTyvarPolarity | OK (collects from constraints) |
+| Polarity in resolution | ftype2fctype.flow | setFTyvar | OK (uses tyvarPolarity) |
+| Polarity in FTypeVar | ftype2fctype.flow | ftype2fctype FTypeVar case | OK (per-tyvar lookup) |
+| FcGrowToFit | type_expect.flow + solver | — | INFRASTRUCTURE ONLY (not emitted) |
+| FRef variance | funify_cases.flow | funifyRef | BUG (write type not contravariant) |

--- a/tools/flowc/typechecker2/gtype_solve.flow
+++ b/tools/flowc/typechecker2/gtype_solve.flow
@@ -132,6 +132,10 @@ gtypeSolve(oenv : GEnv, name : string, tyvarIdGroup : IdGroup, pos : FcPosition)
 			FcLessOrEqual(e1, e2, d, info, ex): {
 				gunify(acc, e1, e2, info, \ -> d + ": " + fcexpDescription(ex));
 			}
+			FcGrowToFit(e1, e2, d, info, ex): {
+				// In gtype solver, treat same as FcLessOrEqual for now
+				gunify(acc, e1, e2, info, \ -> d + ": " + fcexpDescription(ex));
+			}
 			FcVerifyType(e1, e2, d, info, ex): {
 				et1 = gunify(acc, e1, e2, info, \ -> d + " " + fcexpDescription(ex));
 				gunify(et1, e2, e1, info, \ -> d + " " + fcexpDescription(ex));
@@ -245,6 +249,7 @@ extractNamesFromExpectations(names : Set<string>, expectations : List<FcTypeExpe
 	foldList(expectations, names, \acc, expect -> {
 		switch (expect) {
 			FcLessOrEqual(output, input, description, info, e): extractNamesFromFcType(extractNamesFromFcType(acc, output), input);
+			FcGrowToFit(output, input, description, info, e): extractNamesFromFcType(extractNamesFromFcType(acc, output), input);
 			FcExpectField(field, fieldType, t, info, e): extractNamesFromFcType(acc, fieldType);
 			FcVerifyType(type, declared, d, info, e): extractNamesFromFcType(extractNamesFromFcType(acc, type), declared);
 			FcSetMutableField(struct, field, ftype, info): extractNamesFromFcType(extractNamesFromFcType(acc, struct), ftype);


### PR DESCRIPTION
## Summary

Refactors the type checker's FBounded resolution to use per-tyvar polarity from the constraint graph, replacing the previous per-evaluation-context approach.

## Problem

When resolving `FBounded(lower, upper)` during finalization, the correct choice (lower vs upper bound) depends on whether the tyvar is covariant or contravariant. The previous approach threaded `positive:bool` through `ftype2fctype`, but was fundamentally broken: the same tyvar could be resolved at different polarities during a single finalization pass, producing inconsistent results.

## Solution

**Per-tyvar polarity** collected from constraint positions before finalization:
- Walk all `FcLessOrEqual`/`FcGrowToFit` constraints
- Tyvars in output → covariant (+1), input → contravariant (-1)
- Function args flip; refs/mutables → invariant (0)

`setFTyvar` and `ftype2fctype` FTypeVar case use each tyvar's own polarity.

## Changes

**Typechecker code** (commits 1-5):
- `ftype.flow`: Replace `autoGrownUpperBounds : Set<int>` with `tyvarPolarity : Tree<int, int>`
- `ftype_solve.flow`: Add `collectTyvarPolarity` — walks constraints, classifies tyvars
- `ftype2fctype.flow`: `setFTyvar` and FTypeVar case use per-tyvar polarity
- `funify_cases.flow`: Common parent union checks, union-struct narrowing
- 6 files: Update FEnv constructor sites

**Documentation** (commit 6):
- `typechecker_rules.md`: New §9 (polarity collection), §10 (FBounded resolution); updated G1 analysis, implementation map
- `typechecker_improvements.md`: Updated status of all improvement items
