### PR TITLE
fix(print): prevent Chrome shrinking the whole printout when content sits outside the page box

### DIFF
--- a/lib/material/material_print.flow
+++ b/lib/material/material_print.flow
@@ -54,7 +54,9 @@ export {
 	// Default chrome print dialog sizes
 	MPrintPaperSizes : [Pair<string, WidthHeight>];
 
-	// Workaround for Chrome resizing print page when DOM element with absolute positioning is scaled. Not for general use.
+	// Legacy workaround for Chrome shrinking the whole printout when content sits outside the page box.
+	// No longer needed: `contain: size` on `.print-page` (www/flowjspixi.css, @media print) fixes this globally.
+	// Avoid - it rewrites the wrapped subtree's layout in print (zero width, inline flow) and distorts real content.
 	MPrintNeutral(m : Material) { MAccess([ClassName("printNeutral")], m) }
 
 	// Printing units helpers

--- a/www/flowjspixi.css
+++ b/www/flowjspixi.css
@@ -161,6 +161,7 @@ ps-par, ps-sen {
 		page-break-after: always;
 		left:0 !important;
 		top:0 !important;
+		contain: size;
 	}
 }
 


### PR DESCRIPTION
Chrome computes the print layout width from absolutely positioned content whose offset falls past the page edge - even when that content is clipped by`overflow: hidden` on the page container - and then shrink-to-fits the entire document. A single stray element scaled every page down.
Add `contain: size` to `.print-page` in the @media print block. Size containment stops the page's contents from feeding layout overflow back to the initial containing block, which is what Chrome measures. It changes nothing about the position, size or painting of the children, and `.print-page` already carries an explicit width/height, so it always has a definite size to resolve against - verified identical output both with and without the `setPrintPageSize` injected rule.

Rewrite the MPrintNeutral comment: it is the old per-call-site workaround for this same bug, it is now redundant, and it distorts real content because it rewrites the wrapped subtree's layout in print.

Related Nexus:
https://eu.area9studio.com/nexus/lyceum-product-development/3OH1pF0VRpB-book-does-not-take-full-page-space


Old cards:
- https://trello.com/c/NedUvEvw/2711-pg-doesnt-fit-into-a-pdf-page
- https://trello.com/c/U9nDQv7Q/23612-book-pages-with-tab-template-are-distorted-in-printview

Related PRs:
https://github.com/area9innovation/innovation/pull/4822
https://git.area9lyceum.com/Lyceum/lyceum/pulls/10888