### PR TITLE
perf(translations): cache language name lookups

### DIFF
--- a/lib/text/translationutils.flow
+++ b/lib/text/translationutils.flow
@@ -122,9 +122,11 @@ extractTranslationsFromJson(content : string, translationTree : ref Tree<string,
 	onDone();
 }
 
+languageNamesByCode = pairs2tree(map(languages, \language : [string] -> Pair(toLowerCase(language[1]), language[0])));
+languageCodesByName = pairs2tree(map(languages, \language : [string] -> Pair(toLowerCase(language[0]), language[1])));
+
 getLanguageName(letters : string) {
-	letters_lo = toLowerCase(letters);
-	eitherMap(find(languages, \l : [string] -> toLowerCase(l[1]) == letters_lo), \descr -> descr[0], "")
+	lookupTreeDef(languageNamesByCode, toLowerCase(letters), "")
 }
 
 getLanguageNativeName(letters : string) {
@@ -133,8 +135,7 @@ getLanguageNativeName(letters : string) {
 }
 
 getLanguageLetters(langName : string) {
-	langName_lo = toLowerCase(langName);
-	eitherMap(find(languages, \l : [string] -> toLowerCase(l[0]) == langName_lo), \descr -> descr[1], "")
+	lookupTreeDef(languageCodesByName, toLowerCase(langName), "")
 }
 
 getLanguageLettersFromNativeName(nativeName : string) {


### PR DESCRIPTION
Cache the language-code and language-name lookups used by `getLanguageName` and `getLanguageLetters`.
This avoids repeatedly scanning the language list, which is especially noticeable when rendering tables with many language values
