### PR TITLE
fix(security): remove unguarded postMessage changeURL navigation sink in toflow.js

### DIFF
--- a/www/js/toflow.js
+++ b/www/js/toflow.js
@@ -156,20 +156,8 @@ function registerLinkHandler(home_domains) {
 	});
 }
 
-function receiveMessageTest(e) {
-	if (!e.data) return;
-	try {
-		var v = JSON.parse(e.data);
-		if ((typeof(v) == "object") && (typeof(v.changeURL) == "object") && (typeof(v.changeURL.url) == "string")) {
-			console.info("got command to change url : " + v.changeURL.url);
-			document.location.href = v.changeURL.url;
-		}
-	} catch (e) {}
-}
-
 //to define if iframe.contentWindow.callflow was setted up correctly
 window.addEventListener('load', define_cross_domain_once);
-window.addEventListener('message', receiveMessageTest);
 var toFlowInterval = setInterval(function(){ clearInterval(toFlowInterval); postToFlow({toFlowLoaded: {src: document.location.href}}) }, 300);
 
 


### PR DESCRIPTION

https://eu.area9studio.com/nexus/lyceum-product-development/16lIJqWdjgs-security-audit-claude-4-8-h46-dom-xss-via-origin-unvalidated-postmessage-document-location-href-in-toflow-js-changeurl-handler-affects-every-flow-embe

Delete receiveMessageTest and its window 'message' listener: no origin/source check let any framing window navigate an embedded app-origin page to an attacker URL, incl. javascript: -> XSS/JWT theft (audit H46). Zero senders of changeURL in any Area9 repo; browser-confirmed exploitable under prod CSP.
