### PR TITLE
MMenu. Fixed MSubMenuDynamic with MExpanding in menus with more than 100 rows

### DIFF
--- a/lib/material/internal/material_menu.flow
+++ b/lib/material/internal/material_menu.flow
@@ -2212,6 +2212,15 @@ MMenuLines2MPopup(
 	labelIdx = b2i(isSome(mLabel)) + b2i(useFocusInspector);
 	itemsLen = length(newItems);
 
+	// MRecyclerGrid caches row sizes and does not handle rows that change
+	// height at runtime (e.g. MExpanding submenus), so use regular scroll then
+	hasExpandingSubMenu = exists(items0, \it -> switch (it : MMenuLine) {
+		MSubMenu(__, ___, st) : contains(st, MExpanding());
+		MSubMenuDynamic(__, ___, st) : contains(st, MExpanding());
+		MSubMenuCustom(__, ___, st) : contains(st, MExpanding());
+		default : false;
+	});
+
 	popupStyle =
 		[
 			RMBorders(borders),
@@ -2292,6 +2301,7 @@ MMenuLines2MPopup(
 		|> (\f -> concat(f, extractStructMany(style0, MBlockClicks())))
 		|> (\arr -> ifArrayPush(arr, itemsLen > 1, MFocusVertical(true)))
 		|> (\arr -> arrayPush(arr, MTrapFocus()))
+		|> (\arr -> ifArrayPush(arr, hasExpandingSubMenu, RMNoRecyclerGrid()))
 		|> (\f ->
 			concatA([
 				f,

--- a/lib/material/internal/material_popup.flow
+++ b/lib/material/internal/material_popup.flow
@@ -242,7 +242,7 @@ RenderMPopup(manager : MaterialManager, parent : MFocusGroup, m : MPopup, m2t : 
 
 				// Scrollable middle section (if needed)
 				if (scrollArea.from < scrollArea.to) {
-					if (scrollArea.to - scrollArea.from > 100) {
+					if (scrollArea.to - scrollArea.from > 100 && !contains(style, RMNoRecyclerGrid())) {
 						// For large content, use recycler grid for performance
 						gridContentSize = makeWH();
 						[

--- a/lib/material/material.flow
+++ b/lib/material/material.flow
@@ -770,7 +770,7 @@ export {
 				RMLeftAnimation, RMHeight, RMClickOutToClose, RMTranslateAnimation, RMScaleAnimation, RMExpandingAnimation,
 				RMAlphaAnimation, MSameZorder, RMSameFocus, RMScrollArea, MFixPosition,
 				MBackgroundStyle, // Transparency only works in combination with RMNoShadow
-				RMNoScrollbars, TScrollPersistent, TScrollPosition, RMCurrentHeight, RMCurrentWidth, RMCurrentMaxSize, RMDontHandle, RMNoSnapSize,
+				RMNoScrollbars, RMNoRecyclerGrid, TScrollPersistent, TScrollPosition, RMCurrentHeight, RMCurrentWidth, RMCurrentMaxSize, RMDontHandle, RMNoSnapSize,
 				RMNoShadow, TScrollWidthHeight, MCustomScale, MComponentGroupState, MFocusOnPrevious, MBlockClicks, MRippleShape, MActive, MVirtualScreen,
 				RMOnClick, MPopupWrapper;
 
@@ -790,6 +790,8 @@ export {
 				RMSameFocus(focus : MaterialFocus);
 				RMScrollArea(from : int, to : int);
 				RMNoScrollbars();
+				// Disables MRecyclerGrid for popups with dynamic row heights (e.g. MExpanding submenus)
+				RMNoRecyclerGrid();
 				RMCurrentHeight(height : DynamicBehaviour<double>);
 				RMCurrentWidth(width : DynamicBehaviour<double>);
 				RMCurrentMaxSize(wh : DynamicBehaviour<WidthHeight>);


### PR DESCRIPTION
## Problem

`MSubMenuDynamic` with `MExpanding()` breaks when the menu popup contains more than 100 rows: closed submenus appear with blank gaps sized like a previous submenu's children, and clicking a broken submenu renders its items at the wrong offset.

## Root cause

With more than 100 rows, `MPopup` uses `MRecyclerGrid2T` for performance. The recycler caches each row's measured size and lays out row positions from those cached values. Expanding submenus change row heights at runtime (`MShow` toggle), but rows that are not currently rendered are never re-measured, so subsequent rows are positioned using stale sizes.

## Fix

Menus that contain a submenu with `MExpanding()` style now use regular `MScroll` instead of `MRecyclerGrid`:

- `material.flow`: added `RMNoRecyclerGrid()` to `MPopupStyle`.
- `material_popup.flow`: recycler path is skipped when `RMNoRecyclerGrid()` is set.
- `material_menu.flow`: `MMenuLines2MPopup` detects `MExpanding()` submenus and sets the flag.

Only menus with expanding submenus are affected; all other popups keep using the fast recycler path.