### PR TITLE
Adjusted setSandBox

### DIFF
--- a/platforms/js/WebClip.hx
+++ b/platforms/js/WebClip.hx
@@ -315,7 +315,19 @@ class WebClip extends NativeWidgetClip {
 	}
 
 	public function setSandBox(value : String) : Void {
+		var alreadyApplied = iframe.getAttribute("sandbox") == value;
 		iframe.sandbox = value;
+		// WebKit/Safari only evaluates the sandbox attribute at navigation time. Since the
+		// iframe src is assigned in the constructor (before this style is processed), the
+		// attribute would otherwise never take effect on Safari, letting embedded players
+		// (e.g. Vimeo) call window.top.location. Re-trigger navigation so the sandbox applies.
+		if (!alreadyApplied && Platform.isSafari && untyped iframe.src != null && iframe.src != "") {
+			// Save and clear the onload handler to prevent ondone() being called twice
+			var savedOnLoad = iframe.onload;
+			iframe.onload = null;
+			untyped iframe.src = iframe.src;  // Re-trigger navigation with sandbox now set
+			iframe.onload = savedOnLoad;       // Restore for any subsequent reloads
+		}
 	}
 
 	public function evalJS(code : String) : Void {


### PR DESCRIPTION
### **Fix: [LTI kickout when slideshow contains external media (Vimeo) — Safari](https://eu.area9studio.com/nexus/lyceum-product-development/5TGwOIY8XnK-apple-ecosystem-not-working-properly-with-external-videos)**

**Symptom:** Users are kicked out of an LTI module on Safari 26.5+ when navigating to a slideshow that embeds a Vimeo video via the VideoPlayer Prime class. The same module works fine in Saltire and in Chrome.

**Root cause — two-level bug:**
Vimeo’s embedded player JS navigates window.top.location for certain link-out events. When Rhapsode is embedded in an LTI iframe inside the LMS, this top-frame navigation is detected by the LMS’s tracking script, which defensively re-submits its cached signed LTI launch POST — with the same nonce — causing the "Nonce already used" rejection and kicking the user out.

The fix is to add sandbox="allow-scripts allow-same-origin allow-forms" to the Vimeo iframe was applied here:
https://github.com/area9innovation/flow9/commit/cd6a74c91c40c17deb9ae4aebad286992eb3c6f4
https://github.com/area9innovation/innovation/commit/38349ad544972d9d852237fd2596ca32951fe57f

However, there was a second bug: WebKit/Safari only [evaluates the sandbox attribute at navigation time](https://html.spec.whatwg.org/dev/iframe-embed-object.html). In WebClip, iframe.src is set in the constructor before any styles are processed. So by the time setSandBox() ran, the document was already loading and Safari silently ignored the attribute — Chrome was more lenient. The fix re-triggers navigation on Safari after setting the attribute, with onload temporarily cleared to prevent ondone() firing twice.

**Changes:**
 - flow9/platforms/js/WebClip.hx — Fix setSandBox() on Safari: re-trigger iframe navigation after setting the attribute so WebKit actually applies the sandbox to the loaded document. onload is cleared before and restored after the re-navigation to prevent ondone() from firing twice.