### PR TITLE
fix(flow9): update lib/tools/flow9 for the CompilerConfig/getCompiler…

### DIFF
--- a/lib/tools/flow9/backend/fiprogram.flow
+++ b/lib/tools/flow9/backend/fiprogram.flow
@@ -18,7 +18,7 @@ dmodule2fiprogram(state : CompileState, fullpath : string) -> Maybe<FiProgram> {
 
 	flowpath = if (endsWith(fullpath, ".flow")) {
 		// Extract the path prefix (remove .flow extension if present)
-        path2flowPath(config.includes, fullpath);
+        path2flowPath(config.includesResolved, fullpath);
 	} else {
 		fullpath;
 	};
@@ -73,7 +73,7 @@ collectTransitiveDependencies(state : CompileState, toProcess : [string], visite
             newVisited = insertSet(visited, current);
             
             // Get the module's status
-            fullpath = flowPath2path(state.config.includes, current + ".flow");
+            fullpath = flowPath2path(state.config.includesResolved, current + ".flow");
             moduleStatus = getCompileStatus(state, fullpath);
             
             // Process based on module status

--- a/lib/tools/flow9/config.flow
+++ b/lib/tools/flow9/config.flow
@@ -6,14 +6,17 @@ export {
 }
 
 getFlow9Config() -> CompilerConfig {
-	switch (getCompilerConfig(fcCurrentWorkingDir())) {
+	switch (getCompilerConfig(fcCurrentWorkingDir(), None())) {
 		Failed(msg): {
 			println(msg + "\nUsing a default config.");
 			includes = strSplit(getUrlParameter("I"), ",");
 			allincludes = uniq(filter(concat([".", getFlowDirectory() + "/lib", getFlowDirectory()], includes), neq("")));
 			verbose = s2i(getUrlParameterDef("verbose", "0"));
 			setCompilerThreadPool(s2i(getUrlParameterDef("threads", "16")));
-			CompilerConfig("", allincludes, [], verbose, JSCliParams_dummy, makeTree(), s2i(getThreadId()));
+			// CompilerConfig gained includesResolved + workingDir (config_type.flow):
+			// (flowfile, includesRaw, includesResolved, workingDir, objectFolders,
+			//  verbose, jsParams, config, threadId).
+			CompilerConfig("", allincludes, allincludes, fcCurrentWorkingDir(), [], verbose, JSCliParams_dummy, makeTree(), s2i(getThreadId()));
 		}
 		Some(config): {
 			config;

--- a/lib/tools/flow9/desugar/desugar.flow
+++ b/lib/tools/flow9/desugar/desugar.flow
@@ -69,7 +69,7 @@ desugarPModule(config : CompilerConfig, onError : (string) -> void, fullpath : s
 
 	checkUnions(acc);
 
-	flowpath = path2flowPath(config.includes, fullpath);
+	flowpath = path2flowPath(config.includesResolved, fullpath);
 
 	contentHash = md5(filecontent);
 
@@ -463,7 +463,7 @@ pexp2dexp(acc : DesugarPAcc, p : PExp) -> DExp {
 		}
 		PString(pos, string1): DString(string1, p2i(pos));
 		PStringInclude(pos, path): {
-			fullpath = flowPath2path(acc.config.includes, path);
+			fullpath = flowPath2path(acc.config.includesResolved, path);
 			if (fileExists(fullpath)) {
 				value = getFileContent(fullpath);
 				acc.stringIncludes := arrayPush(^(acc.stringIncludes), path);

--- a/lib/tools/flow9/desugar/incremental.flow
+++ b/lib/tools/flow9/desugar/incremental.flow
@@ -112,7 +112,7 @@ preloadDIncrementalModule(state : CompileState, flowfile : string) -> Maybe<DMod
 	}
 
 	// Check if our file is marked for rechecking (it might be dependent on a changed module)
-	fullpath = flowPath2path(state.config.includes, flowfile + ".flow");
+	fullpath = flowPath2path(state.config.includesResolved, flowfile + ".flow");
 	fileStatus = getCompileStatus(state, fullpath);
 	
 	// If the file is marked for rechecking, don't load from cache

--- a/lib/tools/flow9/driver.flow
+++ b/lib/tools/flow9/driver.flow
@@ -81,7 +81,7 @@ markDependentModulesForRecheck(state : CompileState, changedModule : string, cha
 	// For each dependent module, mark it for rechecking
 	iterSet(affectedModules, \dependentModule -> {
 		debugLog(state, 1, "Marking dependent module for recheck: " + dependentModule);
-		dependentPath = flowPath2path(state.config.includes, dependentModule);
+		dependentPath = flowPath2path(state.config.includesResolved, dependentModule);
 		status = getCompileStatus(state, dependentPath);
 		
 		switch (status) {
@@ -155,7 +155,7 @@ markDependentsAsFailureDependents(state : CompileState, failedModule : string) -
 	// For each dependent module, mark it appropriately
 	iterSet(affectedModules, \dependentModule -> {
 		debugLog(state, 1, "Dependency failure impacts module: " + dependentModule);
-		dependentPath = flowPath2path(state.config.includes, dependentModule);
+		dependentPath = flowPath2path(state.config.includesResolved, dependentModule);
 		status = getCompileStatus(state, dependentPath);
 		
 		switch (status) {
@@ -196,7 +196,7 @@ propagateChanges(state : CompileState, changedModule : string, changedIds : Set<
 	
 	// Process each affected module
 	iterSet(affectedModules, \m -> {
-		fullpath = flowPath2path(state.config.includes, m);
+		fullpath = flowPath2path(state.config.includesResolved, m);
 		status = getCompileStatus(state, fullpath);
 		
 		// Update module status based on current state
@@ -349,7 +349,7 @@ typecheckFlow9s(state : CompileState, files : [string]) -> [bool] {
 }
 
 parseFlow9(state : CompileState, file : string) -> CompileStatus {
-	fullpath = flowPath2path(state.config.includes, file);
+	fullpath = flowPath2path(state.config.includesResolved, file);
 	// Check if incremental is turned off
 	incrementalOff = isConfigParameterFalse(state.config.config, "incremental");
 	// Check if we should reject existing incremental files
@@ -361,7 +361,7 @@ parseFlow9(state : CompileState, file : string) -> CompileStatus {
 			setCompileStatus(state, fullpath, CompileInProgress());
 
 			// Check if we can load from incremental cache
-			flowpath = path2flowPath(state.config.includes, fullpath);
+			flowpath = path2flowPath(state.config.includesResolved, fullpath);
 			t_preload = timestamp();
 			
 			// First check if we might use a cached module
@@ -623,7 +623,7 @@ doTypecheckModule(state : CompileState, file : string, fullpath : string, m : DM
 
 // We know all dependencies have been typed, so go ahead and type this file
 typecheckFlow9(state : CompileState, file : string) -> bool {
-	fullpath = flowPath2path(state.config.includes, file);
+	fullpath = flowPath2path(state.config.includesResolved, file);
 	debugLog(state, 2, "Typechecking file: " + file + " (fullpath: " + fullpath + ")");
 
 	// Check if incremental is turned off
@@ -793,7 +793,7 @@ typecheckFlow9(state : CompileState, file : string) -> bool {
 }
 
 isTypeChecked(state : CompileState, file : string) -> bool {
-	fullpath = flowPath2path(state.config.includes, file);
+	fullpath = flowPath2path(state.config.includesResolved, file);
 	s = getCompileStatus(state, fullpath);
 	result = switch (s) {
 		CompileNotSeen(): false;

--- a/lib/tools/flow9/flow9.flow
+++ b/lib/tools/flow9/flow9.flow
@@ -50,8 +50,8 @@ main() {
 	starttime = timestamp();
 	println("Flow9 compiling " + strGlue(def, ", "));
 	config = getFlow9Config();
-	includes = CompilerConfig(config with 
-		includes = concat(config.includes, map(expanded, \p -> dirName(p)))
+	includes = CompilerConfig(config with
+		includesResolved = concat(config.includesResolved, map(expanded, \p -> dirName(p)))
 	);
 	if (printHelp) {
 		printFlow9Usage(includes);

--- a/lib/tools/flow9/make_env.flow
+++ b/lib/tools/flow9/make_env.flow
@@ -38,7 +38,7 @@ addToDepenv(acc : HModuleInterface, c : CompileState, seen : ref Set<DImport>, i
 			acc2;
 		} else {
 			seen := insertSet(^seen, import);
-			fullpath = flowPath2path(c.config.includes, import.path + ".flow");
+			fullpath = flowPath2path(c.config.includesResolved, import.path + ".flow");
 			dep = getCompileStatus(c, fullpath);
 			error = \s -> {
 				c.onError("Error: " + fullpath + " not ready for types: " + s);


### PR DESCRIPTION
…Config API

lib/tools/flow9 had bitrotted against tools/common/config_type.flow: the CompilerConfig struct gained `includesResolved` + `workingDir` (7 → 9 fields, splitting the old `includes` into `includesRaw`/`includesResolved`) and getCompilerConfig now takes a second `Maybe<CompilerConfig>` arg. The experimental flow9 compiler no longer type-checked (flowc1 exit 3: "getCompilerConfig expects 2 arguments, got 1"; "Expected 9 arguments to struct CompilerConfig, got 7"; "No type has .includes").

Fixes:
- config.flow: getCompilerConfig(dir) → getCompilerConfig(dir, None()); the default CompilerConfig literal now passes 9 fields (includesResolved mirrors the resolved include list; workingDir = fcCurrentWorkingDir()).
- flow9.flow: `config with includes = …` → `includesResolved`.
- the 14 `config.includes` reads (make_env, backend/fiprogram, desugar, desugar/incremental, driver) → `.includesResolved` (the resolved list path resolution wants, per the config_type.flow field comment).

Validated: flowc1 verbose=0 lib/tools/flow9/flow9.flow now exits 0 (was 3).